### PR TITLE
Fix max income table missing row issue DAH-530

### DIFF
--- a/app/assets/javascripts/customFilters.js.coffee
+++ b/app/assets/javascripts/customFilters.js.coffee
@@ -82,9 +82,6 @@ angular.module('customFilters', [])
     s = ['th', 'st', 'nd', 'rd']
     v = n % 100
     (s[(v - 20) % 10] or s[v] or s[0])
-.filter 'divideAndRoundDown', ->
-  (input, divider) ->
-    Math.floor(input / divider)
 .filter 'listify', ->
   # will turn an array of items into a comma separated list, ending with "and" e.g.
   # ['john', 'jane', 'joe', 'dana'] | listify

--- a/app/assets/javascripts/listings/ListingEligibilityService.js.coffee
+++ b/app/assets/javascripts/listings/ListingEligibilityService.js.coffee
@@ -46,12 +46,14 @@ ListingEligibilityService = ($localStorage, ListingIdentityService, ListingUnitS
   Service.householdMinMaxForMaxIncomeTable = (listing, amiCharts) ->
     occupancyMinMax = Service.occupancyMinMax(listing)
     min = occupancyMinMax[0] || 1
-    # We add '+ 2' for 2 children under 6 as part of householdsize but not occupancy. Unless it's max
-    maxAllowed = if _.isNumber(occupancyMinMax[1]) then occupancyMinMax[1] + 2 else 1
     maxesForAmiCharts = amiCharts.map (amiLevel) -> Service.maxAmiNumHousehold(amiLevel)
     maxHhAvailable = Math.max(maxesForAmiCharts...)
+    # We add '+ 2' for 2 children under 6 as part of householdsize but not occupancy
+    # If occupancyMax is null (in the case of Sale listings) we show all available AMI rows.
+    maxAllowed = if _.isNumber(occupancyMinMax[1]) then occupancyMinMax[1] + 2 else maxHhAvailable
     max = Math.min(maxAllowed, maxHhAvailable)
-    # TO DO: Hardcoded Temp fix, take this and replace with long term solution
+
+    # TO DO: Create long-term fix for some SRO units that allow 2 people.
     if (
       ListingIdentityService.listingIs('Merry Go Round Shared Housing', listing) ||
       ListingIdentityService.listingIs('1335 Folsom Street', listing)
@@ -64,10 +66,7 @@ ListingEligibilityService = ($localStorage, ListingIdentityService, ListingUnitS
   Service.occupancyIncomeLevels = (listing, amiChart) ->
     return [] unless amiChart
     minMax = Service.householdMinMaxForMaxIncomeTable(listing, [amiChart])
-    # if ListingIdentityService.isSale(listing)
-    #   max = _.max(_.map(amiChart.values, (v) -> v.numOfHousehold))
     _.filter amiChart.values, (value) ->
-      # where numOfHousehold >= min && <= max
       value.numOfHousehold >= minMax.min && value.numOfHousehold <= minMax.max
 
   Service.hhSizesToShowInMaxIncomeTable = (listing, amiCharts) ->

--- a/app/assets/javascripts/listings/ListingEligibilityService.js.coffee
+++ b/app/assets/javascripts/listings/ListingEligibilityService.js.coffee
@@ -43,12 +43,14 @@ ListingEligibilityService = ($localStorage, ListingIdentityService, ListingUnitS
   Service.maxAmiNumHousehold = (amiLevel) ->
     _.max(_.map(amiLevel.values, (v) -> v.numOfHousehold))
 
-  Service.occupancyIncomeLevels = (listing, amiLevel) ->
-    return [] unless amiLevel
+  Service.householdMinMaxForMaxIncomeTable = (listing, amiCharts) ->
     occupancyMinMax = Service.occupancyMinMax(listing)
-    min = occupancyMinMax[0]
+    min = occupancyMinMax[0] || 1
     # We add '+ 2' for 2 children under 6 as part of householdsize but not occupancy. Unless it's max
-    max = if _.isNumber(occupancyMinMax[1]) then occupancyMinMax[1] + 2 else Service.maxAmiNumHousehold(amiLevel)
+    maxAllowed = if _.isNumber(occupancyMinMax[1]) then occupancyMinMax[1] + 2 else 1
+    maxesForAmiCharts = amiCharts.map (amiLevel) -> Service.maxAmiNumHousehold(amiLevel)
+    maxHhAvailable = Math.max(maxesForAmiCharts...)
+    max = Math.min(maxAllowed, maxHhAvailable)
     # TO DO: Hardcoded Temp fix, take this and replace with long term solution
     if (
       ListingIdentityService.listingIs('Merry Go Round Shared Housing', listing) ||
@@ -57,31 +59,35 @@ ListingEligibilityService = ($localStorage, ListingIdentityService, ListingUnitS
       max = 2
     else if ListingUnitService.listingHasOnlySROUnits(listing)
       max = 1
-    # if ListingIdentityService.isSale(listing)
-    #   max = _.max(_.map(amiLevel.values, (v) -> v.numOfHousehold))
-    _.filter amiLevel.values, (value) ->
-      # where numOfHousehold >= min && <= max
-      value.numOfHousehold >= min && value.numOfHousehold <= max
+    {'min': min, 'max': max}
 
-  Service.incomeForHouseholdSize = (amiChart, householdIncomeLevel) ->
+  Service.occupancyIncomeLevels = (listing, amiChart) ->
+    return [] unless amiChart
+    minMax = Service.householdMinMaxForMaxIncomeTable(listing, [amiChart])
+    # if ListingIdentityService.isSale(listing)
+    #   max = _.max(_.map(amiChart.values, (v) -> v.numOfHousehold))
+    _.filter amiChart.values, (value) ->
+      # where numOfHousehold >= min && <= max
+      value.numOfHousehold >= minMax.min && value.numOfHousehold <= minMax.max
+
+  Service.hhSizesToShowInMaxIncomeTable = (listing, amiCharts) ->
+    return [] unless amiCharts
+    minMax = Service.householdMinMaxForMaxIncomeTable(listing, amiCharts)
+    # array with values from min to max
+    [minMax.min..minMax.max]
+
+
+  Service.incomeForHouseholdSize = (amiChart, householdSize) ->
     incomeLevel = _.find amiChart.values, (value) ->
-      value.numOfHousehold == householdIncomeLevel.numOfHousehold
+      value.numOfHousehold == householdSize
     return unless incomeLevel
     incomeLevel.amount
 
   Service.householdAMIChartCutoff = (listing) ->
-    # TODO: Hardcoded Temp fix, take this and replace with long term solution
-    if (
-      ListingIdentityService.listingIs('Merry Go Round Shared Housing', listing) ||
-      ListingIdentityService.listingIs('1335 Folsom Street', listing)
-    )
-      return 2
-    else if ListingUnitService.listingHasOnlySROUnits(listing)
-      return 1
     occupancyMinMax = Service.occupancyMinMax(listing)
     max = if _.isNumber(occupancyMinMax[1]) then occupancyMinMax[1] else 2
-    # cutoff at 2x the num of bedrooms
-    Math.floor(max/2) * 2
+    # cutoff at 2x the num of bedrooms, with a minumum of 1
+    Math.max(Math.floor(max/2) * 2, 1)
 
   return Service
 

--- a/app/assets/javascripts/listings/ListingUnitService.js.coffee
+++ b/app/assets/javascripts/listings/ListingUnitService.js.coffee
@@ -215,8 +215,8 @@ ListingUnitService = ($translate, $http, $q, ListingConstantsService, ListingIde
 
   Service.listingHasOnlySROUnits = (listing) ->
     combined = Service.combineUnitSummaries(listing)
+    return false unless combined.length
     _.every(combined, { Unit_Type: 'SRO' })
-
 
   Service.getListingAMI = (listing) ->
     angular.copy([], Service.AMICharts)

--- a/app/assets/javascripts/listings/components/listing/eligibilitySection.js.coffee
+++ b/app/assets/javascripts/listings/components/listing/eligibilitySection.js.coffee
@@ -64,7 +64,7 @@ angular.module('dahlia.components')
         $filter('currency')(income, '$', 0) + ' ' + $translate.instant('label.per_year')
 
       @formatIncomePerMonth = (income) ->
-        per_month = $filter('divideAndRoundDown')(income, 12)
+        per_month = Math.floor(income / 12)
         $filter('currency')(per_month, '$', 0) + ' ' + $translate.instant('label.per_month')
 
       return ctrl

--- a/app/assets/javascripts/listings/components/listing/eligibilitySection.js.coffee
+++ b/app/assets/javascripts/listings/components/listing/eligibilitySection.js.coffee
@@ -25,10 +25,8 @@ angular.module('dahlia.components')
 
       @showAMItoggler = ->
         return false if _.isEmpty(ListingUnitService.AMICharts)
-        amiLevel = _.last(ListingUnitService.AMICharts)
-        lastHouseholdIncomeLevel = ListingEligibilityService.occupancyIncomeLevels(this.parent.listing, amiLevel)
-        maxNumOfHousehold = _.max(_.map(lastHouseholdIncomeLevel, 'numOfHousehold'))
-        maxNumOfHousehold > ListingEligibilityService.householdAMIChartCutoff(this.parent.listing)
+        minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(this.parent.listing, ListingUnitService.AMICharts)
+        minMax.max > ListingEligibilityService.householdAMIChartCutoff(this.parent.listing)
 
       @hasMultipleAMICharts = ->
         ListingUnitService.AMICharts.length > 1
@@ -48,14 +46,17 @@ angular.module('dahlia.components')
       @priorityLabel = (priority, modifier) ->
         ListingDataService.priorityLabel(priority, modifier)
 
-      @occupancyIncomeLevels = (amiLevel) ->
-        ListingEligibilityService.occupancyIncomeLevels(this.parent.listing, amiLevel)
+      @occupancyIncomeLevels = (amiCharts) ->
+        ListingEligibilityService.occupancyIncomeLevels(this.parent.listing, amiCharts)
+
+      @hhSizesToShowInMaxIncomeTable = (amiCharts) ->
+        ListingEligibilityService.hhSizesToShowInMaxIncomeTable(this.parent.listing, amiCharts)
 
       @householdAMIChartCutoff = ->
         ListingEligibilityService.householdAMIChartCutoff(this.parent.listing)
 
-      @formatIncomeForHouseholdSize = (amiChart, householdIncomeLevel) ->
-        income = ListingEligibilityService.incomeForHouseholdSize(amiChart, householdIncomeLevel)
+      @formatIncomeForHouseholdSize = (amiChart, numOfHousehold) ->
+        income = ListingEligibilityService.incomeForHouseholdSize(amiChart, numOfHousehold)
         if income
           $filter('currency')(income, '$', 0)
 

--- a/app/assets/javascripts/listings/components/listing/eligibilitySection.js.coffee
+++ b/app/assets/javascripts/listings/components/listing/eligibilitySection.js.coffee
@@ -55,10 +55,17 @@ angular.module('dahlia.components')
       @householdAMIChartCutoff = ->
         ListingEligibilityService.householdAMIChartCutoff(this.parent.listing)
 
-      @formatIncomeForHouseholdSize = (amiChart, numOfHousehold) ->
+      @getMultiAmiIncomeString = (amiChart, numOfHousehold) ->
         income = ListingEligibilityService.incomeForHouseholdSize(amiChart, numOfHousehold)
         if income
-          $filter('currency')(income, '$', 0)
+          @formatIncomePerYear income
+
+      @formatIncomePerYear = (income) ->
+        $filter('currency')(income, '$', 0) + ' ' + $translate.instant('label.per_year')
+
+      @formatIncomePerMonth = (income) ->
+        per_month = $filter('divideAndRoundDown')(income, 12)
+        $filter('currency')(per_month, '$', 0) + ' ' + $translate.instant('label.per_month')
 
       return ctrl
   ]

--- a/app/assets/javascripts/listings/templates/listing/_income-table-multiple.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_income-table-multiple.html.slim
@@ -15,8 +15,8 @@
         th scope="col" ng-repeat="amiChart in $ctrl.parent.AMICharts"
           | {{::amiChart.percent}}% {{'t.ami' | translate}} {{'t.units' | translate}}
     tbody
-      tr ng-repeat="householdIncomeLevel in $ctrl.occupancyIncomeLevels($ctrl.parent.AMICharts[0])" ng-show="$ctrl.parent.toggleStates[$ctrl.parent.listing.Id].amiChartExpanded || householdIncomeLevel.numOfHousehold <= $ctrl.householdAMIChartCutoff()"
+      tr ng-repeat="householdSize in $ctrl.hhSizesToShowInMaxIncomeTable($ctrl.parent.AMICharts)" ng-show="$ctrl.parent.toggleStates[$ctrl.parent.listing.Id].amiChartExpanded || householdSize <= $ctrl.householdAMIChartCutoff()"
         td scope="row"
-          | {{::householdIncomeLevel.numOfHousehold}} <small>{{ ::$ctrl.occupancyLabel(householdIncomeLevel.numOfHousehold) }}</small>
+          | {{::householdSize}} <small>{{ ::$ctrl.occupancyLabel(householdSize) }}</small>
         td ng-repeat="amiChart in $ctrl.parent.AMICharts"
-          | <span class="notranslate">{{ $ctrl.formatIncomeForHouseholdSize(amiChart, householdIncomeLevel) }}</span><small>/year</small>
+          | <span class="notranslate">{{ $ctrl.formatIncomeForHouseholdSize(amiChart, householdSize) }}</span><small>/year</small>

--- a/app/assets/javascripts/listings/templates/listing/_income-table-multiple.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_income-table-multiple.html.slim
@@ -18,5 +18,5 @@
       tr ng-repeat="householdSize in $ctrl.hhSizesToShowInMaxIncomeTable($ctrl.parent.AMICharts)" ng-show="$ctrl.parent.toggleStates[$ctrl.parent.listing.Id].amiChartExpanded || householdSize <= $ctrl.householdAMIChartCutoff()"
         td scope="row"
           | {{::householdSize}} <small>{{ ::$ctrl.occupancyLabel(householdSize) }}</small>
-        td ng-repeat="amiChart in $ctrl.parent.AMICharts"
+        td ng-repeat="amiChart in $ctrl.parent.AMICharts" class="notranslate"
           | {{ $ctrl.getMultiAmiIncomeString(amiChart, householdSize) }}

--- a/app/assets/javascripts/listings/templates/listing/_income-table-multiple.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_income-table-multiple.html.slim
@@ -19,4 +19,4 @@
         td scope="row"
           | {{::householdSize}} <small>{{ ::$ctrl.occupancyLabel(householdSize) }}</small>
         td ng-repeat="amiChart in $ctrl.parent.AMICharts"
-          | <span class="notranslate">{{ $ctrl.formatIncomeForHouseholdSize(amiChart, householdSize) }}</span><small>/year</small>
+          | {{ $ctrl.getMultiAmiIncomeString(amiChart, householdSize) }}

--- a/app/assets/javascripts/listings/templates/listing/_income-table.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_income-table.html.slim
@@ -10,6 +10,6 @@
         td scope="row"
           | {{::householdIncomeLevel.numOfHousehold}} <small>{{ ::$ctrl.occupancyLabel(householdIncomeLevel.numOfHousehold) }}</small>
         td
-          | <span class="notranslate">{{::householdIncomeLevel.amount | divideAndRoundDown : 12 | currency : $ : 0}}</span><small>/month</small>
+          | {{::$ctrl.formatIncomePerMonth(householdIncomeLevel.amount)}}
         td
-          | <span class="notranslate">{{::householdIncomeLevel.amount | currency : $ : 0}}</span><small>/year</small>
+          | {{::$ctrl.formatIncomePerYear(householdIncomeLevel.amount)}}

--- a/app/assets/javascripts/listings/templates/listing/_income-table.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_income-table.html.slim
@@ -9,7 +9,7 @@
       tr ng-repeat="householdIncomeLevel in $ctrl.occupancyIncomeLevels($ctrl.parent.AMICharts[0])" ng-show="$ctrl.parent.toggleStates[$ctrl.parent.listing.Id].amiChartExpanded || householdIncomeLevel.numOfHousehold <= $ctrl.householdAMIChartCutoff()"
         td scope="row"
           | {{::householdIncomeLevel.numOfHousehold}} <small>{{ ::$ctrl.occupancyLabel(householdIncomeLevel.numOfHousehold) }}</small>
-        td
+        td class="notranslate"
           | {{::$ctrl.formatIncomePerMonth(householdIncomeLevel.amount)}}
-        td
+        td class="notranslate"
           | {{::$ctrl.formatIncomePerYear(householdIncomeLevel.amount)}}

--- a/spec/javascripts/components/listing/eligibilitySection_spec.coffee
+++ b/spec/javascripts/components/listing/eligibilitySection_spec.coffee
@@ -16,6 +16,7 @@ do ->
       occupancyIncomeLevels: ->
       incomeForHouseholdSize: jasmine.createSpy()
       householdAMIChartCutoff: ->
+      householdMinMaxForMaxIncomeTable: ->
     }
     fakeListingDataService =
       AMICharts: []
@@ -77,33 +78,29 @@ do ->
           fakeListingUnitService.AMICharts = fakeAMI
 
         it 'returns false for empty AMICharts', ->
+          fakeListingUnitService.AMICharts = {}
           expect(ctrl.showAMItoggler()).toBe(false)
-        it 'calls ListingEligibilityService.occupancyIncomeLevels', ->
-          spyOn(fakeListingEligibilityService, 'occupancyIncomeLevels')
+        it 'calls ListingEligibilityService.householdMinMaxForMaxIncomeTable', ->
+          spyOn(fakeListingEligibilityService, 'householdMinMaxForMaxIncomeTable').and.returnValue(
+            {'min': 1, 'max': 1}
+          )
           ctrl.showAMItoggler()
-          expect(fakeListingEligibilityService.occupancyIncomeLevels).toHaveBeenCalledWith(fakeListing, _.last(fakeAMI))
+          expect(fakeListingEligibilityService.householdMinMaxForMaxIncomeTable).toHaveBeenCalledWith(fakeListing, fakeAMI)
         it 'calls ListingEligibilityService.householdAMIChartCutoff', ->
+          spyOn(fakeListingEligibilityService, 'householdMinMaxForMaxIncomeTable').and.returnValue(
+            {'min': 1, 'max': 1}
+          )
           spyOn(fakeListingEligibilityService, 'householdAMIChartCutoff')
           ctrl.showAMItoggler()
           expect(fakeListingEligibilityService.householdAMIChartCutoff).toHaveBeenCalled()
         it 'returns true when maxNumOfHousehold is > householdAMIChartCutoff', ->
-          fakeOccupancyIncomeLevel = {
-            numOfHousehold: 5
-          }
-          fakeOccupancyIncomeLevel2 = {
-            numOfHousehold: 3
-          }
-          spyOn(fakeListingEligibilityService, 'occupancyIncomeLevels').and.returnValue([fakeOccupancyIncomeLevel, fakeOccupancyIncomeLevel2])
+          fakeMinMaxForIncomeTable = {'min': 3, 'max': 5}
+          spyOn(fakeListingEligibilityService, 'householdMinMaxForMaxIncomeTable').and.returnValue(fakeMinMaxForIncomeTable)
           spyOn(fakeListingEligibilityService, 'householdAMIChartCutoff').and.returnValue(4)
           expect(ctrl.showAMItoggler()).toEqual true
         it 'returns false when maxNumOfHousehold is < householdAMIChartCutoff', ->
-          fakeOccupancyIncomeLevel = {
-            numOfHousehold: 5
-          }
-          fakeOccupancyIncomeLevel2 = {
-            numOfHousehold: 3
-          }
-          spyOn(fakeListingEligibilityService, 'occupancyIncomeLevels').and.returnValue([fakeOccupancyIncomeLevel, fakeOccupancyIncomeLevel2])
+          fakeMinMaxForIncomeTable = {'min': 3, 'max': 5}
+          spyOn(fakeListingEligibilityService, 'householdMinMaxForMaxIncomeTable').and.returnValue(fakeMinMaxForIncomeTable)
           spyOn(fakeListingEligibilityService, 'householdAMIChartCutoff').and.returnValue(6)
           expect(ctrl.showAMItoggler()).toEqual false
 

--- a/spec/javascripts/components/listing/eligibilitySection_spec.coffee
+++ b/spec/javascripts/components/listing/eligibilitySection_spec.coffee
@@ -14,7 +14,7 @@ do ->
     }
     fakeListingEligibilityService = {
       occupancyIncomeLevels: ->
-      incomeForHouseholdSize: jasmine.createSpy()
+      incomeForHouseholdSize: ->
       householdAMIChartCutoff: ->
       householdMinMaxForMaxIncomeTable: ->
     }
@@ -152,7 +152,25 @@ do ->
           ctrl.householdAMIChartCutoff()
           expect(fakeListingEligibilityService.householdAMIChartCutoff).toHaveBeenCalled()
 
-      describe 'formatIncomeForHouseholdSize', ->
+      describe 'getMultiAmiIncomeString', ->
         it 'calls ListingEligibilityService.incomeForHouseholdSize with the given arguments', ->
-          ctrl.formatIncomeForHouseholdSize(1, 2)
+          spyOn(fakeListingEligibilityService, 'incomeForHouseholdSize')
+          ctrl.getMultiAmiIncomeString(1, 2)
           expect(fakeListingEligibilityService.incomeForHouseholdSize).toHaveBeenCalledWith(1, 2)
+        it 'calls formatIncomePerYear if income is available', ->
+          spyOn(ctrl, 'formatIncomePerYear')
+          spyOn(fakeListingEligibilityService, 'incomeForHouseholdSize').and.returnValue(1234)
+          ctrl.getMultiAmiIncomeString(fakeAMI.ami[0], 2)
+          expect(ctrl.formatIncomePerYear).toHaveBeenCalledWith(1234)
+
+      describe 'formatIncomePerYear', ->
+        it 'formats floats to currency per year as expected', ->
+          spyOn($translate, 'instant').and.returnValue('per year')
+          result = ctrl.formatIncomePerYear(123.456)
+          expect(result).toEqual('$123 per year')
+
+      describe 'formatIncomePerMonth', ->
+        it 'divides and formats incomes as expected', ->
+          spyOn($translate, 'instant').and.returnValue('per month')
+          result = ctrl.formatIncomePerMonth(49)
+          expect(result).toEqual('$4 per month')

--- a/spec/javascripts/services/listing_eligibility_service_spec.coffee
+++ b/spec/javascripts/services/listing_eligibility_service_spec.coffee
@@ -59,22 +59,73 @@ do ->
     describe 'Service.incomeForHouseholdSize', ->
       it 'should get the income amount for the selected AMI Chart and householdIncomeLevel', ->
         fakeChart = fakeAMI.ami[0]
-        fakeIncomeLevel = {numOfHousehold: 2}
-        amount = ListingEligibilityService.incomeForHouseholdSize(fakeChart, fakeIncomeLevel)
+        amount = ListingEligibilityService.incomeForHouseholdSize(fakeChart, 2)
         expect(amount).toEqual fakeChart.values[1].amount
 
-    describe 'Service.occupancyIncomeLevels', ->
+    describe 'Service.occupancyMinMax', ->
+      it 'returns 1 for min and max if no unit summary is available', ->
+        minMax = ListingEligibilityService.occupancyMinMax({})
+        expect(minMax).toEqual [1, 1]
+
+      it 'returns min and max occupancies if listing only has one unitSummary', ->
+        listing = {'unitSummary': [{'minOccupancy':1, 'maxOccupancy':3}]}
+        minMax = ListingEligibilityService.occupancyMinMax(listing)
+        expect(minMax).toEqual [1, 3]
+
+      it 'returns the absolute min and absolute max if listing has multiple unit summaries', ->
+        listing = {'unitSummary': [
+          {'minOccupancy':2, 'maxOccupancy':5},
+          {'minOccupancy':3, 'maxOccupancy':6},
+          {'minOccupancy':4, 'maxOccupancy':7}
+        ]}
+        minMax = ListingEligibilityService.occupancyMinMax(listing)
+        expect(minMax).toEqual [2, 7]
+
+    describe 'Service.householdMinMaxForMaxIncomeTable', ->
       beforeEach ->
-        incomeLevels = ListingEligibilityService.occupancyIncomeLevels(fakeListing.listing, fakeAMI.ami[0])
-        minMax = ListingEligibilityService.occupancyMinMax(fakeListing.listing)
-      it 'should filter the incomeLevels to start from min household', ->
-        expect(incomeLevels[0].numOfHousehold).toEqual minMax[0]
-      it 'should filter the incomeLevels to end at max household + 2', ->
-        expect(incomeLevels.slice(-1)[0].numOfHousehold).toEqual minMax[1] + 2
-      it 'should filter the incomeLevels to only show 1 person if all SROs', ->
-        incomeLevels = ListingEligibilityService.occupancyIncomeLevels(fakeListingAllSRO, fakeAMI.ami[0])
-        minMax = ListingEligibilityService.occupancyMinMax(fakeListingAllSRO)
-        expect(incomeLevels.slice(-1)[0].numOfHousehold).toEqual 1
+        fakeUnitSummaries = [{'minOccupancy': 1, 'maxOccupancy': 3}]
+        fakeListing = {'unitSummary': fakeUnitSummaries}
+      it 'should return the expected minimum value', ->
+        minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeListing, fakeAMI.ami)
+        expect(minMax.min).toEqual 1
+      it 'should return 1 if all units are SROs', ->
+        minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeListingAllSRO, fakeAMI.ami)
+        expect(minMax.min).toEqual 1
+        expect(minMax.max).toEqual 1
+      it 'should return a max of the max occupancy plus 2 if available on the AMI chart', ->
+        minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeListing, fakeAMI.ami)
+        expect(minMax.max).toEqual 5
+      describe 'when limited by what\'s available from the AMI charts', ->
+        it 'should return the max available AMI value if it\'s smaller than the max occupancy plus 2', ->
+          fakeBigUnitListing = {'unitSummary': [{'minOccupancy': 1, 'maxOccupancy': 8}]}
+          minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeBigUnitListing, fakeAMI.ami)
+          expect(minMax.max).toEqual 8
+        it 'should return the max available AMI value of the AMI chart with the most available values', ->
+          fakeBigUnitListing = {'unitSummary': [{'minOccupancy': 1, 'maxOccupancy': 8}]}
+          ami = [
+            {'percent': "50", values: [{'numOfHousehold': 8}]},
+            {'percent': "55", values: [{'numOfHousehold': 9}]}
+          ]
+          minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeBigUnitListing, ami)
+          expect(minMax.max).toEqual 9
+
+
+    describe 'Service.occupancyIncomeLevels', ->
+      describe 'when listing is not an SRO', ->
+        beforeEach ->
+
+        it 'should filter the incomeLevels to start from min household', ->
+          spyOn(
+            ListingEligibilityService, 'householdMinMaxForMaxIncomeTable'
+          ).and.returnValue({'min': 2, 'max': 5})
+          incomeLevels = ListingEligibilityService.occupancyIncomeLevels(fakeListing.listing, fakeAMI.ami[0])
+          expect(incomeLevels[0].numOfHousehold).toEqual 2
+        it 'should filter the incomeLevels to end at max value', ->
+          spyOn(
+            ListingEligibilityService,'householdMinMaxForMaxIncomeTable'
+          ).and.returnValue({'min': 2, 'max': 5})
+          incomeLevels = ListingEligibilityService.occupancyIncomeLevels(fakeListing.listing, fakeAMI.ami[0])
+          expect(incomeLevels.slice(-1)[0].numOfHousehold).toEqual 5
 
     describe 'Service.householdAMIChartCutoff', ->
       it 'returns 1 if all units are SROs', ->

