### PR TITLE
Fix English language prefix DAH-866

### DIFF
--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -1,5 +1,5 @@
 {
-  "config.routePrefix": "en",
+  "config.routePrefix": "",
   "footer.cityCountyOfSf": "City & County of San Francisco",
   "footer.contact": "Contact",
   "footer.dahliaDescription": "DAHLIA: San Francisco Housing Portal is a project of the <br /><a className='text-white' href='%{mohcdUrl}' target='_blank'>Mayor's Office of Housing and Community Development</a>",


### PR DESCRIPTION
Resolves [DAH-866](https://sfgovdt.jira.com/browse/DAH-866)

English language prefix was set to `en`, but we are using empty string in that case. 