### PR TITLE
Try removing sendgrid from review apps, replacing with Full creds

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,6 +22,16 @@
       "url": "https://github.com/bobbus/image-optim-buildpack"
     }
   ],
+  "environments": {
+    "review": {
+    "addons": [
+      "newrelic",
+      "papertrail",
+      "memcachier",
+      "heroku-postgresql"
+      ]
+    }
+  },
   "env":{
     "LANG":{
       "required":true


### PR DESCRIPTION
Following up on this previously-closed ticket because of continuing issues with sendgrid and heroku review apps.

To fix the issue I:
1. Removed sendgrid from the add-ons for review apps (this PR)
1. Copied the sendgrid credentials from sf-dahlia-full into the pipeline env vars

I tested with the review app for this PR (https://dahlia-web-full-pr-1383.herokuapp.com) and it appears to be working.

We'll have to just wait and see if it can be an ongoing solution