### PR TITLE
Make lottery venue fields optional [DAH-722]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ prod_and_release_jobs: &prod_and_release_jobs
     branches:
       only:
         - /^release.*$/
+        - /^hotfix.*$/
         - production
 aliases:
   - &attach_workspace

--- a/app/assets/javascripts/listings/components/listing/lottery-info-section.html.slim
+++ b/app/assets/javascripts/listings/components/listing/lottery-info-section.html.slim
@@ -15,7 +15,7 @@ section.content-wrap
             use xlink:href="#i-clock"
         span translate="listings.applications_closed" translate-value-date="{{::$ctrl.parent.listing.Application_Due_Date | date : 'MMM d, yyyy \'at\' h:mm a'}}"
 
-  span ng-if="$ctrl.parent.lotteryDateVenueAvailable($ctrl.parent.listing) && !$ctrl.lotteryComplete()"
+  span ng-if="$ctrl.parent.lotteryDateAvailable($ctrl.parent.listing) && !$ctrl.lotteryComplete()"
     ng-include src="'listings/templates/listing/_pre_lottery_info.html'"
 
   .content-group ng-if='!$ctrl.lotteryComplete()'

--- a/app/assets/javascripts/listings/components/listing/process-section.html.slim
+++ b/app/assets/javascripts/listings/components/listing/process-section.html.slim
@@ -38,22 +38,22 @@ accordion-heading
 
   .content-group
     h4.h-caps-lined translate="listings.process.public_lottery"
-    ul ng-if="::$ctrl.parent.lotteryDateVenueAvailable($ctrl.parent.listing)"
+    ul ng-if="::$ctrl.parent.lotteryDateAvailable($ctrl.parent.listing)"
       li
         p.content-group_date
           span.content-group_day
             | {{ ::$ctrl.parent.listing.Lottery_Date | date : 'longDate' }}
           span.content-group_time
             | {{ ::$ctrl.parent.listing.Lottery_Date | date : 'shortTime' | lowercase }}
-        div.margin-top ng-if="::$ctrl.parent.showCovidUpdate"
+        div.margin-top ng-if="$ctrl.parent.showCovidUpdate"
           p.t-sans.margin-bottom--half translate="listings.apply.covid_update"
           p.c-steel translate="listings.apply.covid_update_lotteries"
-        div ng-if="::!$ctrl.parent.showCovidUpdate"
+        div ng-if="!$ctrl.parent.showCovidUpdate && $ctrl.parent.lotteryVenueAvailable($ctrl.parent.listing)"
           p.content-group_address.no-margin.skiptranslate
             |  {{ ::$ctrl.parent.listing.Lottery_Venue }}
           p.content-group_address.c-steel.skiptranslate
             | {{ ::$ctrl.parent.listing.Lottery_Street_Address }} {{ ::$ctrl.parent.listing.Lottery_City }}
-    p.t-small.c-steel ng-if="::!$ctrl.parent.lotteryDateVenueAvailable($ctrl.parent.listing)" translate="listings.process.lottery_date_time_and_venue_to_be_scheduled"
+    p.t-small.c-steel ng-if="::!$ctrl.parent.lotteryDateAvailable($ctrl.parent.listing)" translate="listings.process.lottery_date_time_and_venue_to_be_scheduled"
 
   ng-include src="'listings/templates/listing/_additional_sidebar_info.html'"
 

--- a/app/assets/javascripts/listings/components/listingContainer.js.coffee
+++ b/app/assets/javascripts/listings/components/listingContainer.js.coffee
@@ -81,9 +81,11 @@ angular.module('dahlia.components')
     @hasEligibilityFilters = ->
       ListingEligibilityService.hasEligibilityFilters()
 
-    @lotteryDateVenueAvailable = (listing) ->
-      (listing.Lottery_Date != undefined &&
-        listing.Lottery_Venue != undefined && listing.Lottery_Street_Address != undefined)
+    @lotteryDateAvailable = (listing) ->
+      listing.Lottery_Date != undefined
+
+    @lotteryVenueAvailable = (listing) ->
+      (listing.Lottery_Venue != undefined && listing.Lottery_Street_Address != undefined)
 
     @agentInfoAvailable = (listing) ->
       listing.Leasing_Agent_Phone || listing.Leasing_Agent_Email || listing.Leasing_Agent_Street

--- a/app/assets/javascripts/listings/templates/listing/_pre_lottery_info.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_pre_lottery_info.html.slim
@@ -6,7 +6,7 @@
       | {{ $ctrl.parent.listing.Lottery_Date | date : 'longDate' }}
     span.content-group_time
       | {{ $ctrl.parent.listing.Lottery_Date | date : 'shortTime' | lowercase }}
