### PR TITLE
Fix rake script after running in prod [DAH-155]

### DIFF
--- a/lib/tasks/proof_reupload.rake
+++ b/lib/tasks/proof_reupload.rake
@@ -67,6 +67,7 @@ namespace :proof do # rubocop:disable Metrics/BlockLength
       Force::ShortFormService.attach_file(application, record, record.descriptive_name)
 
     if response.status != 200
+      puts response.body.to_s
       log_error(id, 'attach_file failed', :with_upload_to_salesforce_error)
       return
     end
@@ -106,10 +107,11 @@ namespace :proof do # rubocop:disable Metrics/BlockLength
     @result_ids[id_list_sym].append(id)
   end
 
-  def for_each_line_in_file(filename, func)
+  def for_each_id_in_file(filename, func)
     fpath = File.expand_path(filename)
     File.readlines(fpath).each do |line|
-      method(func).call(line.gsub(/\s+/, ''))
+      line_stripped = line.gsub(/\s+/, '')
+      method(func).call(line_stripped) if !line_stripped.empty? && line_stripped != 'id'
     end
   end
 

--- a/lib/tasks/proof_reupload.rake
+++ b/lib/tasks/proof_reupload.rake
@@ -2,6 +2,18 @@ require 'optparse'
 
 namespace :proof do # rubocop:disable Metrics/BlockLength
   desc 'Re-upload provided failed proof uploads'
+
+  # This one-off task re-tries proof uploads that have failed in the past.
+  # It takes a file with proof IDs to retry as input and processes them
+  #   by doing the following:
+  # 1. Finding the postgres record with that ID
+  # 2. Checking that the record has an error and a file binary attached
+  # 3. Re-attaching the record via salesforce
+  # 4. On success, updating the DB to remove the error and file binary
+  #    from the postgres record.
+  #
+  # See https://sfgovdt.jira.com/wiki/spaces/HOUS/pages/2252439625/Guide+Re-uploading+failed+preference+proofs
+  #   for a step-by-step guide on how to run this script in production.
   task reupload: :environment do
     puts 'performing reupload task'
     options = get_args(ARGV)


### PR DESCRIPTION
Final fix for [DAH-155]

two small fixes:
- Somehow my method name change wasn't commited, change method name to "for_each_id_in_file"
- print more detailed error message when the salesforce request fails. This is just something I realized would be nice when running the one-off.

[DAH-155]: https://sfgovdt.jira.com/browse/DAH-155