### PR TITLE
Add missing to ListingUnitService #173695074

### DIFF
--- a/app/assets/javascripts/listings/ListingUnitService.js.coffee
+++ b/app/assets/javascripts/listings/ListingUnitService.js.coffee
@@ -2,7 +2,7 @@
 ####################################### SERVICE ############################################
 ############################################################################################
 
-ListingUnitService = ($translate, $http, ListingConstantsService, ListingIdentityService) ->
+ListingUnitService = ($translate, $http, $q, ListingConstantsService, ListingIdentityService) ->
   Service = {}
   Service.loading = {}
   Service.error = {}
@@ -261,7 +261,7 @@ ListingUnitService = ($translate, $http, ListingConstantsService, ListingIdentit
 ######################################## CONFIG ############################################
 ############################################################################################
 
-ListingUnitService.$inject = ['$translate', '$http', 'ListingConstantsService', 'ListingIdentityService']
+ListingUnitService.$inject = ['$translate', '$http', '$q', 'ListingConstantsService', 'ListingIdentityService']
 
 angular
   .module('dahlia.services')

--- a/app/assets/javascripts/listings/ListingUnitService.js.coffee
+++ b/app/assets/javascripts/listings/ListingUnitService.js.coffee
@@ -222,7 +222,8 @@ ListingUnitService = ($translate, $http, $q, ListingConstantsService, ListingIde
     angular.copy([], Service.AMICharts)
     Service.loading.ami = true
     Service.error.ami = false
-    # If chartTypes are not defined on the listing, exit early.
+    # If chartTypes are not defined on the listing
+    # e.g. if there are no units on the listing yet, exit early.
     return $q.when() unless listing.chartTypes
     allChartTypes = _.sortBy(listing.chartTypes, 'percent')
     data =


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/173695074

Adds a missing reference to `$q` to `ListingUnitService`. Bug occurs when listing is missing units (eg. listing `a0W0P00000DZDKZUA5`)