### PR TITLE
Fix 588 mission missing summary DAH-744

### DIFF
--- a/app/assets/javascripts/listings/ListingDataService.js.coffee
+++ b/app/assets/javascripts/listings/ListingDataService.js.coffee
@@ -317,6 +317,7 @@ ListingDataService = (
         listingPreferenceID: lotteryPref.Id
         preferenceName: lotteryPref.Lottery_Preference.Name
       }
+    ListingPreferenceService._extractCustomPreferences(listing)
     angular.copy(listing, Service.listing)
 
   Service.formattedAddress = (listing, type='Building', display='full') ->

--- a/spec/javascripts/fixtures/json/listing-from-application.json
+++ b/spec/javascripts/fixtures/json/listing-from-application.json
@@ -1,0 +1,236 @@
+ {
+    "unitSummaries": {
+      "reserved": null,
+      "general": [
+        {
+          "unitType": "1 BR",
+          "totalUnits": 3,
+          "minSquareFt": 1000,
+          "minRentalMinIncome": 2000,
+          "minPriceWithParking": null,
+          "minPriceWithoutParking": null,
+          "minPercentIncome": null,
+          "minOccupancy": 1,
+          "minMonthlyRent": 1000,
+          "minHoaDuesWithParking": null,
+          "minHoaDuesWithoutParking": null,
+          "maxSquareFt": 1000,
+          "maxRentalMinIncome": 2000,
+          "maxPriceWithParking": null,
+          "maxPriceWithoutParking": null,
+          "maxPercentIncome": null,
+          "maxOccupancy": 3,
+          "maxMonthlyRent": 1000,
+          "maxHoaDuesWithParking": null,
+          "maxHoaDuesWithoutParking": null,
+          "listingID": "a0W6s0000005MPHEA2",
+          "availability": 3,
+          "absoluteMinIncome": 2000,
+          "absoluteMaxIncome": 8645
+        }
+      ]
+    },
+    "reservedDescriptor": null,
+    "prioritiesDescriptor": null,
+    "listingID": "a0W6s0000005MPHEA2",
+    "chartTypes": [
+      {
+        "year": 2020,
+        "percent": 90,
+        "numOfHousehold": null,
+        "chartType": "MOHCD Adjusted HUD Unadjusted",
+        "amount": null
+      }
+    ],
+    "attributes": {
+      "type": "Listing",
+      "url": "/services/data/v35.0/sobjects/Listing/a0W6s0000005MPHEA2"
+    },
+    "Name": "588 Mission Bay Pref Test",
+    "Realtor_Commission_Unit": "percent",
+    "Allows_Realtor_Commission": false,
+    "Tenure": "Re-rental",
+    "First_Come_First_Served": false,
+    "Building": {
+      "attributes": {
+        "type": "Building",
+        "url": "/services/data/v35.0/sobjects/Building/a0a0P00000ERmQnQAL"
+      },
+      "Id": "a0a0P00000ERmQnQAL"
+    },
+    "In_Lottery": 15,
+    "Units_Available": 3,
+    "SASE_Required_for_Lottery_Ticket": false,
+    "nGeneral_Application_Total": 2,
+    "Lottery_Status": "Not Yet Run",
+    "Building_Name": "Arc Mercy Community",
+    "Project_ID": "2010-004",
+    "Building_Street_Address": "588 Mission Bay Blvd North",
+    "Building_City": "San Francisco",
+    "Building_State": "CA",
+    "Building_Zip_Code": "94158",
+    "Developer": "Powell-Roberts",
+    "Neighborhood": "Mission Bay",
+    "Year_Built": 2017,
+    "LastModifiedDate": "2021-04-30T19:48:48.000+0000",
+    "Marketing_URL": "588-Mission-Bay",
+    "Application_Due_Date": "2021-05-15T00:00:00.000+0000",
+    "Application_State": "CA",
+    "Lottery_City": "San Francisco",
+    "Lottery_Date": "2021-06-01T17:00:00.000+0000",
+    "Publish_Lottery_Results": true,
+    "Accepting_Online_Applications": true,
+    "Lottery_Winners": 0,
+    "Leasing_Agent_Name": "Jason Houston",
+    "Leasing_Agent_Title": "Leasing Agent",
+    "Leasing_Agent_Email": "drivera@email.com",
+    "Leasing_Agent_Phone": "(510) 555-5555",
+    "Accepting_applications_at_leasing_agent": false,
+    "Accepting_applications_by_PO_Box": false,
+    "Blank_paper_application_can_be_picked_up": false,
+    "Deposit_Min": 0,
+    "Reserved_community_maximum_age": 0,
+    "Reserved_community_minimum_age": 0,
+    "hasWaitlist": false,
+    "Total_waitlist_openings": 0,
+    "Total_number_of_building_units": 4,
+    "RecordTypeId": "0120P000000kPUSQA2",
+    "Id": "a0W6s0000005MPHEA2",
+    "Listing_Lottery_Preferences": [
+      {
+        "attributes": {
+          "type": "Listing_Lottery_Preference",
+          "url": "/services/data/v35.0/sobjects/Listing_Lottery_Preference/a0l6s000000CJ7qAAG"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0l6s000000CJ7qAAG",
+        "Total_Submitted_Apps": 5,
+        "Order": 1,
+        "Current_Units_Available": 0,
+        "Lottery_Preference": {
+          "attributes": {
+            "type": "Lottery_Preference",
+            "url": "/services/data/v35.0/sobjects/Lottery_Preference/a0m0P00000wwi3IQAQ"
+          },
+          "Id": "a0m0P00000wwi3IQAQ",
+          "Name": "Certificate of Preference (COP)"
+        }
+      },
+      {
+        "attributes": {
+          "type": "Listing_Lottery_Preference",
+          "url": "/services/data/v35.0/sobjects/Listing_Lottery_Preference/a0l6s000000CJ7vAAG"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0l6s000000CJ7vAAG",
+        "Total_Submitted_Apps": 5,
+        "Order": 2,
+        "Current_Units_Available": 0,
+        "Lottery_Preference": {
+          "attributes": {
+            "type": "Lottery_Preference",
+            "url": "/services/data/v35.0/sobjects/Lottery_Preference/a0m0P00000www1mQAA"
+          },
+          "Id": "a0m0P00000www1mQAA",
+          "Name": "Displaced Tenant Housing Preference (DTHP)"
+        }
+      },
+      {
+        "attributes": {
+          "type": "Listing_Lottery_Preference",
+          "url": "/services/data/v35.0/sobjects/Listing_Lottery_Preference/a0l6s000000CJ80AAG"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0l6s000000CJ80AAG",
+        "Total_Submitted_Apps": 12,
+        "Order": 3,
+        "Current_Units_Available": 0,
+        "Lottery_Preference": {
+          "attributes": {
+            "type": "Lottery_Preference",
+            "url": "/services/data/v35.0/sobjects/Lottery_Preference/a0m6s000000itNwAAI"
+          },
+          "Id": "a0m6s000000itNwAAI",
+          "Name": "Employment or Disability Preference"
+        }
+      },
+      {
+        "attributes": {
+          "type": "Listing_Lottery_Preference",
+          "url": "/services/data/v35.0/sobjects/Listing_Lottery_Preference/a0l6s000000CJ85AAG"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0l6s000000CJ85AAG",
+        "Total_Submitted_Apps": 7,
+        "Order": 4,
+        "Current_Units_Available": 0,
+        "Lottery_Preference": {
+          "attributes": {
+            "type": "Lottery_Preference",
+            "url": "/services/data/v35.0/sobjects/Lottery_Preference/a0m0P00000wwi3NQAQ"
+          },
+          "Id": "a0m0P00000wwi3NQAQ",
+          "Name": "Live or Work in San Francisco Preference"
+        }
+      }
+    ],
+    "Units": [
+      {
+        "attributes": {
+          "type": "Unit",
+          "url": "/services/data/v35.0/sobjects/Unit/a0b6s000000kWldAAE"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0b6s000000kWldAAE",
+        "Unit_Type": "1 BR",
+        "BMR_Rent_Monthly": 1000,
+        "BMR_Rental_Minimum_Monthly_Income_Needed": 2000,
+        "Status": "Available",
+        "isReservedCommunity": false,
+        "AMI_chart_type": "MOHCD Adjusted HUD Unadjusted",
+        "AMI_chart_year": 2020,
+        "Max_AMI_for_Qualifying_Unit": 90
+      },
+      {
+        "attributes": {
+          "type": "Unit",
+          "url": "/services/data/v35.0/sobjects/Unit/a0b6s000000kWlnAAE"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0b6s000000kWlnAAE",
+        "Unit_Type": "1 BR",
+        "BMR_Rent_Monthly": 1000,
+        "BMR_Rental_Minimum_Monthly_Income_Needed": 2000,
+        "Status": "Available",
+        "isReservedCommunity": false,
+        "AMI_chart_type": "MOHCD Adjusted HUD Unadjusted",
+        "AMI_chart_year": 2020,
+        "Max_AMI_for_Qualifying_Unit": 90
+      },
+      {
+        "attributes": {
+          "type": "Unit",
+          "url": "/services/data/v35.0/sobjects/Unit/a0b6s000000kWliAAE"
+        },
+        "Listing": "a0W6s0000005MPHEA2",
+        "Id": "a0b6s000000kWliAAE",
+        "Unit_Type": "1 BR",
+        "BMR_Rent_Monthly": 1000,
+        "BMR_Rental_Minimum_Monthly_Income_Needed": 2000,
+        "Status": "Available",
+        "isReservedCommunity": false,
+        "AMI_chart_type": "MOHCD Adjusted HUD Unadjusted",
+        "AMI_chart_year": 2020,
+        "Max_AMI_for_Qualifying_Unit": 90
+      }
+    ],
+    "RecordType": {
+      "attributes": {
+        "type": "RecordType",
+        "url": "/services/data/v35.0/sobjects/RecordType/0120P000000kPUSQA2"
+      },
+      "Id": "0120P000000kPUSQA2",
+      "Name": "Rental"
+    },
+    "imageURL": null
+  }

--- a/spec/javascripts/services/listing_data_service_spec.coffee
+++ b/spec/javascripts/services/listing_data_service_spec.coffee
@@ -5,6 +5,7 @@ do ->
     httpBackend = undefined
     fakeListings = getJSONFixture('listings-api-index.json')
     fakeListing = getJSONFixture('listings-api-show.json')
+    fakeListingFromApplication = getJSONFixture('listing-from-application.json')
     fakeAMI = getJSONFixture('listings-api-ami.json')
     fakeEligibilityListings = getJSONFixture('listings-api-eligibility-listings.json')
     fakeEligibilityFilters =
@@ -326,15 +327,21 @@ do ->
 
     describe 'Service.loadListing', ->
       beforeEach ->
-        ListingDataService.loadListing(fakeListing.listing)
+        ListingDataService.loadListing(fakeListingFromApplication)
 
       it 'should populate Service.listing', ->
-        expect(ListingDataService.listing.Id).toEqual fakeListing.listing.Id
+        expect(ListingDataService.listing.Id).toEqual fakeListingFromApplication.Id
       it 'should populate Service.listing.preferences', ->
-        count = fakeListing.listing.Listing_Lottery_Preferences.length
+        count = fakeListingFromApplication.Listing_Lottery_Preferences.length
         expect(ListingDataService.listing.preferences.length).toEqual count
-        prefId = fakeListing.listing.Listing_Lottery_Preferences[0].Id
+        prefId = fakeListingFromApplication.Listing_Lottery_Preferences[0].Id
         expect(ListingDataService.listing.preferences[0].listingPreferenceID).toEqual prefId
+      it 'should populate Service.listing.customPreferences', ->
+        expectedCustomPref = {
+          listingPreferenceID: 'a0l6s000000CJ80AAG', preferenceName: 'Employment or Disability Preference'
+        }
+        expect(ListingDataService.listing.customPreferences).
+        toContain(jasmine.objectContaining(expectedCustomPref))
 
     describe 'Service.getListingPaperAppURLs', ->
       describe 'for a rental listing', ->


### PR DESCRIPTION
DAH-744

This fixes the issue where custom preferences were not showing in the application summary section because of the way we get listing data from an application object. 

Review instructions in the ticket