--- a/spec/javascripts/services/listing_eligibility_service_spec.coffee
+++ b/spec/javascripts/services/listing_eligibility_service_spec.coffee
@@ -80,6 +80,14 @@ do ->
         ]}
         minMax = ListingEligibilityService.occupancyMinMax(listing)
         expect(minMax).toEqual [2, 7]
+      it 'returns null for max if the listing is a sale unit and has no maxOccupancy', ->
+        listing = {'unitSummary': [
+          {'minOccupancy':2},
+          {'minOccupancy':3},
+          {'minOccupancy':4}
+        ]}
+        minMax = ListingEligibilityService.occupancyMinMax(listing)
+        expect(minMax).toEqual [2, null]
 
     describe 'Service.householdMinMaxForMaxIncomeTable', ->
       beforeEach ->
@@ -95,6 +103,11 @@ do ->
       it 'should return a max of the max occupancy plus 2 if available on the AMI chart', ->
         minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeListing, fakeAMI.ami)
         expect(minMax.max).toEqual 5
+      it 'should return all available values from the AMI table if the listing has no max occupancy', ->
+        fakeSaleListing = {'unitSummary': [{'minOccupancy': 1}]}
+        minMax = ListingEligibilityService.householdMinMaxForMaxIncomeTable(fakeSaleListing, fakeAMI.ami)
+        expect(minMax.max).toEqual 8
+
       describe 'when limited by what\'s available from the AMI charts', ->
         it 'should return the max available AMI value if it\'s smaller than the max occupancy plus 2', ->
           fakeBigUnitListing = {'unitSummary': [{'minOccupancy': 1, 'maxOccupancy': 8}]}

