### PR TITLE
Update Gruntfile to allow for phrase pull and push #172927249

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -166,9 +166,16 @@ module.exports = function(grunt) {
     // }
   },
   exec: {
-    pull_phrase: {
-      cmd: function(phraseAccessToken) {
-        return 'phrase pull --access_token ' + phraseAccessToken;
+    phrasePull: {
+      cmd: function() {
+        var token = grunt.option('phraseAccessToken')
+        return 'phrase pull --access_token ' + token;
+      }
+    },
+    phrasePush: {
+      cmd: function() {
+        var token = grunt.option('phraseAccessToken')
+        return 'phrase push --access_token ' + token;
       }
     }
   }
@@ -183,6 +190,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-json-remove-fields');
   grunt.loadNpmTasks('grunt-exec');
 
+  // Set this variable by appending --phraseAccessToken=[token] to any grunt command.
+  var phraseAccessToken = grunt.option('phraseAccessToken');
   // register task
   grunt.registerTask('default', [
     'clean',
@@ -198,17 +207,20 @@ module.exports = function(grunt) {
     'sortJSON',
   ]);
   grunt.registerTask('phrasePush', [
+    'copy:removeLanguageKey',
+    'exec:phrasePush',
     'copy:addBackLanguageKey',
     'json_remove_fields',
     'sortJSON',
   ]);
 
-  grunt.registerTask('translations-remove-language-key', [
+  grunt.registerTask('phrasePull', [
     'copy:removeLanguageKey',
+    'exec:phrasePull',
+    'copy:addBackLanguageKey',
     'json_remove_fields',
     'sortJSON',
   ]);
-
 
   grunt.registerTask('deploy', [
     'clean',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,23 +22,23 @@ module.exports = function(grunt) {
         }
       ],
     },
-    translationsToTmp: {
+    removeLanguageKey: {
       files: [
         {
           src: 'app/assets/json/translations/locale-en.json',
-          dest: 'tmp/translations/locale-en.json'
+          dest: 'app/assets/json/translations/locale-en.json'
         },
         {
           src: 'app/assets/json/translations/locale-es.json',
-          dest: 'tmp/translations/locale-es.json'
+          dest: 'app/assets/json/translations/locale-es.json'
         },
         {
           src: 'app/assets/json/translations/locale-tl.json',
-          dest: 'tmp/translations/locale-tl.json'
+          dest: 'app/assets/json/translations/locale-tl.json'
         },
         {
           src: 'app/assets/json/translations/locale-zh.json',
-          dest: 'tmp/translations/locale-zh.json'
+          dest: 'app/assets/json/translations/locale-zh.json'
         }
       ],
       options: {
@@ -51,22 +51,22 @@ module.exports = function(grunt) {
         }
       }
     },
-    translationsFromTmp: {
+    addBackLanguageKey: {
       files: [
         {
-          src: 'tmp/translations/locale-en.json',
+          src: 'app/assets/json/translations/locale-en.json',
           dest: 'app/assets/json/translations/locale-en.json'
         },
         {
-          src: 'tmp/translations/locale-es.json',
+          src: 'app/assets/json/translations/locale-es.json',
           dest: 'app/assets/json/translations/locale-es.json'
         },
         {
-          src: 'tmp/translations/locale-tl.json',
+          src: 'app/assets/json/translations/locale-tl.json',
           dest: 'app/assets/json/translations/locale-tl.json'
         },
         {
-          src: 'tmp/translations/locale-zh.json',
+          src: 'app/assets/json/translations/locale-zh.json',
           dest: 'app/assets/json/translations/locale-zh.json'
         }
       ],
@@ -140,7 +140,7 @@ module.exports = function(grunt) {
        ],
       namespace: true,
       lang:     ['locale-en', 'locale-es', 'locale-tl', 'locale-zh'],
-      dest:     'tmp/translations'
+      dest:     'app/assets/json/translations'
     }
   },
   json_remove_fields: {
@@ -184,12 +184,25 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('translations', [
-    'copy:translationsToTmp',
+    'copy:removeLanguageKey',
     'i18nextract',
-    'copy:translationsFromTmp',
+    'copy:addBackLanguageKey',
     'json_remove_fields',
     'sortJSON',
   ]);
+
+  grunt.registerTask('translations-add-language-key', [
+    'copy:addBackLanguageKey',
+    'json_remove_fields',
+    'sortJSON',
+  ]);
+
+  grunt.registerTask('translations-remove-language-key', [
+    'copy:removeLanguageKey',
+    'json_remove_fields',
+    'sortJSON',
+  ]);
+
 
   grunt.registerTask('deploy', [
     'clean',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -159,12 +159,18 @@ module.exports = function(grunt) {
       'app/assets/json/translations/locale-en.json',
       'app/assets/json/translations/locale-es.json',
       'app/assets/json/translations/locale-tl.json',
-      'app/assets/json/translations/locale-zh.json',
-      'tmp/translations/locale-en.json'
+      'app/assets/json/translations/locale-zh.json'
     ],
     // options: {
     //   spacing: 2
     // }
+  },
+  exec: {
+    pull_phrase: {
+      cmd: function(phraseAccessToken) {
+        return 'phrase pull --access_token ' + phraseAccessToken;
+      }
+    }
   }
 });
 
@@ -175,6 +181,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-angular-translate');
   grunt.loadNpmTasks('grunt-sort-json');
   grunt.loadNpmTasks('grunt-json-remove-fields');
+  grunt.loadNpmTasks('grunt-exec');
 
   // register task
   grunt.registerTask('default', [
@@ -190,8 +197,7 @@ module.exports = function(grunt) {
     'json_remove_fields',
     'sortJSON',
   ]);
-
-  grunt.registerTask('translations-add-language-key', [
+  grunt.registerTask('phrasePush', [
     'copy:addBackLanguageKey',
     'json_remove_fields',
     'sortJSON',

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ In order to test caching locally,
 
 To run stress testing against the Salesforce instance, refer to the documentation in the [stress testing folder](load_testing/load_testing.md)
 
+## Pulling and pushing translations from [our project on Phrase](https://app.phrase.com/accounts/city-county-of-san-francisco/projects/dahlia-sf-dahlia-web/dashboard)
+To get started working with our Phrase translations, you will need to:
+
+1. Install the Phrase CLI with `brew tap phrase/brewed && brew install phrase`
+1. [Create and save a new access token](https://app.phrase.com/settings/oauth_access_tokens)
+
+**To upload new strings or translations to Phrase**
+Run `grunt phrasePull --phraseAccessToken=[your access token]`
+
+**To download new strings or translations from Phrase**
+Run `grunt phrasePush --phraseAccessToken=[your access token]`
+
 ## Contributing changes
 
 Use the engineering workflow and coding style standards established below. :smiley:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To run stress testing against the Salesforce instance, refer to the documentatio
 To get started working with our Phrase translations, you will need to:
 
 1. Install the Phrase CLI with `brew tap phrase/brewed && brew install phrase`
-1. [Create and save a new access token](https://app.phrase.com/settings/oauth_access_tokens)
+1. [Create an access token for Phrase](https://app.phrase.com/settings/oauth_access_tokens). Save it for future use in e.g. LastPass
 
 **To upload new strings or translations to Phrase**
 Run `grunt phrasePull --phraseAccessToken=[your access token]`

--- a/app/assets/javascripts/short-form/ShortFormHelperService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormHelperService.js.coffee
@@ -9,7 +9,7 @@ ShortFormHelperService = ($translate, $filter, $sce, $state) ->
     ['Family Member', Service.flagForI18n('label.family_member')]
     ['Friend', Service.flagForI18n('label.friend')]
     ['Social Worker or Housing Counselor', Service.flagForI18n('label.social_worker_or_housing_counselor')]
-    ['Other', Service.flagForI18n('label.other')]
+    ['Other', Service.flagForI18n('label._other')]
   ]
   Service.gender_options = [
     ['Female', Service.flagForI18n('label.female')]
@@ -35,7 +35,7 @@ ShortFormHelperService = ($translate, $filter, $sce, $state) ->
     ['Great Grandparent', Service.flagForI18n('label.great_grandparent')]
     ['In-Law', Service.flagForI18n('label.in_law')]
     ['Friend', Service.flagForI18n('label.friend')]
-    ['Other', Service.flagForI18n('label.other')]
+    ['Other', Service.flagForI18n('label._other')]
   ]
   Service.ethnicity_options = [
     ['Hispanic/Latino', Service.flagForI18n('label.hispanic_latino')]
@@ -113,7 +113,7 @@ ShortFormHelperService = ($translate, $filter, $sce, $state) ->
     ['Housing Counselor', Service.flagForI18n('referral.housing_counselor')]
     ['Radio Ad', Service.flagForI18n('referral.radio_ad')]
     ['Bus Ad', Service.flagForI18n('referral.bus_ad')]
-    ['Other', Service.flagForI18n('label.other')]
+    ['Other', Service.flagForI18n('label._other')]
   ]
 
   Service.proofOptions = (preference) ->

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -489,6 +489,7 @@
             "header": "For more help, we suggest talking with a housing counselor to explore your options."
         },
         "label": {
+            "_other": "Other",
             "ada_accessible_units": "ADA Accessible Units",
             "add_household_member": "Add household member",
             "additional_phone": "Additional Phone",

--- a/app/assets/json/translations/locale-es.json
+++ b/app/assets/json/translations/locale-es.json
@@ -488,6 +488,7 @@
             "header": "Para obtener más ayuda, le sugerimos que hable con un consejero de vivienda para explorar sus opciones."
         },
         "label": {
+            "_other": "Otro",
             "ada_accessible_units": "Unidades con características de accesibilidad según la Americans with Disabilities Act (Ley de Estadounidenses con Discapacidades, ADA)",
             "add_household_member": "Agregar integrante de la familia",
             "additional_phone": "Teléfono adicional",

--- a/app/assets/json/translations/locale-tl.json
+++ b/app/assets/json/translations/locale-tl.json
@@ -488,6 +488,7 @@
             "header": "Para sa dagdag na tulong, iminumungkahi naming makipag-usap kayo sa tagapayo sa pabahay para masiyasat ang inyong mga opsiyon."
         },
         "label": {
+            "_other": "Iba pa",
             "ada_accessible_units": "Mga Unit na ADA Accessible (may madaraanan ang may kapansanan)",
             "add_household_member": "Magdagdag ng miyembro ng kabahayan",
             "additional_phone": "Iba pang Telepono",

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -489,6 +489,7 @@
             "header": "如您需要更多協助，我們建議您諮詢一位住房顧問，幫您探索各種方案。"
         },
         "label": {
+            "_other": "其他",
             "ada_accessible_units": "ADA 無障礙設施單位",
             "add_household_member": "新增家庭成員",
             "additional_phone": "其他電話",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,13 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "adm-zip": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha1-WX4vjMNnIVHhMH0+lc3bx1ZyMUo=",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
       "dev": true
     },
     "ansi-regex": {
@@ -49,7 +49,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -85,7 +85,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -106,7 +106,7 @@
     "assertion-error-formatter": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-2.0.1.tgz",
-      "integrity": "sha1-a73/rsji+p4rDrFYv+NTEy18Cps=",
+      "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
       "dev": true,
       "requires": {
         "diff": "^3.0.0",
@@ -135,7 +135,7 @@
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-runtime": {
@@ -166,7 +166,7 @@
     "blocking-proxy": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-1.0.1.tgz",
-      "integrity": "sha1-gdb9H+E6TA1pV99/kbdemNrEDLI=",
+      "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -204,7 +204,7 @@
     "browserstack": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.2.tgz",
-      "integrity": "sha1-F9i7dhJ6HMDqQWQk34DSGPgDZz8=",
+      "integrity": "sha512-+6AFt9HzhKykcPF79W6yjEUJcdvZOV0lIXdkORXMJftGrDl0OKWqRF4GHqpDNkxiceDT/uB7Fb/aDwktvXX7dg==",
       "dev": true,
       "requires": {
         "https-proxy-agent": "^2.2.1"
@@ -249,7 +249,7 @@
     "chai-as-promised": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
         "check-error": "^1.0.2"
@@ -300,7 +300,7 @@
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM=",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
       "dev": true
     },
     "coffeelint": {
@@ -340,7 +340,7 @@
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -502,7 +502,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -555,7 +555,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dotenv": {
@@ -587,7 +587,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -596,7 +596,7 @@
     "error-stack-parser": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-      "integrity": "sha1-Sujbqiv5CotFBwe5FJ3KvKE1Ug0=",
+      "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
       "dev": true,
       "requires": {
         "stackframe": "^1.0.4"
@@ -657,7 +657,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "eventemitter2": {
@@ -675,7 +675,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extsprintf": {
@@ -754,7 +754,7 @@
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -863,7 +863,7 @@
     "grunt": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
-      "integrity": "sha1-x5mIOUWlOj0HYi4HN8j3C/4Z6zg=",
+      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -989,7 +989,7 @@
     "grunt-contrib-clean": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz",
-      "integrity": "sha1-O+fKSA2kt0CqXp2GPi9+iyT4pos=",
+      "integrity": "sha512-g5ZD3ORk6gMa5ugZosLDQl3dZO7cI3R14U75hTM+dVLVxdMNJCPVmwf9OUt4v4eWgpKKWWoVK9DZc1amJp4nQw==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -999,7 +999,7 @@
         "async": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.11"
@@ -1032,6 +1032,12 @@
         "file-sync-cmp": "^0.1.0"
       }
     },
+    "grunt-exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-3.0.0.tgz",
+      "integrity": "sha512-cgAlreXf3muSYS5LzW0Cc4xHK03BjFOYk0MqCQ/MZ3k1Xz2GU7D+IAJg4UKicxpO+XdONJdx/NJ6kpy2wI+uHg==",
+      "dev": true
+    },
     "grunt-json-remove-fields": {
       "version": "github:SFDigitalServices/grunt-json-remove-fields#4f9ef75865cc0ff5fbf7fc55037d19e4f4edda62",
       "from": "github:SFDigitalServices/grunt-json-remove-fields#4f9ef75",
@@ -1040,13 +1046,13 @@
     "grunt-known-options": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
-      "integrity": "sha1-bMCIEHvQIZ3F0+V9kZI/RpBZgE0=",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
       "dev": true
     },
     "grunt-legacy-log": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
-      "integrity": "sha1-yM0sbIGkRlubvy2HTZY/73pZ/7k=",
+      "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
         "colors": "~1.1.2",
@@ -1066,7 +1072,7 @@
     "grunt-legacy-log-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
-      "integrity": "sha1-0vRCx8AVAGXZAEsI/XQQ03UZGU4=",
+      "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
         "chalk": "~2.4.1",
@@ -1076,7 +1082,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -1096,7 +1102,7 @@
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -1107,7 +1113,7 @@
     "grunt-legacy-util": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
-      "integrity": "sha1-4QYk58hgNOW4cMioYWdD8KCEXkI=",
+      "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
         "async": "~1.5.2",
@@ -1122,7 +1128,7 @@
     "grunt-replace-regex": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/grunt-replace-regex/-/grunt-replace-regex-1.0.3.tgz",
-      "integrity": "sha1-1CSMEnmODheJ6/xPNGtMfNMviQA=",
+      "integrity": "sha512-WdQwywS59xxTyVtcDm2wDj8J0M3Qu/S3q6EHbdn4gqHllZ8AnoujAKmcuuZ0Ewj87eKwlmWHSkxpy5jMkO+gvg==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.0",
@@ -1146,7 +1152,7 @@
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",
@@ -1191,7 +1197,7 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-signature": {
@@ -1244,7 +1250,7 @@
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -1287,7 +1293,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "is-arrayish": {
@@ -1299,7 +1305,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-finite": {
@@ -1403,7 +1409,7 @@
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1425,7 +1431,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify": {
@@ -1552,7 +1558,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._isnative": {
@@ -1606,7 +1612,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -1630,7 +1636,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1660,7 +1666,7 @@
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
@@ -1671,7 +1677,7 @@
     "next-applause": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/next-applause/-/next-applause-2.2.4.tgz",
-      "integrity": "sha1-pE0UqPQbtQ2DLmA56YDwHe+ePPc=",
+      "integrity": "sha512-ktqjWT512q6vzAYnmRfJcqqVCA7ft8VcqkfBzgWuqI9SDSHM//B+hvjrGlkNzOzDMzljc3flok01t79OGkRVXQ==",
       "dev": true,
       "requires": {
         "cson-parser": "^1.2.0",
@@ -1699,7 +1705,7 @@
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -1734,7 +1740,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -1889,7 +1895,7 @@
     "protractor": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.4.2.tgz",
-      "integrity": "sha1-Mp7+N/SLIUGrlGd5m+LU0S60jBM=",
+      "integrity": "sha512-zlIj64Cr6IOWP7RwxVeD8O4UskLYPoyIcg0HboWJL9T79F1F0VWtKkGTr/9GN6BKL+/Q/GmM7C9kFVCfDbP5sA==",
       "dev": true,
       "requires": {
         "@types/q": "^0.0.32",
@@ -1990,7 +1996,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "q": {
@@ -2002,7 +2008,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "read-pkg": {
@@ -2050,7 +2056,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "repeat-string": {
@@ -2071,7 +2077,7 @@
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -2128,13 +2134,13 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "saucelabs": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.5.0.tgz",
-      "integrity": "sha1-lAWnPDYNRJsjKDmRmobDltN5/Z0=",
+      "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "dev": true,
       "requires": {
         "https-proxy-agent": "^2.2.1"
@@ -2143,13 +2149,13 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "selenium-webdriver": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
-      "integrity": "sha1-K6h6FmLAILiYjJga5iyyoBKY6vw=",
+      "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
         "jszip": "^3.1.3",
@@ -2190,7 +2196,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
@@ -2199,7 +2205,7 @@
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2209,13 +2215,13 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -2225,7 +2231,7 @@
     "spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
@@ -2237,7 +2243,7 @@
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -2260,7 +2266,7 @@
     "stack-generator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-      "integrity": "sha1-u3Q4XGf/xMzzxN7lgxgy1OUJyKA=",
+      "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
       "dev": true,
       "requires": {
         "stackframe": "^1.0.4"
@@ -2269,13 +2275,13 @@
     "stackframe": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-      "integrity": "sha1-NXskqZL5Qny6a1RdlqFO0svKGHs=",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
       "dev": true
     },
     "stacktrace-gps": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
-      "integrity": "sha1-M/i6pEZzI6sr0YFu+ieZQrpDHMw=",
+      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
       "dev": true,
       "requires": {
         "source-map": "0.5.6",
@@ -2353,7 +2359,7 @@
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
         "psl": "^1.1.24",
@@ -2398,7 +2404,7 @@
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
-      "integrity": "sha1-/CrSVbi9MJ4jnLxYFv0jqbfqQCM=",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
       "dev": true,
       "requires": {
         "sprintf-js": "^1.0.3",
@@ -2423,7 +2429,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -2444,13 +2450,13 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -2471,7 +2477,7 @@
     "webdriver-js-extender": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.1.0.tgz",
-      "integrity": "sha1-V9epPADbTMjVVuTT20tdsKgMO7c=",
+      "integrity": "sha512-lcUKrjbBfCK6MNsh7xaY2UAUmZwe+/ib03AjVOpFobX4O7+83BUveSrLfU0Qsyb1DaKJdQRbuU+kM9aZ6QUhiQ==",
       "dev": true,
       "requires": {
         "@types/selenium-webdriver": "^3.0.0",
@@ -2481,7 +2487,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -2496,7 +2502,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "grunt-angular-translate": "^1.0.0",
         "grunt-contrib-clean": "2.0.0",
         "grunt-contrib-copy": "0.8.1",
+        "grunt-exec": "3.0.0",
         "grunt-json-remove-fields": "github:SFDigitalServices/grunt-json-remove-fields#4f9ef75",
         "grunt-replace-regex": "^1.0.3",
         "grunt-sort-json": "0.0.5",


### PR DESCRIPTION
This PR:
1. Removes use of tmp files in `grunt translations`
1. Adds `phrasePush` and `phrasePull` commands to Gruntfile.js to automatically push and pull from Phrase with only one command. 
1. Switches label.other to label._other because otherwise Phrase assumes that it's the "other" option for pluralization of "label"

Still TODO:

- [ ] Verify that we're procuring Phrase
- [x] Add instructions to the readme 

Things we could do in the future (We can do them in [this ticket](https://www.pivotaltracker.com/story/show/173635532)):
1. Figure out a [branching scheme](https://help.phrase.com/help/branches)
1. Establish best practices around tags/labels for uploads 
1. Setup automated Github sync

# Review instructions
**Verify that grunt translations still works**
1. Try removing usage of a key throughout the code, run `grunt translations`, and verify that it's deleted from all of the locale files
1. Try messing up the sorting of one of the locale files, run `grunt translations`, and verify that it re-sorts

**Test out the README instructions and phrase push/pull functionality**
1. Follow instructions in the readme to get setup
1. Try running `grunt phrasePull` and verify that there's no diff
1. Try updating an english string in phrase, and then run phrase Pull and verify that it's pulled down OK
1. Try making an update in a locale-en string locally, try running phrase push and verify that it pushes up OK. (maybe fix the string you just messed up)
1. Verify that you didn't end up with any net changes on phrase or locally. 
1. 