### PR TITLE
Remove vendors footer and add SFDS link #169017078

### DIFF
--- a/app/assets/javascripts/shared/templates/footer.html.slim
+++ b/app/assets/javascripts/shared/templates/footer.html.slim
@@ -15,7 +15,7 @@ footer.bg-tuatara.padding-top--2x
       img.city-logo.margin-bottom--2x alt="City & County of San Francisco Logo" ng-src="{{::assetPaths['logo-city.png']}}"
     .clear
     .medium-8.medium-centered.columns.skiptranslate
-      div translate="footer.dahlia_description" translate-value-mohcd-url="http://sf-moh.org" translate-value-sfds-url="https://digitalservices.sfgov.org/" translate-value-mayor-url="http://innovatesf.com/"
+      div translate="footer.dahlia_description" translate-value-mohcd-url="http://sf-moh.org" translate-value-sfds-url="https://digitalservices.sfgov.org/" translate-value-mayor-url="https://www.innovation.sfgov.org/"
       p.t-small.c-iron.margin-top--2x
         | {{ "footer.listing_questions" | translate }}
         br

--- a/app/assets/javascripts/shared/templates/footer.html.slim
+++ b/app/assets/javascripts/shared/templates/footer.html.slim
@@ -15,7 +15,7 @@ footer.bg-tuatara.padding-top--2x
       img.city-logo.margin-bottom--2x alt="City & County of San Francisco Logo" ng-src="{{::assetPaths['logo-city.png']}}"
     .clear
     .medium-8.medium-centered.columns.skiptranslate
-      div translate="footer.dahlia_description" translate-value-mohcd-url="http://sf-moh.org" translate-value-sf-dept-url="http://sfgov.org/dt/" translate-value-mayor-url="http://innovatesf.com/"
+      div translate="footer.dahlia_description" translate-value-mohcd-url="http://sf-moh.org" translate-value-sfds-url="https://digitalservices.sfgov.org/" translate-value-mayor-url="http://innovatesf.com/"
       p.t-small.c-iron.margin-top--2x
         | {{ "footer.listing_questions" | translate }}
         br
@@ -42,16 +42,3 @@ footer.bg-tuatara.padding-top--2x
           li
             a href="https://heapanalytics.com/?utm_source=badge" target="_blank" rel="nofollow"
               img style="width:108px;height:41px" ng-src="{{::assetPaths['heap.png']}}" alt="Heap | Mobile and Web Analytics"
