### PR TITLE
[Webapp] Add circleci prod e2e tests #173302542

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ prod_and_release_jobs: &prod_and_release_jobs
     branches:
       only:
         - /^release.*$/
-        - chores/circle-ci-on-production-#173302542
         - production
 aliases:
   - &attach_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,6 @@ workflows:
             branches:
               ignore:
                 - production
-                - chores/circle-ci-on-production-#173302542
       - e2e-submit-application:
           requires:
             - build
@@ -191,7 +190,6 @@ workflows:
             branches:
               ignore:
                 - production
-                - chores/circle-ci-on-production-#173302542
       - e2e-sign-in-apply:
           requires:
             - build
@@ -199,7 +197,6 @@ workflows:
             branches:
               ignore:
                 - production
-                - chores/circle-ci-on-production-#173302542
       - e2e-other-short-form:
           requires:
             - build
@@ -207,7 +204,6 @@ workflows:
             branches:
               ignore:
                 - production
-                - chores/circle-ci-on-production-#173302542
       - e2e-production:
           context: webapp-prod
           requires:
@@ -215,5 +211,4 @@ workflows:
           filters:
             branches:
               only:
-                - chores/circle-ci-on-production-#173302542
                 - production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,10 +182,10 @@ workflows:
           <<: *non_production_jobs
       - e2e-submit-application:
           <<: *prod_and_release_jobs
-          name: e2e-submit-application-prod
+          name: prod-e2e-submit-application
       - e2e-sign-in-apply:
           <<: *prod_and_release_jobs
-          name: e2e-sign-in-apply-prod
+          name: prod-e2e-sign-in-apply
       - e2e-other-short-form:
           <<: *prod_and_release_jobs
-          name: e2e-other-short-form-prod
+          name: prod-e2e-other-short-form

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,21 @@ defaults: &defaults
         POSTGRES_USER: root
         POSTGRES_DB: sf_dahlia
   executor: ruby/default
+non_production_jobs: &non_production_jobs
+  filters:
+    branches:
+      ignore: production
+  requires:
+    - build
+prod_and_release_jobs: &prod_and_release_jobs
+  context: webapp-prod
+  requires:
+    - build
+  filters:
+    branches:
+      only:
+        - /^release.*$/
+        - production
 aliases:
   - &attach_workspace
     attach_workspace:
@@ -85,15 +100,9 @@ commands:
       path:
         type: string
         default: "./spec/e2e/test-feature-path.feature"
-      skip-setup:
-        type: boolean
-        default: false
     steps:
-      - unless:
-          condition: << parameters.skip-setup >>
-          steps:
-            - setup
-            - start-server
+      - setup
+      - start-server
       - run: npm run protractor -- --specs '<< parameters.path >>'
 
 jobs:
@@ -157,59 +166,26 @@ jobs:
     steps:
       - run-e2e-tests-for-path:
           path: "./spec/e2e/features/short_form/!(submitting_application|sign_in_while_applying).feature"
-  e2e-production:
-    <<: *defaults
-    steps:
-      - setup
-      - start-server
-      - run-e2e-tests-for-path:
-          path: "./spec/e2e/features/short_form/submitting_application.feature"
-          skip-setup: true
-      - run-e2e-tests-for-path:
-          path: "./spec/e2e/features/short_form/sign_in_while_applying.feature"
-          skip-setup: true
-      - run-e2e-tests-for-path:
-          path: "./spec/e2e/features/short_form/!(submitting_application|sign_in_while_applying).feature"
-          skip-setup: true
+
 workflows:
   version: 2.1
   build-and-deploy:
     jobs:
       - build
       - backend:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - production
+          <<: *non_production_jobs
       - e2e-submit-application:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - production
+          <<: *non_production_jobs
       - e2e-sign-in-apply:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - production
+          <<: *non_production_jobs
       - e2e-other-short-form:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - production
