### PR TITLE
Create rake script to reupload proof files [DAH-155]

### DIFF
--- a/app/jobs/short_form_attachment_job.rb
+++ b/app/jobs/short_form_attachment_job.rb
@@ -16,7 +16,7 @@ class ShortFormAttachmentJob < ApplicationJob
       response =
         Force::ShortFormService.attach_file(application, file, file.descriptive_name)
       if response.status == 200
-        update_file_on_success(file, application_id)
+        ShortFormAttachmentJob.update_file_on_success(file, application_id)
         return
       else
         error_message = "status: #{response.status}; #{response.body}"

--- a/app/jobs/short_form_attachment_job.rb
+++ b/app/jobs/short_form_attachment_job.rb
@@ -16,12 +16,7 @@ class ShortFormAttachmentJob < ApplicationJob
       response =
         Force::ShortFormService.attach_file(application, file, file.descriptive_name)
       if response.status == 200
-        # now that file is saved in SF, remove file binary and mark as delivered
-        file.update(
-          file: nil,
-          application_id: application_id,
-          delivered_at: Time.now,
-        )
+        update_file_on_success(file, application_id)
         return
       else
         error_message = "status: #{response.status}; #{response.body}"
@@ -33,6 +28,16 @@ class ShortFormAttachmentJob < ApplicationJob
     file.update(
       application_id: application_id,
       error: error_message,
+    )
+  end
+
+  # now that file is saved in SF, remove file binary and mark as delivered
+  def self.update_file_on_success(file, application_id)
+    file.update(
+      file: nil,
+      error: nil,
+      application_id: application_id,
+      delivered_at: Time.now,
     )
   end
 end

--- a/lib/tasks/proof_reupload.rake
+++ b/lib/tasks/proof_reupload.rake
@@ -1,0 +1,67 @@
+require 'optparse'
+
+namespace :proof do # rubocop:disable Metrics/BlockLength
+  desc 'Re-upload provided failed proof uploads'
+  task reupload: :environment do
+    puts 'performing reupload task'
+    options = get_args(ARGV)
+
+    for_each_line_in_file(options[:filename], :process_id)
+    exit
+  end
+
+  private
+
+  def process_id(id)
+    puts "Processing id #{id}"
+    # record = UploadedFile.where(id: id)
+    # get most recent record
+    # Check that the record has error != null
+    # Check that the record has a file
+    # retry uploading to salesforce
+    # on fail, print error
+    # on succeed, null out file and error in pg db
+  end
+
+  def for_each_line_in_file(filename, func)
+    fpath = File.expand_path(filename)
+    File.readlines(fpath).each do |line|
+      method(func).call(line.gsub(/\s+/, ''))
+    end
+  end
+
+  def valid_filename?(filename)
+    return false unless filename.present?
+
+    fpath = File.expand_path(filename)
+    File.exist?(fpath)
+  end
+
+  def get_args(cmd_args)
+    options = { is_dry_run: true }
+
+    o = OptionParser.new
+    o.banner = 'Usage: rake proof:reupload -- [options]'
+    o.on(
+      '-d',
+      '--dry-run [FLAG]',
+      TrueClass,
+      'When dry-run is off, we actually upload the proofs. Defaults to true.',
+    ) do |is_dry_run|
+      options[:is_dry_run] = is_dry_run.nil? ? true : is_dry_run
+    end
+
+    o.on('-f', '--failedProofsFile ARG', String) do |filename|
+      options[:filename] = filename
+    end
+
+    args = o.order!(cmd_args) {}
+    o.parse!(args)
+
+    unless valid_filename?(options[:filename])
+      raise "Invalid filename passed: #{options[:filename]}"
+    end
+
+    options
+  end
+end

--- a/lib/tasks/proof_reupload.rake
+++ b/lib/tasks/proof_reupload.rake
@@ -6,7 +6,27 @@ namespace :proof do # rubocop:disable Metrics/BlockLength
     puts 'performing reupload task'
     options = get_args(ARGV)
 
+    @result_ids = {
+      successful: [],
+      with_no_record: [],
+      with_no_file: [],
+      with_no_application_id: [],
+      failed_fetch_application: [],
+      with_null_error: [],
+      with_upload_to_salesforce_error: [],
+    }
+
     for_each_line_in_file(options[:filename], :process_id)
+
+    puts
+    puts 'Processed all IDs.' \
+    "\n  Successful: #{@result_ids[:successful]}" \
+    "\n  No record found: #{@result_ids[:with_no_record]}" \
+    "\n  Record file is null: #{@result_ids[:with_no_file]}" \
+    "\n  Record application id is null: #{@result_ids[:with_no_application_id]}" \
+    "\n  Record error is null: #{@result_ids[:with_null_error]}" \
+    "\n  Application fetch failed: #{@result_ids[:failed_fetch_application]}" \
+    "\n  Salesforce error: #{@result_ids[:with_upload_to_salesforce_error]}"
     exit
   end
 
