### PR TITLE
Fix flashing on listing redirect [DAH-786]

### DIFF
--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -47,20 +47,21 @@
         $state.go('dahlia.listing', {timeout: true, id: ShortFormApplicationService.listing.Id})
 
     $rootScope.$on '$stateChangeStart', (e, toState, toParams, fromState, fromParams) ->
-      if (toState.name == 'dahlia.unknown-url' || (toState.name == 'dahlia.welcome' && !isFirstLoad))
+      # always start the loading overlay
+      bsLoadingOverlayService.start()
+
+      if (toState.name == 'dahlia.redirect-home' || (toState.name == 'dahlia.welcome' && !isFirstLoad))
         isFirstLoad = false
 
         # stop the state transition event from propagating
-        e.preventDefault()
+        if (toState.name != 'dahlia.redirect-home')
+          e.preventDefault()
         langString = if toParams.lang == 'en' then '' else toParams.lang
         $window.location.href = '/' + langString
 
         return
 
       isFirstLoad = false
-
-      # always start the loading overlay
-      bsLoadingOverlayService.start()
 
       # close any open modals
       ModalService.closeModal()
@@ -243,5 +244,5 @@
         if toState.name == 'dahlia.listing' && error.status == 404
           return $state.go('dahlia.listings-for-rent')
         else
-          return $state.go('dahlia.welcome')
+          return $state.go('dahlia.redirect-home')
 ]

--- a/app/assets/javascripts/config/angularRoutes.js.coffee
+++ b/app/assets/javascripts/config/angularRoutes.js.coffee
@@ -114,7 +114,7 @@
               deferred.resolve(ListingDataService.listing)
               if _.isEmpty(ListingDataService.listing)
                 # kick them out unless there's a real listing
-                return $state.go('dahlia.welcome')
+                return $state.go("dahlia.redirect-home")
               if _.includes(MAINTENANCE_LISTINGS, $stateParams.id)
                 return deferred.promise
 
@@ -613,7 +613,7 @@
                 deferred.resolve(ListingDataService.listing)
             ).catch( (response) ->
               # if no listing info is found, treat this as a 404 and redirect to homepage
-              $state.go('dahlia.welcome') unless ListingDataService.listing
+              $state.go('dahlia.redirect-home') unless ListingDataService.listing
               deferred.reject(response)
             )
             return deferred.promise
@@ -1163,14 +1163,17 @@
           $auth.validateUser()
         ]
     })
-    .state('dahlia.unknown-url', {
+    .state('dahlia.redirect-home', {
       # actual redirect occurs in onStateChangeStart in angularInitialize.js
       url: '/redirect-home'
+      views:
+        'container@':
+          templateUrl: 'pages/templates/blank.html'
     })
 
     $urlRouterProvider.otherwise(($injector, $location) ->
       $state = $injector.get('$state')
-      $state.go("dahlia.unknown-url")
+      $state.go("dahlia.redirect-home")
     ) # default to welcome screen
 
     # have to check if browser supports html5mode (http://stackoverflow.com/a/22771095)

--- a/app/assets/javascripts/listings/ListingDataService.js.coffee
+++ b/app/assets/javascripts/listings/ListingDataService.js.coffee
@@ -253,7 +253,7 @@ ListingDataService = (
       deferred.resolve(Service.listing)
       if _.isEmpty(Service.listing)
         # kick them out unless there's a real listing
-        return $state.go('dahlia.welcome')
+        return $state.go('dahlia.redirect-home')
       else if !Service.isAcceptingOnlineApplications(Service.listing)
         # kick them back to the listing
         return $state.go('dahlia.listing', {id: id})

--- a/app/assets/javascripts/pages/templates/blank.html.slim
+++ b/app/assets/javascripts/pages/templates/blank.html.slim
@@ -1,0 +1,3 @@
+// Just a big white block that takes up the whole screen.
+// Should only be used for redirects.
+div.topfocus style="position:fixed;padding:0;margin:0;top:0;left:0;z-index:104;width: 100%;height: 100%;background:rgba(255,255,255);"


### PR DESCRIPTION
DAH-786

## Why was it flashing before?
When redirecting from the listing details page to the welcome page, it was showing an empty listing details page before the redirect finished.

A few reasons why this happened:
1) Redirects to rails take longer than angular state changes, so it used to be basically instant, now it's not.
1) we were calling e.preventDefault on the state change to stop the new view from loading (because we don't want to show the angular homepage necessarily either)
2) without the new view loading, the empty listing template starts showing because even though the listing load failed, "loading" is still complete according to angular

## what was the fix
Instead of telling angular router to not render any template (which inevitably falls back to render the old template), we tell angular to render a pure white, blank template on redirects.

## Why not just make the template a blank div instead of the hacky all white box
A blank div will still show the header and footer. This looked pretty bad to me but I can remove the hacky solution if we don't like it.