-  section.footer-sole
-    span
-      | made with
-      span.ui-icon.ui-static.ui-small.i-color
-        svg
-          use xlink:href="#i-favorite"
-      ' by
-      a href="http://exygy.com" target="_blank"
-        | exygy
-      '
-      ' &amp;
-      a href="http://www.vertiba.com" target="_blank"
-        | vertiba

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -448,7 +448,7 @@
         "footer": {
             "city_county_of_sf": "City & County of San Francisco",
             "contact": "Contact",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: San Francisco Housing Portal is a project of the <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Mayor's Office of Housing and Community Development</a></p><p class='t-small c-iron margin-top'>in partnership with<br><a class='a-white' href='{{sfDeptUrl}}' target='_blank'>San Francisco Department of Technology</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Mayor's Office of Civic Innovation</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: San Francisco Housing Portal is a project of the <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Mayor's Office of Housing and Community Development</a></p><p class='t-small c-iron margin-top'>in partnership with<br><a class='a-white' href='{{sfdsUrl}}' target='_blank'>San Francisco Digital Services</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Mayor's Office of Civic Innovation</a></p>",
             "disclaimer": "Disclaimer",
             "for_general_questions": "For general program inquiries, you may call MOHCD at 415-701-5500.",
             "give_feedback": "Give Feedback",

--- a/app/assets/json/translations/locale-es.json
+++ b/app/assets/json/translations/locale-es.json
@@ -442,7 +442,7 @@
         "footer": {
             "city_county_of_sf": "Ciudad y condado de San Francisco",
             "contact": "Contacto",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: El Portal de Vivienda de San Francisco es un proyecto de la <br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Oficina de Desarrollo Comunitario y de Viviendas del Alcalde</a></p><p class='t-small c-iron margin-top'>en colaboración con la<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Oficina de Innovación Cívica del Alcalde (Mayor's Office of Civic Innovation)</a>del<br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>Departamento de Tecnología de San Francisco (San Francisco Department of Technology)</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: El Portal de Vivienda de San Francisco es un proyecto de la <br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Oficina de Desarrollo Comunitario y de Viviendas del Alcalde</a></p><p class='t-small c-iron margin-top'>en colaboración con la<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Departamento de Servicios Digitales de San Francisco (San Francisco Digital Services)</a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>Oficina de Innovación Cívica del Alcalde (Mayor's Office of Civic Innovation)</a></p>",
             "disclaimer": "Aviso de responsabilidad",
             "for_general_questions": "Si desea hacer una consulta general sobre el programa, comuníquese con MOHCD al 415-701-5500.",
             "give_feedback": "Envíe sus comentarios",

--- a/app/assets/json/translations/locale-es.json
+++ b/app/assets/json/translations/locale-es.json
@@ -442,7 +442,7 @@
         "footer": {
             "city_county_of_sf": "Ciudad y condado de San Francisco",
             "contact": "Contacto",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: El Portal de Vivienda de San Francisco es un proyecto de la <br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Oficina de Desarrollo Comunitario y de Viviendas del Alcalde</a></p><p class='t-small c-iron margin-top'>en colaboración con la<br/><a class='a-white' href='{{sfDeptUrl}}' target='_blank'>Oficina de Innovación Cívica del Alcalde (Mayor's Office of Civic Innovation)</a>del<br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>Departamento de Tecnología de San Francisco (San Francisco Department of Technology)</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: El Portal de Vivienda de San Francisco es un proyecto de la <br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Oficina de Desarrollo Comunitario y de Viviendas del Alcalde</a></p><p class='t-small c-iron margin-top'>en colaboración con la<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Oficina de Innovación Cívica del Alcalde (Mayor's Office of Civic Innovation)</a>del<br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>Departamento de Tecnología de San Francisco (San Francisco Department of Technology)</a></p>",
             "disclaimer": "Aviso de responsabilidad",
             "for_general_questions": "Si desea hacer una consulta general sobre el programa, comuníquese con MOHCD al 415-701-5500.",
             "give_feedback": "Envíe sus comentarios",

--- a/app/assets/json/translations/locale-es.json
+++ b/app/assets/json/translations/locale-es.json
@@ -442,7 +442,7 @@
         "footer": {
             "city_county_of_sf": "Ciudad y condado de San Francisco",
             "contact": "Contacto",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: El Portal de Vivienda de San Francisco es un proyecto de la <br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Oficina de Desarrollo Comunitario y de Viviendas del Alcalde</a></p><p class='t-small c-iron margin-top'>en colaboración con la<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Departamento de Servicios Digitales de San Francisco (San Francisco Digital Services)</a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>Oficina de Innovación Cívica del Alcalde (Mayor's Office of Civic Innovation)</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: El Portal de Vivienda de San Francisco es un proyecto de la <br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Oficina de Desarrollo Comunitario y de Viviendas del Alcalde</a></p><p class='t-small c-iron margin-top'>en colaboración con la<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Departamento de Servicios Digitales de San Francisco (San Francisco Digital Services)</a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>Oficina de Innovación Cívica de la Alcaldía (Mayor's Office of Civic Innovation)</a></p>",
             "disclaimer": "Aviso de responsabilidad",
             "for_general_questions": "Si desea hacer una consulta general sobre el programa, comuníquese con MOHCD al 415-701-5500.",
             "give_feedback": "Envíe sus comentarios",

--- a/app/assets/json/translations/locale-tl.json
+++ b/app/assets/json/translations/locale-tl.json
@@ -442,7 +442,7 @@
         "footer": {
             "city_county_of_sf": "Lungsod at County ng San Francisco",
             "contact": "Kontakin ",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: Ang San Francisco Housing Portal ay proyekto ng  <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Opisina para sa Pabahay at Pagpapaunlad ng Komunidad (Housing and Community Development) ng Mayor </a></p><p class='t-small c-iron margin-top'>sa  pakikipagtulungan sa<br><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Serbisyong Pang-Digital ng San Francisco (San Francisco Digital Services)</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Opisina para sa mga Inobasyong Pangmamamayan (Office of Civic Innovation) ng Mayor</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: Ang San Francisco Housing Portal ay proyekto ng  <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Opisina para sa Pabahay at Pagpapaunlad ng Komunidad (Housing and Community Development) ng Mayor </a></p><p class='t-small c-iron margin-top'>sa  pakikipagtulungan sa<br><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Serbisyong Pang-Digital ng San Francisco (San Francisco Digital Services)</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Opisina ng Meyor sa Sibikang Inobasyon (Office of Civic Innovation)</a></p>",
             "disclaimer": "Pagwawaksi ng Pananagutan (Disclaimer)",
             "for_general_questions": "Para sa mga tanong tungkol sa pangkalahatang programa, puwede ninyong tawagan ang MOHCD sa 415-701-5500.",
             "give_feedback": "Magbigay ng Opinyon ",

--- a/app/assets/json/translations/locale-tl.json
+++ b/app/assets/json/translations/locale-tl.json
@@ -442,7 +442,7 @@
         "footer": {
             "city_county_of_sf": "Lungsod at County ng San Francisco",
             "contact": "Kontakin ",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: Ang San Francisco Housing Portal ay proyekto ng  <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Opisina para sa Pabahay at Pagpapaunlad ng Komunidad (Housing and Community Development) ng Mayor </a></p><p class='t-small c-iron margin-top'>sa  pakikipagtulungan sa<br><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Departamento ng Teknolohiya (Department of Technology) ng San Francisco</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Opisina para sa mga Inobasyong Pangmamamayan (Office of Civic Innovation) ng Mayor</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: Ang San Francisco Housing Portal ay proyekto ng  <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Opisina para sa Pabahay at Pagpapaunlad ng Komunidad (Housing and Community Development) ng Mayor </a></p><p class='t-small c-iron margin-top'>sa  pakikipagtulungan sa<br><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Serbisyong Pang-Digital ng San Francisco (San Francisco Digital Services)</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Opisina para sa mga Inobasyong Pangmamamayan (Office of Civic Innovation) ng Mayor</a></p>",
             "disclaimer": "Pagwawaksi ng Pananagutan (Disclaimer)",
             "for_general_questions": "Para sa mga tanong tungkol sa pangkalahatang programa, puwede ninyong tawagan ang MOHCD sa 415-701-5500.",
             "give_feedback": "Magbigay ng Opinyon ",

--- a/app/assets/json/translations/locale-tl.json
+++ b/app/assets/json/translations/locale-tl.json
@@ -442,7 +442,7 @@
         "footer": {
             "city_county_of_sf": "Lungsod at County ng San Francisco",
             "contact": "Kontakin ",
-            "dahlia_description": "<p class='c-iron'>DAHLIA: Ang San Francisco Housing Portal ay proyekto ng  <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Opisina para sa Pabahay at Pagpapaunlad ng Komunidad (Housing and Community Development) ng Mayor </a></p><p class='t-small c-iron margin-top'>sa  pakikipagtulungan sa<br><a class='a-white' href='{{sfDeptUrl}}' target='_blank'>Departamento ng Teknolohiya (Department of Technology) ng San Francisco</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Opisina para sa mga Inobasyong Pangmamamayan (Office of Civic Innovation) ng Mayor</a></p>",
+            "dahlia_description": "<p class='c-iron'>DAHLIA: Ang San Francisco Housing Portal ay proyekto ng  <br><a class='a-white' href='{{mohcdUrl}}' target='_blank'>Opisina para sa Pabahay at Pagpapaunlad ng Komunidad (Housing and Community Development) ng Mayor </a></p><p class='t-small c-iron margin-top'>sa  pakikipagtulungan sa<br><a class='a-white' href='{{sfdsUrl}}' target='_blank'>Departamento ng Teknolohiya (Department of Technology) ng San Francisco</a><br><a class='a-white' href='{{mayorUrl}}' target='_blank'>Opisina para sa mga Inobasyong Pangmamamayan (Office of Civic Innovation) ng Mayor</a></p>",
             "disclaimer": "Pagwawaksi ng Pananagutan (Disclaimer)",
             "for_general_questions": "Para sa mga tanong tungkol sa pangkalahatang programa, puwede ninyong tawagan ang MOHCD sa 415-701-5500.",
             "give_feedback": "Magbigay ng Opinyon ",

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -443,7 +443,7 @@
         "footer": {
             "city_county_of_sf": "舊金山市和郡",
             "contact": "聯絡資訊",
-            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'>與<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>三藩市數碼服務部 (San Francisco Digital Services) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作</p>",
+            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'><a class='a-white' href='{{sfdsUrl}}' target='_blank'>本專案與三藩市數碼服務部和 (San Francisco Digital Services) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作。</p>",
             "disclaimer": "免責聲明",
             "for_general_questions": "有關一般計畫詢問，可以致電 MOHCD，電話是 415-701-5500。",
             "give_feedback": "提供意見",

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -443,7 +443,7 @@
         "footer": {
             "city_county_of_sf": "舊金山市和郡",
             "contact": "聯絡資訊",
-            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'>與<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>舊金山技術部 (San Francisco Department of Technology) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作</p>",
+            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'>與<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>三藩市數碼服務部 (San Francisco Digital Services) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作</p>",
             "disclaimer": "免責聲明",
             "for_general_questions": "有關一般計畫詢問，可以致電 MOHCD，電話是 415-701-5500。",
             "give_feedback": "提供意見",

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -443,7 +443,7 @@
         "footer": {
             "city_county_of_sf": "舊金山市和郡",
             "contact": "聯絡資訊",
-            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'>與<br/><a class='a-white' href='{{sfDeptUrl}}' target='_blank'>舊金山技術部 (San Francisco Department of Technology) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作</p>",
+            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'>與<br/><a class='a-white' href='{{sfdsUrl}}' target='_blank'>舊金山技術部 (San Francisco Department of Technology) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作</p>",
             "disclaimer": "免責聲明",
             "for_general_questions": "有關一般計畫詢問，可以致電 MOHCD，電話是 415-701-5500。",
             "give_feedback": "提供意見",

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -443,7 +443,7 @@
         "footer": {
             "city_county_of_sf": "舊金山市和郡",
             "contact": "聯絡資訊",
-            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'><a class='a-white' href='{{sfdsUrl}}' target='_blank'>本專案與三藩市數碼服務部和 (San Francisco Digital Services) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長城市創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作。</p>",
+            "dahlia_description": "<p class='c-iron'>可負擔房屋項目名單、資訊和申請表資料庫 (Database of Affordable Housing Listings, Information, and Applications, DAHLIA)：三藩市房屋網站 (San Francisco Housing Portal) 是<br/><a class='a-white' href='{{mohcdUrl}}' target='_blank'>市長住房與社區發展辦公室的一項專案</a></p><p class='t-small c-iron margin-top'><a class='a-white' href='{{sfdsUrl}}' target='_blank'>本專案與三藩市數碼服務部和 (San Francisco Digital Services) </a><br/><a class='a-white' href='{{mayorUrl}}' target='_blank'>市長市政創新辦公室 (Mayor's Office of Civic Innovation)</a> 合作。</p>",
             "disclaimer": "免責聲明",
             "for_general_questions": "有關一般計畫詢問，可以致電 MOHCD，電話是 415-701-5500。",
             "give_feedback": "提供意見",


### PR DESCRIPTION
[Pivotal #169017078](https://www.pivotaltracker.com/n/projects/1405352)

## Summary
Remove the app footer that says "made with <3 from Exigy and Vertiba"
and update the "in partnership with" list to include SFDS and link to
the SFDS site.

Additonally:

- Remove "del" from spanish translation. It's not necessary
- Swap the link text for Spanish, the links were going to the wrong locations
- Update the translations for Spanish, Chinese, Tagalog to say "San Francisco Digital Services"

## Screenshot (before)
<img width="1401" alt="Screen Shot 2020-04-23 at 3 40 01 PM" src="https://user-images.githubusercontent.com/64036574/80156791-a2f93700-8579-11ea-9311-9d8a8e6d1181.png">


## Screenshot (after)
Note that there is no footer at the bottom anymore that calls out Vertiba and Exigy, and `San Francisco Digital Services` has replaced the `San Francisco Department of Technology` link.

<img width="1396" alt="Screen Shot 2020-04-23 at 3 27 49 PM" src="https://user-images.githubusercontent.com/64036574/80156883-d20fa880-8579-11ea-993d-944e8a321e10.png">



## Screenshot (after clicking on "San Francisco Digital Services")
<img width="1402" alt="Screen Shot 2020-04-23 at 3 27 35 PM" src="https://user-images.githubusercontent.com/64036574/80156762-8f4dd080-8579-11ea-86c0-802e156723a6.png">


## Comparison: English old / new
<img width="1154" alt="Screen Shot 2020-04-28 at 1 58 30 PM" src="https://user-images.githubusercontent.com/64036574/80543828-9bb09f80-8964-11ea-957e-a9f57cd72695.png">

## Comparison: Spanish old / new
<img width="1287" alt="Screen Shot 2020-04-28 at 1 58 04 PM" src="https://user-images.githubusercontent.com/64036574/80543824-96ebeb80-8964-11ea-9fec-54ef05fe8820.png">

## Comparison: Chinese old / new
<img width="1374" alt="Screen Shot 2020-04-28 at 3 24 45 PM" src="https://user-images.githubusercontent.com/64036574/80543788-86d40c00-8964-11ea-830d-adcbe83f8554.png">

## Comparison: Tagalog old / new
<img width="1500" alt="Screen Shot 2020-04-28 at 1 57 48 PM" src="https://user-images.githubusercontent.com/64036574/80543810-90f60a80-8964-11ea-939b-62610fc91799.png">

## After updating office of innovation translations
![Screen Shot 2020-04-29 at 3 59 20 PM](https://user-images.githubusercontent.com/64036574/80655079-a6396a80-8a32-11ea-8bbb-74636da82373.png)
![Screen Shot 2020-04-29 at 3 59 29 PM](https://user-images.githubusercontent.com/64036574/80655082-a8032e00-8a32-11ea-834c-14409ad224be.png)
![Screen Shot 2020-04-29 at 3 59 37 PM](https://user-images.githubusercontent.com/64036574/80655085-a89bc480-8a32-11ea-861b-866c172e4570.png)

