### PR TITLE
Fix missing listing directory unit rows #173504337

### DIFF
--- a/app/assets/javascripts/listings/templates/property-card/_rental-stats-row.html.slim
+++ b/app/assets/javascripts/listings/templates/property-card/_rental-stats-row.html.slim
@@ -1,4 +1,4 @@
-tr ng-repeat-start="unit_summary in ::summary" ng-if="::unit_summary.minRentalMinIncome || unit_summary.maxRentalMinIncome || unit_summary.minPercentIncome"
+tr ng-repeat-start="unit_summary in ::summary" ng-if="::unit_summary.minMonthlyRent || unit_summary.minPercentIncome"
   td.is-subtitled data-th="{{'t.unit_type' | translate}}"
     | {{::unit_summary.unitType}}
   td.is-subtitled data-th="{{'listings.stats.availability' | translate}}"
@@ -11,7 +11,7 @@ tr ng-repeat-start="unit_summary in ::summary" ng-if="::unit_summary.minRentalMi
       small
         | {{'listings.stats.waitlist' | translate}}
   td.text-right.is-subtitled data-th="Rent"
-    span ng-if="::unit_summary.minRentalMinIncome || unit_summary.maxRentalMinIncome"
+    span ng-if="::unit_summary.minMonthlyRent"
       | {{::unit_summary.minMonthlyRent | currency:"$":0}}
       span ng-show="::unit_summary.maxMonthlyRent > unit_summary.minMonthlyRent"
         |  to {{::unit_summary.maxMonthlyRent | currency:"$":0}}


### PR DESCRIPTION
This PR fixes an issue where unit groups with min % AMI instead of min income were not showing in the listing directory page
[ticket](https://www.pivotaltracker.com/story/show/173504337)

Before
![image](https://user-images.githubusercontent.com/11825994/85769230-a53d5600-b6ce-11ea-9145-de941bb75e3a.png)


After
![image](https://user-images.githubusercontent.com/11825994/85769154-9656a380-b6ce-11ea-906a-c445934760a7.png)
