### PR TITLE
Fix widths of additional info sections DAH-769

### DIFF
--- a/app/assets/javascripts/listings/components/listing/legal-section.html.slim
+++ b/app/assets/javascripts/listings/components/listing/legal-section.html.slim
@@ -7,7 +7,7 @@ accordion-heading
     svg
       use xlink:href="#i-arrow-down"
 
-.content.content-section.clearfix
+.content-section.clearfix
   .content-panel.wide
     .content-card.bg-dust ng-if="::$ctrl.parent.listing.Listing_Other_Notes"
       h4.content-card_title.t-serif


### PR DESCRIPTION
Looks like this issue came from redesigning the pricing tables in https://github.com/SFDigitalServices/sf-dahlia-pattern-library/pull/167 and https://github.com/SFDigitalServices/sf-dahlia-web/pull/1430.

Those PRs widened [the selector for content under accordion](https://github.com/SFDigitalServices/sf-dahlia-pattern-library/pull/167/files#diff-802a35df7f23c0a420c12e5687f87a8923b399e09511faf93bdf490e6a347cc2L45) to add styles that don't make sense for these sections. Simplest solution seems to be to remove the "content" class altogether because styles don't appear to change when you do.

Review instructions are in the ticket (DAH-769)

Before:
![image](https://user-images.githubusercontent.com/11825994/132931246-86719808-1218-4607-bb27-3801ff2d7f6f.png)


After:
![image](https://user-images.githubusercontent.com/11825994/132931130-fcecd9d2-fb0b-4017-bac8-d6041d439e51.png)
![image](https://user-images.githubusercontent.com/11825994/132931146-84907f68-57b4-4509-8966-d11997df6391.png)
 