### PR TITLE
[Hotfix][Webapp] Bump mimemagic gem to 3.8 [DAH-751]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ end
 
 gem 'rails', '~> 5.1.7'
 
+# Rails depends on 0.3.5, this has since been taken down (as of 3/24/2021),
+# so we have to force 0.3.8
+gem 'mimemagic', '~> 0.3.8'
+
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Slim templates generator for Rails 3 and 4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
+    mimemagic (0.3.8)
+      nokogiri (~> 1)
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -438,6 +440,7 @@ DEPENDENCIES
   jbuilder (~> 2.8.0)
   jquery-rails
   memcachier
+  mimemagic (~> 0.3.8)
   mini_magick (~> 4.9.4)
   newrelic_rpm
   nokogiri (>= 1.10.10)


### PR DESCRIPTION
Webapp ticket: [DAH-751]
Partners ticket: [DAH-752]

Webapp currently relies on mimemagic 3.5, which has been removed from the gem repository for licensing reasons. This bumps it to 3.8, which still exists.

We want to hold off on deploying this change until we're sure this is the correct solution, as the situation is still developing. 

See these issues [new mimemagic version released under MIT](https://github.com/rails/rails/issues/41757), [dependency on mimemagic no longer valid](https://github.com/rails/rails/issues/41750) for more info

[DAH-751]: https://sfgovdt.jira.com/browse/DAH-751
[DAH-752]: https://sfgovdt.jira.com/browse/DAH-752