@@ -14,13 +34,62 @@ namespace :proof do # rubocop:disable Metrics/BlockLength
 
   def process_id(id)
     puts "Processing id #{id}"
-    # record = UploadedFile.where(id: id)
-    # get most recent record
-    # Check that the record has error != null
-    # Check that the record has a file
-    # retry uploading to salesforce
-    # on fail, print error
+    record = UploadedFile.find_by(id: id)
+
+    return unless check_required_fields?(id, record)
+
+    application = Force::ShortFormService.get(record[:application_id])
+
+    if application.nil?
+      log_error(
+        id,
+        "ShortFormService.get(#{record[:application_id]}) returned nil.",
+        :failed_fetch_application,
+      )
+      return
+    end
+
+    response =
+      Force::ShortFormService.attach_file(application, record, record.descriptive_name)
+
+    if response.status != 200
+      log_error(id, 'attach_file failed', :with_upload_to_salesforce_error)
+      return
+    end
+
     # on succeed, null out file and error in pg db
+    ShortFormAttachmentJob.update_file_on_success(record, record[:application_id])
+
+    @result_ids[:successful].append(id)
+  end
+
+  def check_required_fields?(id, record)
+    if record.nil?
+      log_error(id, 'Record not found.', :with_no_record)
+      return false
+    end
+
+    if record[:error].nil?
+      log_error(id, 'Record field error is null', :with_null_error)
+      return false
+    end
+
+    if record[:file].nil?
+      log_error(id, 'Record field file is null', :with_no_file)
+      return false
+    end
+
+    if record[:application_id].nil?
+      log_error(id, 'Record field application_id is null', :with_no_application_id)
+      return false
+    end
+
+    true
+  end
+
+  def log_error(id, message, id_list_sym)
+    puts "Error for id: #{id}. Message: #{message}"
+    @result_ids[id_list_sym].append(id)
   end
 
   def for_each_line_in_file(filename, func)
@@ -30,26 +99,11 @@ namespace :proof do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  def valid_filename?(filename)
-    return false unless filename.present?
-
-    fpath = File.expand_path(filename)
-    File.exist?(fpath)
-  end
-
   def get_args(cmd_args)
-    options = { is_dry_run: true }
+    options = {}
 
     o = OptionParser.new
     o.banner = 'Usage: rake proof:reupload -- [options]'
-    o.on(
-      '-d',
-      '--dry-run [FLAG]',
-      TrueClass,
-      'When dry-run is off, we actually upload the proofs. Defaults to true.',
-    ) do |is_dry_run|
-      options[:is_dry_run] = is_dry_run.nil? ? true : is_dry_run
-    end
 
     o.on('-f', '--failedProofsFile ARG', String) do |filename|
       options[:filename] = filename
@@ -63,5 +117,12 @@ namespace :proof do # rubocop:disable Metrics/BlockLength
     end
 
     options
+  end
+
+  def valid_filename?(filename)
+    return false unless filename.present?
+
+    fpath = File.expand_path(filename)
+    File.exist?(fpath)
   end
 end


### PR DESCRIPTION
[DAH-155]

confluence readme link: https://sfgovdt.jira.com/wiki/spaces/HOUS/pages/2252439625/Guide+Re-uploading+failed+preference+proofs

Example input file: `testIds-68-69.txt`:
```
68
69
```

Example command:
```
 rake proof:reupload -- -f '~/Desktop/testIds-68-69.txt' --dry-run false
```

Example output:
```
performing reupload task
Processing id 68
Processing id 69

Processed all IDs.
  Successful: ["68", "69"]
  No record found: []
  Record file is null: []
  Record application id is null: []
  Record error is null: []
  Application fetch failed: []
  Salesforce error: []
```


Example dataclip to get errored ids with specific error message substring:
```
/*
Errors by Type,	Error string to match
String too long,	'%first error: STRING_TOO_LONG%'
String length exceeds max,	'%String length exceeds maximum%'
Heap size,	'%JSON string exceeds heap size limit%'
Missing version data,	'%Required fields are missing: [VersionData]%'
Invalid picklist,	'%INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST%'
Unkown exception,	'%UNKNOWN_EXCEPTION%'
Insufficient access,	'%INSUFFICIENT_ACCESS%'
*/

SELECT id
FROM uploaded_files
WHERE Error is Not NULL and file is Not NULL and application_id is Not NULL and Error like '%first error: STRING_TOO_LONG%'
ORDER BY created_at DESC
LIMIT 2
```

TODO:
- [x]  create example dataclip to find application with a specific error type
- [x] update readme and/or production mgmt doc with instructions how to use this script

[DAH-155]: https://sfgovdt.jira.com/browse/DAH-155