### PR TITLE
Fix screen reader for nav bar #169027064

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -72,14 +72,15 @@ html lang="en" ng-app="dahlia" ng-strict-di="" ng-controller="SharedController"
         section(ui-view="version")
         section(ui-view="navigation")
       .loading-overlay(bs-loading-overlay)
-        section#main-content.main-content(ui-view="container" aria-live="polite")
+        section#main-content.main-content(ui-view="container")
     .footer-section.skiptranslate
       .loading-overlay(bs-loading-overlay)
         section(ui-view="footer")
 
+    div.sr-only id="announce-text" aria-live="polite" {{$title || 'DAHLIA San Francisco Housing Portal'}}
+
     / icon collection
     ng-include src="'shared/templates/icons.html'"
-
 
     / RAVEN: scrub the password and just include the URL in the format of: https://abc123@sentry.io/123123
     - if ENV['SENTRY_DSN']

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -61,8 +61,6 @@ html lang="en" ng-app="dahlia" ng-strict-di="" ng-controller="SharedController"
         iframe height="0" src="//www.googletagmanager.com/ns.html?id=#{ENV['GOOGLE_TAG_MANAGER_KEY']}" style="display:none;visibility:hidden" width="0"
     #google_translate_element
 
-    div.sr-only id="announce-text" aria-live="polite" {{$title || 'DAHLIA San Francisco Housing Portal'}}
-
     button.button-link.skip-link.sr-only ng-click="focusOnMainContent()"
       | {{'t.skip_to_main_content' | translate}}
 
@@ -74,7 +72,7 @@ html lang="en" ng-app="dahlia" ng-strict-di="" ng-controller="SharedController"
         section(ui-view="version")
         section(ui-view="navigation")
       .loading-overlay(bs-loading-overlay)
-        section#main-content.main-content(ui-view="container")
+        section#main-content.main-content(ui-view="container" aria-live="polite")
     .footer-section.skiptranslate
       .loading-overlay(bs-loading-overlay)
         section(ui-view="footer")

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -61,6 +61,8 @@ html lang="en" ng-app="dahlia" ng-strict-di="" ng-controller="SharedController"
         iframe height="0" src="//www.googletagmanager.com/ns.html?id=#{ENV['GOOGLE_TAG_MANAGER_KEY']}" style="display:none;visibility:hidden" width="0"
     #google_translate_element
 
+    div.sr-only id="announce-text" aria-live="polite" {{$title || 'DAHLIA San Francisco Housing Portal'}}
+
     button.button-link.skip-link.sr-only ng-click="focusOnMainContent()"
       | {{'t.skip_to_main_content' | translate}}
 


### PR DESCRIPTION
[#169027064](https://www.pivotaltracker.com/n/projects/1405352/stories/169027064)

## Summary
Previously, tab changes weren't being read by the screen reader. This change adds a hidden aria-live div that reads changes to the page title.

### Why did you put the div in the application.html, why not make each component header an aria-live region?
aria-live regions only read when content is changed, they don't register when the span with aria-live appears or disappears

### Why'd you use aria-live="polite"
Polite makes it not interrupt the current reading. Maybe it should interrupt it?

### What if we want to read something more customized than the page title?
I spent probably 6 hours researching how to plug in custom data to `application.html.slim` but every solution was fragile and I couldn't quite get it working. I think this is better than nothing as a first pass and if we want custom readouts I can come back to this.

## Screencast: note the titles are read after the new tab loads
![tabs screen reader](https://user-images.githubusercontent.com/64036574/81876846-757c2980-9538-11ea-8017-90efb16b4d04.gif)
