### PR TITLE
Remove HOPE SF from document checklist DAH-790

### DIFF
--- a/app/assets/javascripts/pages/templates/document-checklist.html.slim
+++ b/app/assets/javascripts/pages/templates/document-checklist.html.slim
@@ -68,7 +68,7 @@ section.row
       hr.tall#right-to-return
       .content-section
         h3
-          | {{ 'preferences.rtr_sunnydale.title_with_hope_sf' | translate }}
+          | {{ 'preferences.rtr_sunnydale.title' | translate }}
         p
           | {{ 'preferences.rtr_sunnydale.proof_desc' | translate }}
         ul

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -1161,8 +1161,7 @@
                 "address_desc": "Your current or former address at the Sunnydale public housing development",
                 "desc": "For households in which at least one person is a former or current resident of Sunnydale public housing. Please note, these units are not subsidized, the rent will not change if your income changes. ",
                 "proof_desc": "You'll need one of the following documents showing your address at Sunnydale Housing Development.",
-                "title": "Right to Return - Sunnydale Preference",
-                "title_with_hope_sf": "Hope SF Right to Return - Sunnydale"
+                "title": "Right to Return - Sunnydale Preference"
             }
         },
         "privacy_policy": {

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -731,7 +731,10 @@
                 "paystub_home": "薪資單 (列出住家地址)",
                 "public_benefits": "公共福利記錄",
                 "school_record": "學校證明",
+                "sf_city_id": "三藩市城市身份證",
+                "sfha_lease": "三藩市房屋署 (San Francisco Housing Authority, SFHA) 租約",
                 "sfha_letter": "SFHA 地址驗證信函",
+                "sfha_residency_letter": "三藩市房屋署 (San Francisco Housing Authority, SFHA) 的住所證明信函",
                 "telephone_bill": "電話帳單 (僅限市話)",
                 "water_bill": "水費帳單"
             },
@@ -1152,6 +1155,13 @@
                 "proof_desc": "您需要提供以下任一文件，證明您的地址於 2010 年 10 月 26 日（或之後）位在 Alice Griffith 住宅區：",
                 "sfha_letter_instructions": "來自舊金山住房管理局 (San Francisco Housing Authority) 的信函，確認申請人於 2010 年 10 月 26 日（或之後）居住在 Alice Griffith 住宅區",
                 "title": "Alice Griffith 住宅區居民優先權利"
+            },
+            "rtr_sunnydale": {
+                "address": "Sunnydale 住址",
+                "address_desc": "您目前或從前在Sunnydale公共住宅建築的住址。",
+                "desc": "適用於家庭中至少有一位是曾經或現在居住在Sunnydale公共住宅的民眾。請注意，這些單位沒有提供補助。房租不會因您的收入改變而調整。",
+                "proof_desc": "您需要準備以下其中一項的文件來證明您在Sunnydale住宅建築的地址。",
+                "title": "回歸權 - Sunnydale 優先權"
             }
         },
         "privacy_policy": {


### PR DESCRIPTION
DAH-790

Mel asked to remove Hope SF from the document checklist after QAing the rest of the application. 
Since I had to delete the key in Phrase anyways, I also pulled down Sharon's latest chinese translations

From an email from Mel:
> I think Maria would prefer if it wasn’t there because last week she asked me to remove “HOPE SF” from other documents.  I think for now keep it since so much work has been done, but you have to change to “HOPE SF” because it’s an acronym.  I’m sorry if I didn’t catch it earlier. 


## Review instructions
1. Go to the document checklist page
2. See that the Right to Return - Sunnydale section no longer has "Hope SF" in the title and still looks OK