-  p.content-group_address.c-steel.skiptranslate
+  p.content-group_address.c-steel.skiptranslate ng-if="!$ctrl.parent.lotteryVenueAvailable()"
     | {{ $ctrl.parent.listing.Lottery_Venue }}
     br
     | {{ $ctrl.parent.listing.Lottery_Street_Address }}

--- a/app/assets/javascripts/listings/templates/listing/_pre_lottery_info.html.slim
+++ b/app/assets/javascripts/listings/templates/listing/_pre_lottery_info.html.slim
@@ -9,7 +9,7 @@
   div.margin-top ng-if="$ctrl.parent.showCovidUpdate"
           p.t-sans.margin-bottom--half translate="listings.apply.covid_update"
           p.c-steel translate="listings.apply.covid_update_lotteries"
-  p.content-group_address.c-steel.skiptranslate ng-if="!$ctrl.parent.showCovidUpdate && $ctrl.parent.lotteryVenueAvailable()"
+  p.content-group_address.c-steel.skiptranslate ng-if="!$ctrl.parent.showCovidUpdate && $ctrl.parent.lotteryVenueAvailable($ctrl.parent.listing)"
     | {{ $ctrl.parent.listing.Lottery_Venue }}
     br
     | {{ $ctrl.parent.listing.Lottery_Street_Address }}

--- a/spec/javascripts/components/listingContainer_spec.coffee
+++ b/spec/javascripts/components/listingContainer_spec.coffee
@@ -229,7 +229,7 @@ do ->
           ctrl.listingApplicationClosed(fakeListing)
           expect(fakeListingIdentityService.isOpen).toHaveBeenCalled()
 
-      describe '$ctrl.lotteryDateVenueAvailable', ->
+      describe '$ctrl.lotteryDateAvailable', ->
         beforeEach ->
           listing = fakeListing
           listing.Lottery_Date = new Date()
@@ -238,22 +238,22 @@ do ->
 
         describe 'listing lottery date, venue and lottery address all have values', ->
           it 'returns true', ->
-            expect(ctrl.lotteryDateVenueAvailable(listing)).toEqual true
+            expect(ctrl.lotteryDateAvailable(listing)).toEqual true
 
         describe 'listing lottery date missing', ->
           it 'returns false', ->
             listing.Lottery_Date = undefined
-            expect(ctrl.lotteryDateVenueAvailable(listing)).toEqual false
+            expect(ctrl.lotteryDateAvailable(listing)).toEqual false
 
         describe 'listing venue missing', ->
           it 'returns false', ->
             listing.Lottery_Venue = undefined
-            expect(ctrl.lotteryDateVenueAvailable(listing)).toEqual false
+            expect(ctrl.lotteryDateAvailable(listing)).toEqual true
 
         describe 'listing lottery address missing', ->
           it 'returns false', ->
             listing.Lottery_Street_Address = undefined
-            expect(ctrl.lotteryDateVenueAvailable(listing)).toEqual false
+            expect(ctrl.lotteryDateAvailable(listing)).toEqual true
 
       describe '$ctrl.formattedBuildingAddress', ->
         it 'expects ListingDataService.formattedAddress to be called', ->


### PR DESCRIPTION
[DAH-722]

We're not showing the lottery venue fields, so they should be optional.

## Old behavior
Lottery section does not show the date or covid update unless Lottery_Date, Lottery_Venue, and Lottery_Street_Address are all filled in.

## New Behvaior
Lottery section shows the date + covid update if Lottery_Date is not populated, doesn't matter if venue is populated


## COVID_UPDATE=false + Lottery_Venue="String"
<img width="1104" alt="covid_update_false" src="https://user-images.githubusercontent.com/64036574/108407695-edb70000-71d8-11eb-8f9b-d0a4fc173c71.png">

## COVID_UPDATE=false + Lottery_Venue=null
<img width="1144" alt="covid_update_false_no_string" src="https://user-images.githubusercontent.com/64036574/108407682-eb54a600-71d8-11eb-8c29-826bbfcd104c.png">

## COVID_UPDATE=true + Lottery_Venue="String"
<img width="1138" alt="covid_update_true_with_string" src="https://user-images.githubusercontent.com/64036574/108407675-e859b580-71d8-11eb-8c63-e0627dd6057a.png">

## COVID_UPDATE=true + Lottery_Venue=null
<img width="1075" alt="covid_update_true_no_string" src="https://user-images.githubusercontent.com/64036574/108407668-e5f75b80-71d8-11eb-80d4-d79559c0711f.png">


[DAH-722]: https://sfgovdt.jira.com/browse/DAH-722