### PR TITLE
Update preference title for TIDA preference DAH-862

### DIFF
--- a/app/assets/javascripts/short-form/components/preferenceComponent.js.coffee
+++ b/app/assets/javascripts/short-form/components/preferenceComponent.js.coffee
@@ -58,7 +58,7 @@ angular.module('dahlia.components')
 
       # For TIDA pref, we need to be able to show certificate
       @isTida = =>
-        @title == 'TIDA Treasure Island Resident (TIR) Preference'
+        @title == 'Treasure Island Resident (TIR) Preference'
 
       @descriptionToTranslate = =>
         if @isEmploymentDisability()

--- a/spec/javascripts/components/preference_components_spec.coffee
+++ b/spec/javascripts/components/preference_components_spec.coffee
@@ -98,7 +98,7 @@ do ->
 
       describe 'isTida', ->
         it 'should determine if the preference is employment/disability based on the title', ->
-          fakeBindings.title = 'TIDA Treasure Island Resident (TIR) Preference'
+          fakeBindings.title = 'Treasure Island Resident (TIR) Preference'
           ctrl = $componentController 'preference', locals, fakeBindings
           expect(ctrl.isTida()).toBe(true)
           fakeBindings.title = 'Something else'
@@ -117,7 +117,7 @@ do ->
           expect(ctrl.descriptionToTranslate()).toEqual('translated_description_key')
 
       it 'sets expected translation keys for TIDA', ->
-          fakeBindings.title = 'TIDA Treasure Island Resident (TIR) Preference'
+          fakeBindings.title = 'Treasure Island Resident (TIR) Preference'
           ctrl = $componentController 'preference', locals, fakeBindings
           expect(ctrl.certificateLabelKey).toContain('tida')
           expect(ctrl.certificateCaptionKey).toContain('tida')


### PR DESCRIPTION
DAH-862

Fixes release testing issue with DAH-862 where the preference title needed to be updated.

## Review instructions
1. Go to review app
2. Go to sample listing w/ TIDA preference (Test TIDA preference, `listings/a0W4U00000K9pniUAB` and fill out application
3. Make sure that when you get to the tida preference, you see the certificate field. 