### PR TITLE
Run Lighthouse CI on successful deployments

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,12 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.deployment.sha }}
+
+      - name: determine branch
+        uses: SFDigitalServices/git-the-branch@v1
+
       - uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.GIT_BRANCH }}
           LHCI_GITHUB_TOKEN: ${{ github.token }}
           LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.payload.web_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm ci
 
       - name: determine branch
         uses: SFDigitalServices/git-the-branch@v1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        # here we only install the dependencies require()d in lighthouserc.js
+      - run: |
+          npm i url-join
 
       - name: determine branch
         uses: SFDigitalServices/git-the-branch@v1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-      - run: npm ci
 
       - name: determine branch
         uses: SFDigitalServices/git-the-branch@v1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,4 +22,4 @@ jobs:
         env:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.GIT_BRANCH }}
           LHCI_GITHUB_TOKEN: ${{ github.token }}
-          LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.payload.web_url }}
+          LHCI_COLLECT_BASE_URL: ${{ github.event.deployment.payload.web_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,24 +1,18 @@
 name: Lighthouse
-on: [push]
+on: [deployment_status]
 
 jobs:
   lighthouse:
+    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-      - run: npm ci
-      - id: deployment
-        uses: SFDigitalServices/wait-for-deployment-action@v2
         with:
-          github-token: ${{ github.token }}
-          interval: 300
-          timeout: 600
-
+          ref: ${{ github.event.deployment.sha }}
       - uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
           LHCI_GITHUB_TOKEN: ${{ github.token }}
-          LHCI_COLLECT_BASE_URL: ${{ steps.deployment.outputs.url }}
+          LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.payload.web_url }}

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,9 +1,3 @@
-try {
-  require('dotenv').config()
-} catch (error) {
-  // this can fail in CI, where there is no .env
-}
-
 const join = require('url-join')
 
 const {


### PR DESCRIPTION
This is an update to the Lighthouse workflow that should only run the Lighthouse CI workflow when any deployment is successful, by responding to the [`deployment_status` event](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#deployment_status).

I had to write [another action](https://github.com/SFDigitalServices/git-the-branch) to figure out which branch the commit SHA belongs to, since only `push` events set `GITHUB_REF`, and actions/checkout doesn't appear to bother doing the "reverse" lookup (with `git name-rev`).

The other thing I changed to speed up these runs is that the `npm install` step only installs `url-join` explicitly, rather than all of the dev dependencies. 🚀 