-      - e2e-production:
-          context: webapp-prod
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - /^release.*$/
-                - production
+          <<: *non_production_jobs
+      - e2e-submit-application:
+          <<: *prod_and_release_jobs
+          name: e2e-submit-application-prod
+      - e2e-sign-in-apply:
+          <<: *prod_and_release_jobs
+          name: e2e-sign-in-apply-prod
+      - e2e-other-short-form:
+          <<: *prod_and_release_jobs
+          name: e2e-other-short-form-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,15 @@ jobs:
     steps:
       - run-e2e-tests-for-path:
           path: "./spec/e2e/features/short_form/!(submitting_application|sign_in_while_applying).feature"
+  e2e-production:
+    <<: *defaults
+    steps:
+      - run-e2e-tests-for-path:
+          path: "./spec/e2e/features/short_form/submitting_application.feature"
+      - run-e2e-tests-for-path:
+          path: "./spec/e2e/features/short_form/sign_in_while_applying.feature"
+      - run-e2e-tests-for-path:
+          path: "./spec/e2e/features/short_form/!(submitting_application|sign_in_while_applying).feature"
 workflows:
   version: 2.1
   build-and-deploy:
@@ -159,12 +168,41 @@ workflows:
       - backend:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - production
+                - chores/circle-ci-on-production-#173302542
       - e2e-submit-application:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - production
+                - chores/circle-ci-on-production-#173302542
       - e2e-sign-in-apply:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - production
+                - chores/circle-ci-on-production-#173302542
       - e2e-other-short-form:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - production
+                - chores/circle-ci-on-production-#173302542
+      - e2e-production:
+          context: webapp-production
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - chores/circle-ci-on-production-#173302542
+                - production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,15 @@ commands:
       path:
         type: string
         default: "./spec/e2e/test-feature-path.feature"
+      skip-setup:
+        type: boolean
+        default: false
     steps:
-      - setup
-      - start-server
+      - unless:
+          condition: << parameters.skip-setup >>
+          steps:
+            - setup
+            - start-server
       - run: npm run protractor -- --specs '<< parameters.path >>'
 
 jobs:
@@ -154,12 +160,17 @@ jobs:
   e2e-production:
     <<: *defaults
     steps:
+      - setup
+      - start-server
       - run-e2e-tests-for-path:
           path: "./spec/e2e/features/short_form/submitting_application.feature"
+          skip-setup: true
       - run-e2e-tests-for-path:
           path: "./spec/e2e/features/short_form/sign_in_while_applying.feature"
+          skip-setup: true
       - run-e2e-tests-for-path:
           path: "./spec/e2e/features/short_form/!(submitting_application|sign_in_while_applying).feature"
+          skip-setup: true
 workflows:
   version: 2.1
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,5 @@ workflows:
           filters:
             branches:
               only:
-                - /^releases.*$/
                 - /^release.*$/
                 - production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,4 +211,6 @@ workflows:
           filters:
             branches:
               only:
+                - /^releases.*$/
+                - /^release.*$/
                 - production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ workflows:
                 - production
                 - chores/circle-ci-on-production-#173302542
       - e2e-production:
-          context: webapp-production
+          context: webapp-prod
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ prod_and_release_jobs: &prod_and_release_jobs
     branches:
       only:
         - /^release.*$/
+        - chores/circle-ci-on-production-#173302542
         - production
 aliases:
   - &attach_workspace


### PR DESCRIPTION
[#173302542](https://www.pivotaltracker.com/n/projects/1405352/stories/173302542)


## Summary
Add tests that will run only on the "production" branch with prod env
variables.

## Steps taken to verify
- [x] added this pr name to the e2e-production conditional to test that it runs the production tests (and skips the rest)
<img src="https://user-images.githubusercontent.com/64036574/85606042-9cce1800-b607-11ea-8242-b3b58e96f482.png" width="330" />

- [x] removed this pr name to the e2e-conditional to test that regular branches are unchanged.
<img src="https://user-images.githubusercontent.com/64036574/85606404-fafafb00-b607-11ea-98a1-0ffe5d81472d.png" width="330" />

- [x] sshed into e2e-production box and verified that it's using prod credentials.