--- a/spec/javascripts/services/listing_eligibility_service_spec.coffee
+++ b/spec/javascripts/services/listing_eligibility_service_spec.coffee
@@ -127,6 +127,14 @@ do ->
           incomeLevels = ListingEligibilityService.occupancyIncomeLevels(fakeListing.listing, fakeAMI.ami[0])
           expect(incomeLevels.slice(-1)[0].numOfHousehold).toEqual 5
 
+    describe 'Service.hhSizesToShowInMaxIncomeTable', ->
+      it 'should return an array with values from the min to max available hh sizes', ->
+          spyOn(
+            ListingEligibilityService,'householdMinMaxForMaxIncomeTable'
+          ).and.returnValue({'min': 2, 'max': 5})
+          range = ListingEligibilityService.hhSizesToShowInMaxIncomeTable(fakeListing.listing, fakeAMI.ami[0])
+          expect(range).toEqual [2, 3, 4, 5]
+
     describe 'Service.householdAMIChartCutoff', ->
       it 'returns 1 if all units are SROs', ->
         expect(ListingEligibilityService.householdAMIChartCutoff(fakeListingAllSRO)).toEqual(1)


### PR DESCRIPTION
DAH-530

I did a few things in this PR:
1. Fix the issue where showAMItoggler thought that the max value was 9 because it was looking at the "last" AMI chart
1. Generalized the way that we decide how many rows to show in the max income table to look across all AMI chart values for the max available value instead of just looking at the first value
1. Explicitly only look for the household size range in _income-table-multiple.slim.html instead of passing around irrelevant income values
1. Add more tests/improve tests for related functions. 
1. Fixed a bug where we were showing "/year" for missing AMI values 
![image](https://user-images.githubusercontent.com/11825994/94096585-52f8f780-fdd9-11ea-972b-3e13cfb8c53c.png)
1. Switched from "/month" and "/year" to "per month" and "per year" for better experience for screen readers, and started using human translations. 

Review instructions are in the ticket.