### PR TITLE
Do not show SRO box on 1335 Folsom DAH-683

### DIFF
--- a/app/assets/javascripts/listings/ListingConstantsService.js.coffee
+++ b/app/assets/javascripts/listings/ListingConstantsService.js.coffee
@@ -91,6 +91,7 @@ ListingConstantsService = () ->
   Service.LISTING_MAP = {
     'a0W0P00000F7t4uUAB': 'Merry Go Round Shared Housing'
     'a0W0P00000FIuv3UAD': '1335 Folsom Street'
+    'a0W4U00000HlubxUAB': '1335 Folsom Street'
   }
 
   return Service


### PR DESCRIPTION
DAH-683

Since we already had a listing for this building that made some changes, just adding this ID impacts the result in 3 places:
- https://github.com/SFDigitalServices/sf-dahlia-web/blob/main/app/assets/javascripts/listings/ListingEligibilityService.js.coffee#L59
- https://github.com/SFDigitalServices/sf-dahlia-web/blob/main/app/assets/javascripts/listings/components/listing/property-hero.html.slim#L93
- https://github.com/SFDigitalServices/sf-dahlia-web/blob/main/app/assets/javascripts/listings/components/listing/eligibility-section.html.slim#L75-L77
This is simpler than adding code to each of those places saying that it's technically 1335 Folsom Unit 403. 

Would be nice to check based on the building instead, but that is a bigger fix