### PR TITLE
Remove usage of SHOW_SALE_LISTINGS env var #172845330

### DIFF
--- a/app/assets/javascripts/account/AccountController.js.coffee
+++ b/app/assets/javascripts/account/AccountController.js.coffee
@@ -3,7 +3,6 @@ AccountController = (
   $scope,
   $state,
   $translate,
-  $window,
   AccountService,
   AnalyticsService,
   inputMaxLength,
@@ -36,7 +35,6 @@ AccountController = (
 
   $scope.passwordRegex = /^(?=.*[0-9])(?=.*[a-zA-Z])(.+){8,}$/
   $scope.emailRegex = SharedService.emailRegex
-  $scope.showSaleListings = $window.env.showSaleListings == 'true'
 
   $scope.accountForm = ->
     # pick up which ever one is defined (the other will be undefined)
@@ -283,7 +281,7 @@ AccountController = (
       $translate.instant('error.password_confirmation')
 
 AccountController.$inject = [
-  '$document', '$scope', '$state', '$translate', '$window', 'AccountService', 'AnalyticsService', 'inputMaxLength',
+  '$document', '$scope', '$state', '$translate', 'AccountService', 'AnalyticsService', 'inputMaxLength',
   'ListingIdentityService', 'ModalService', 'SharedService', 'ShortFormApplicationService'
 ]
 

--- a/app/assets/javascripts/account/templates/my-applications.html.slim
+++ b/app/assets/javascripts/account/templates/my-applications.html.slim
@@ -14,10 +14,10 @@
             | {{'my_applications.no_applications' | translate}}
           .row
             .medium-12.large-8.medium-centered.columns
-              .margin-bottom ng-class="{'small-centered': !showSaleListings}"
+              .margin-bottom
                 a.button.secondary.expand ui-sref="dahlia.listings-for-rent"
                   | Browse Rentals
-              .margin-bottom ng-if="showSaleListings"
+              .margin-bottom
                 a.button.secondary.expand ui-sref="dahlia.listings-for-sale"
                   | Browse Sales
         article.feed-item ng-if="hasSaleAndRentalApplications(myApplications)"

--- a/app/assets/javascripts/listings/components/favorites-component.html.slim
+++ b/app/assets/javascripts/listings/components/favorites-component.html.slim
@@ -12,9 +12,9 @@ header.lead-header.bg-image
       p.t-delta.t-serif.c-oil translate="listings.no_favorites"
   .row
     .medium-12.large-4.medium-centered.columns
-        .margin-bottom ng-class="{'small-centered': !$ctrl.parent.showSaleListings}"
+        .margin-bottom
           a.button.secondary.expand ui-sref="dahlia.listings-for-rent" translate="listings.browse_rentals"
-        .margin-bottom ng-if="$ctrl.parent.showSaleListings"
+        .margin-bottom
           a.button.secondary.expand ui-sref="dahlia.listings-for-sale" translate="listings.browse_sales"
 
 .results-section

--- a/app/assets/javascripts/listings/components/listingContainer.js.coffee
+++ b/app/assets/javascripts/listings/components/listingContainer.js.coffee
@@ -2,9 +2,9 @@ angular.module('dahlia.components')
 .component 'listingContainer',
   transclude: true
   templateUrl: 'listings/components/listing-container.html'
-  controller: ['$translate', '$window', 'ListingDataService', 'ListingEligibilityService', 'ListingIdentityService',
+  controller: ['$translate', 'ListingDataService', 'ListingEligibilityService', 'ListingIdentityService',
   'ListingUnitService', 'SharedService',
-  ($translate, $window, ListingDataService, ListingEligibilityService, ListingIdentityService, ListingUnitService, SharedService) ->
+  ($translate, ListingDataService, ListingEligibilityService, ListingIdentityService, ListingUnitService, SharedService) ->
     ctrl = @
     # TODO: remove Shared Service once we create a Shared Container
     @listingEmailAlertUrl = "http://eepurl.com/dkBd2n"
@@ -22,7 +22,6 @@ angular.module('dahlia.components')
     @openNotMatchListings = ListingDataService.openNotMatchListings
     @closedListings = ListingDataService.closedListings
     @lotteryResultsListings = ListingDataService.lotteryResultsListings
-    @showSaleListings = $window.env.showSaleListings == 'true'
 
     @isRental = (listing) ->
       ListingIdentityService.isRental(listing)

--- a/app/assets/javascripts/listings/components/welcome-component.html.slim
+++ b/app/assets/javascripts/listings/components/welcome-component.html.slim
@@ -5,10 +5,10 @@ section.splash-header.bg-image
         | {{'welcome.title' | translate}}
       .row
         .medium-6.medium-centered.columns
-          .medium-6.columns ng-class="{'small-centered': !$ctrl.parent.showSaleListings}"
+          .medium-6.columns
             a.button.secondary.expand ui-sref="dahlia.listings-for-rent"
               | {{'welcome.see_rental_listings' | translate}}
-          .medium-6.columns ng-if="$ctrl.parent.showSaleListings"
+          .medium-6.columns
             a.button.secondary.expand ui-sref="dahlia.listings-for-sale"
               | {{'welcome.see_sale_listings' | translate}}
 .row

--- a/app/assets/javascripts/shared/NavController.js.coffee
+++ b/app/assets/javascripts/shared/NavController.js.coffee
@@ -2,11 +2,9 @@
 ###################################### CONTROLLER ##########################################
 ############################################################################################
 
-NavController = ($document, $rootScope, $scope, $state, $timeout, $translate, AccountService, ModalService, ShortFormApplicationService,
-$window) ->
+NavController = ($document, $rootScope, $scope, $state, $timeout, $translate, AccountService, ModalService, ShortFormApplicationService) ->
   $scope.loggedIn = AccountService.loggedIn
   $scope.showNavMobile = false
-  $scope.showSaleListings = $window.env.showSaleListings == 'true'
 
   $scope.signOut = ->
     if ShortFormApplicationService.isShortFormPage($state.current)
@@ -65,8 +63,7 @@ $window) ->
 
 NavController.$inject = [
   '$document', '$rootScope', '$scope', '$state', '$timeout', '$translate',
-  'AccountService', 'ModalService', 'ShortFormApplicationService', '$window'
-]
+  'AccountService', 'ModalService', 'ShortFormApplicationService']
 
 angular
   .module('dahlia.controllers')

--- a/app/assets/javascripts/shared/templates/nav/_nav_items.html.slim
+++ b/app/assets/javascripts/shared/templates/nav/_nav_items.html.slim
@@ -1,10 +1,7 @@
-li ng-if="!showSaleListings"
-  a ui-sref="dahlia.listings-for-rent"
-    | {{ "nav.browse_properties" | translate}}
-li ng-if-start="showSaleListings"
+li
   a ui-sref="dahlia.listings-for-rent"
     | {{ "nav.rent" | translate}}
-li ng-if-end="true"
+li
   a ui-sref="dahlia.listings-for-sale"
     | {{ "nav.buy" | translate}}
 li

--- a/app/assets/javascripts/shared/templates/nav/nav-mobile.html.slim
+++ b/app/assets/javascripts/shared/templates/nav/nav-mobile.html.slim
@@ -6,13 +6,10 @@ pageslide ps-class="ng-pageslide hide-for-print" ps-open="showNavMobile" ps-side
           use xlink:href="#i-right"
 
   ul.nav-mobile.skiptranslate
-    li ng-if="!showSaleListings"
-      a.nav-mobile-focus ui-sref="dahlia.listings-for-rent" ng-blur="trapFocus($event)"
-        | {{ "nav.browse_properties" | translate}}
-    li ng-if-start="showSaleListings"
+    li
       a.nav-mobile-focus ui-sref="dahlia.listings-for-rent" ng-blur="trapFocus($event)"
         | {{ "nav.rent" | translate}}
-    li ng-if-end="true"
+    li
       a.nav-mobile-focus ui-sref="dahlia.listings-for-sale" ng-blur="trapFocus($event)"
         | {{ "nav.buy" | translate}}
     li

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,7 +38,7 @@ html lang="en" ng-app="dahlia" ng-strict-di="" ng-controller="SharedController"
     meta property="og:type" content="website"
 
     javascript:
-      window.env = {showSaleListings: "#{ENV['SHOW_SALE_LISTINGS']}", showPreLotteryInfo: "#{ENV['SHOW_PRE_LOTTERY_INFO']}", researchFormUrl: "#{ENV['RESEARCH_FORM_URL']}"}
+      window.env = {showPreLotteryInfo: "#{ENV['SHOW_PRE_LOTTERY_INFO']}", researchFormUrl: "#{ENV['RESEARCH_FORM_URL']}"}
 
     - if ENV['HEAP_ANALYTICS_KEY']
       /! HEAP Analytics

--- a/spec/javascripts/components/listing/lotteryInfoSection_spec.coffee
+++ b/spec/javascripts/components/listing/lotteryInfoSection_spec.coffee
@@ -2,7 +2,7 @@ do ->
   'use strict'
   describe 'Lottery Info Section Component', ->
     fakeWindow = {}
-    fakeWindow['env'] = {showSaleListings: 'true', showPreLotteryInfo: 'true'}
+    fakeWindow['env'] = {showPreLotteryInfo: 'true'}
     $componentController = undefined
     ctrl = undefined
     locals = undefined

--- a/spec/javascripts/components/listingContainer_spec.coffee
+++ b/spec/javascripts/components/listingContainer_spec.coffee
@@ -12,8 +12,6 @@ do ->
     fakeListingDataService = {}
     $translate =
       instant: jasmine.createSpy()
-    fakeWindow = {}
-    fakeWindow['env'] = {showSaleListings: 'true'}
     fakeSharedService = {}
     fakeShortFormApplicationService =
       getLanguageCode: jasmine.createSpy()
@@ -72,7 +70,6 @@ do ->
       $componentController = _$componentController_
       locals = {
         $translate: $translate
-        $window: fakeWindow
         ListingDataService: fakeListingDataService
         ListingEligibilityService: fakeListingEligibilityService
         ListingIdentityService: fakeListingIdentityService

--- a/spec/javascripts/controllers/account_controller_spec.coffee
+++ b/spec/javascripts/controllers/account_controller_spec.coffee
@@ -6,8 +6,6 @@ do ->
     deferred = undefined
     $translate =
       instant: jasmine.createSpy()
-    fakeWindow = {}
-    fakeWindow['env'] = {showSaleListings: 'true'}
     fakeAnalyticsService =
       trackFormSuccess: jasmine.createSpy()
       trackFormError: jasmine.createSpy()
@@ -47,7 +45,6 @@ do ->
 
     beforeEach module('dahlia.controllers', ($provide) ->
       $provide.value '$translate', $translate
-      $provide.value '$window', fakeWindow
       return
     )
 

--- a/spec/javascripts/controllers/nav_controller_spec.coffee
+++ b/spec/javascripts/controllers/nav_controller_spec.coffee
@@ -1,8 +1,7 @@
 do ->
   'use strict'
   describe 'NavController', ->
-    fakeWindow = {}
-    fakeWindow['env'] = {showSaleListings: 'true'}
+
     fakeDocument = {}
     scope = undefined
     state = undefined
@@ -21,7 +20,6 @@ do ->
       $provide.value 'AccountService', fakeAccountService
       $provide.value 'ModalService', fakeModalService
       $provide.value 'ShortFormApplicationService', fakeShortFormApplicationService
-      $provide.value '$window', fakeWindow
       return
     )
 

--- a/spec/javascripts/controllers/nav_controller_spec.coffee
+++ b/spec/javascripts/controllers/nav_controller_spec.coffee
@@ -1,7 +1,6 @@
 do ->
   'use strict'
   describe 'NavController', ->
-
     fakeDocument = {}
     scope = undefined
     state = undefined
@@ -52,5 +51,4 @@ do ->
           expect(fakeAccountService.signOut).toHaveBeenCalled()
         it 'direct you to sign in page', ->
           expect(state.go).toHaveBeenCalledWith('dahlia.sign-in', {signedOut: true})
-
 


### PR DESCRIPTION
Picked up from the small-wins pile. [Ticket](https://www.pivotaltracker.com/story/show/172845330)
After we release we'll need to remove the env var from the prod app. 

# Review instructions
Goal is just to check that al the places where we were using the flag still look OK (the same as before)

1. Top nav bar
![image](https://user-images.githubusercontent.com/11825994/87100537-7f04d380-c201-11ea-969a-ec79b1205fb9.png)

1. Mobile nav
![image](https://user-images.githubusercontent.com/11825994/87100552-8926d200-c201-11ea-82d2-14a8644dfd33.png)

2. Empty My-favorites page
![image](https://user-images.githubusercontent.com/11825994/87100562-917f0d00-c201-11ea-9a62-1cf40c3a8d96.png)

3. Empty My-applications page
![image](https://user-images.githubusercontent.com/11825994/87100430-4238dc80-c201-11ea-92eb-d2b4cd73b6e6.png)
