### PR TITLE
Fix Google translate switching languages [DAH-787]

### DIFF
--- a/app/assets/javascripts/shared/ExternalTranslateService.js.coffee
+++ b/app/assets/javascripts/shared/ExternalTranslateService.js.coffee
@@ -47,7 +47,7 @@ ExternalTranslateService = ($q, $timeout, $window) ->
       # Default to 15 recursive calls, break the loop if it's not working.
       if iterationCount > 0
         Service.init()
-        $timeout Service.translatePageContent(iterationCount-1), 25, false
+        $timeout((() -> Service.translatePageContent(iterationCount - 1)), 50)
       else
         return false
 


### PR DESCRIPTION
[DAH-787]

The way we were calling `$timeout()` before was incorrect, it was actually calling timeout 15 times instantaneously, instead of waiting 25ms between each.

## why is the false parameter removed?
That's the `invokeApply` parameter that defaults to true: https://docs.angularjs.org/api/ng/service/$timeout

I have no idea what "model dirty checking" is but what I do know is when this is `false` the function is called immediately, not after the ms have passed.

## Why 50ms instead of 25?
No great reason, but when it was at 25 I was noticing 5-6 iterations go by, which worried me that we could by chance go all the way to 15 iterations without finding the element. Now it usually only makes it to iteration 2 or 3 before finding the element.

[DAH-787]: https://sfgovdt.jira.com/browse/DAH-787