### PR TITLE
[Webapp] Add heroku stack to app.json [DAH-675]

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "name":"sf-dahlia-web",
   "description":"",
+  "stack": "heroku-20",
   "scripts":{
     "postdeploy": "rake db:setup && rake db:migrate && rake listing_images:process_images"
   },


### PR DESCRIPTION
Webapp: DAH-675
Partners: DAH-665

Following these instructions: https://devcenter.heroku.com/articles/heroku-20-stack

We need to add the new heroku stack version to make sure that review apps are on the correct version. Deploying this code won't upgrade existing apps, though, we have to upgrade them manually.

Partners PR is here: https://github.com/SFDigitalServices/sf-dahlia-lap/pull/493