### PR TITLE
[Hotfix] Remove SRO box from 1335 Folsom Unit 308 rerental DAH-877

### DIFF
--- a/app/assets/javascripts/listings/ListingConstantsService.js.coffee
+++ b/app/assets/javascripts/listings/ListingConstantsService.js.coffee
@@ -97,6 +97,7 @@ ListingConstantsService = () ->
     'a0W0P00000F7t4uUAB': 'Merry Go Round Shared Housing'
     'a0W0P00000FIuv3UAD': '1335 Folsom Street'
     'a0W4U00000HlubxUAB': '1335 Folsom Street'
+    'a0W4U00000KGFDWUA5': '1335 Folsom Street'
   }
 
   return Service


### PR DESCRIPTION
[Slack link](https://sfinnovation.slack.com/archives/CPL7PN1AP/p1625697158063700)

DAH-877

Past PR when we made the same change: #1422 

## Review instructions
- Look at the listing on prod-test (https://dahlia-prod-test.herokuapp.com/listings/a0W4U00000KGFDWUA5?preview=true)
- Verify that the SRO box is gone, like it is in this old re-rental https://dahlia-prod-test.herokuapp.com/listings/a0W4U00000HlubxUAB?preview=true
- Check with Brooke and make sure that it looks OK for her