### PR TITLE
Update config for DALP env vars DAH-668

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ This script will:
 - Merge it with the latest main
 - Open a PR in a browser window
 
+## Environment variable configurations
+### DALP Advertising
+ - ADVERTISE_DALP -> If set to 'true', the Sales directory page will display info about applying to DALP in a "Help with downpayments" section. Otherwise it'll show the plain "Get help" section
+ - DALP_PROGRAM_INFO -> If provided, we will override the default DALP text of "The 2021 Downpayment Assistance Loan Program (DALP) will begin accepting applications on February 26, 2021." with whatever is in this env var.
+
 ## Contributing changes
 
 Use the engineering workflow and coding style standards established below. :smiley:

--- a/app.json
+++ b/app.json
@@ -100,10 +100,10 @@
       "required":true
     },
     "ADVERTISE_DALP": {
-      "required": true
+      "required": false
     },
     "DALP_PROGRAM_INFO": {
-      "required": true
+      "required": false
     }
   }
 }


### PR DESCRIPTION
DAH-668

This PR:
1. Adds info to README about these env vars
2. Makes the env vars not required on Heroku so we won't get an error on deploy is they're not present.

I've confirmed locally that if they aren't provided we get the same text that we have now
![image](https://user-images.githubusercontent.com/11825994/104664796-00439400-5685-11eb-9afa-2dc19afbe903.png)

Prevents errors like:
![image](https://user-images.githubusercontent.com/11825994/104665166-94adf680-5685-11eb-831c-1a9ab0264346.png)

And is best practice since the env vars are not required