### PR TITLE
Fix failing review apps and fix failing e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,6 @@ If we have new verified translations in Phrase, run `grunt phrasePull` to get th
 
 Use the engineering workflow and coding style standards established below. :smiley:
 
-### Engineering Workflow Overview
-
-Dahlia's current engineering workflow has been fully documented and can be found [here](https://docs.google.com/a/exygy.com/presentation/d/1Y5yAVUcKMFoNobutOH_Sehm69ZCZoTZzJZewupR-5KI/edit?usp=sharing).
-
-Dahlia's project backlog is in [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1405352).
-
 ### Acceptance/Feature Apps
 
 Temporary "acceptance" apps are created upon opening a pull request for a feature branch. After the pull request is closed, the acceptance app is automatically spun down. See [this Heroku article](https://devcenter.heroku.com/articles/github-integration-review-apps) for details.

--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
         "heroku-postgresql"
       ],
       "scripts": {
-        "postdeploy": "rake db:schema:load && rake db:migrate && rake listing_images:process_images"
+        "postdeploy": "rake db:migrate && rake listing_images:process_images"
       }
     }
   },

--- a/app.json
+++ b/app.json
@@ -24,12 +24,15 @@
   ],
   "environments": {
     "review": {
-    "addons": [
-      "newrelic",
-      "papertrail",
-      "memcachier",
-      "heroku-postgresql"
-      ]
+      "addons": [
+        "newrelic",
+        "papertrail",
+        "memcachier",
+        "heroku-postgresql"
+      ],
+      "scripts": {
+        "postdeploy": "db:schema:load && rake db:migrate && rake listing_images:process_images"
+      }
     }
   },
   "env":{

--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
         "heroku-postgresql"
       ],
       "scripts": {
-        "postdeploy": "db:schema:load && rake db:migrate && rake listing_images:process_images"
+        "postdeploy": "rake db:schema:load && rake db:migrate && rake listing_images:process_images"
       }
     }
   },

--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
         "heroku-postgresql"
       ],
       "scripts": {
-        "postdeploy": "rake db:migrate && rake listing_images:process_images"
+        "postdeploy": "rake db:migrate"
       }
     }
   },

--- a/spec/e2e/features/short_form/autofill.feature
+++ b/spec/e2e/features/short_form/autofill.feature
@@ -58,6 +58,7 @@ Feature: Autofill application
         And I opt out of "Live/Work" preference
         And I don't choose COP-DTHP preferences
         And I continue past the general lottery notice page
+        And I wait "2" seconds
         Then I should land on the optional survey page
         And on the optional survey page I should see my correct info
         And I confirm details on the review page


### PR DESCRIPTION
This PR tries to fix 2 things at once:
1. Fix flaky e2e tests: I added a wait as Marçin suggested and it tests keep passing so I think that solves our issue
1. I updated the post-deploy script to see if it'll stop causing the error below on review apps. I removed `rake db:setup` because of the message from Heroku support (below) and `rake listing_images:process_images` because we have been OK without it running for a long time and because it'll run automatically if we turn on caching. 

![image](https://user-images.githubusercontent.com/11825994/90074366-e7871a80-dcaf-11ea-9333-166557d8b19f.png)


Suggestion from Heroku support:
> db:setup tries to also create the database, but it doesn't actually have permission to do so. db:schema:load, db:structure:load or db:migrate are the only rake commands we formally support for scenarios that involve feeding starter data. It's possible that in the past db:setup either didn't explicitly try to create the database or didn't bother to try if the database already existed.

> In the two-step process you have, swapping db:setup with db:schema:load should do the trick.

I tried a couple of variations and this one seems to work best. I tried rake db:schema:load instead of db:setup but it caused issues with "destroying a production database". This script matches what we have in Partners. 