### PR TITLE
Change name from backend to unit tests in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
           root: .
           paths:
             - .
-  backend:
+  unit:
     <<: *defaults
     steps:
       - setup
@@ -183,7 +183,7 @@ workflows:
   build-and-deploy:
     jobs:
       - build
-      - backend:
+      - unit:
           <<: *non_production_jobs
       - e2e:
           <<: *non_production_jobs


### PR DESCRIPTION
Very minor change, just was a bit of a misnomer since we are running both jasmine and rspec tests in the "backend" job. 