### PR TITLE
features/a11y linting (DAH-891)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
     "@typescript-eslint",
     "prettier",
     "unicorn",
-    "unused-imports"
+    "unused-imports",
+    "jsx-a11y",
   ],
   extends: [
     "plugin:sfgov/recommended",
@@ -53,6 +54,7 @@ module.exports = {
     "prettier/react",
     "prettier/standard",
     "prettier",
+    "plugin:jsx-a11y/recommended",
   ],
   rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
@@ -61,13 +63,13 @@ module.exports = {
     "@typescript-eslint/naming-convention": [
       "error",
       {
-        "selector": "variable",
-        "format": ["camelCase", "PascalCase", "UPPER_CASE"]
-      }
+        selector: "variable",
+        format: ["camelCase", "PascalCase", "UPPER_CASE"],
+      },
     ],
 
     // This is already covered (and more) with naming-convention
-    "camelcase": "off",
+    camelcase: "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
 
@@ -75,10 +77,15 @@ module.exports = {
     // and vars into two separate rules, and has autofix, so here we turn on
     // both of the unused-imports rules and turn off the no-unused-vars rule.
     "unused-imports/no-unused-imports": "error",
-    "unused-imports/no-unused-vars": ["error", {
-      "vars": "all", "varsIgnorePattern": "^_",
-      "args": "after-used", "argsIgnorePattern": "^_"
-    }],
+    "unused-imports/no-unused-vars": [
+      "error",
+      {
+        vars: "all",
+        varsIgnorePattern: "^_",
+        args: "after-used",
+        argsIgnorePattern: "^_",
+      },
+    ],
     "@typescript-eslint/no-unused-vars": "off",
 
     "@typescript-eslint/no-var-requires": "off",
@@ -87,7 +94,7 @@ module.exports = {
       "error",
       {
         allowAsStatement: true,
-      }
+      },
     ],
     "@typescript-eslint/no-use-before-define": ["error"],
     "react/jsx-uses-vars": "error",
@@ -150,14 +157,12 @@ module.exports = {
     "unicorn/filename-case": [
       "error",
       {
-        "cases": {
-          "camelCase": true,
-          "pascalCase": true
+        cases: {
+          camelCase: true,
+          pascalCase: true,
         },
-        "ignore": [
-          "^react_application.tsx"
-        ]
-      }
+        ignore: ["^react_application.tsx"],
+      },
     ],
     "unicorn/prevent-abbreviations": "off",
     "import/order": [
@@ -180,15 +185,15 @@ module.exports = {
       },
     ],
   },
-  "overrides": [
+  overrides: [
     {
-      "files": [ "cypress/integration/*e2e.ts", "cypress/integration/*e2e.js" ],
-      "rules": {
+      files: ["cypress/integration/*e2e.ts", "cypress/integration/*e2e.js"],
+      rules: {
         // e2e files use chai-expect, not jest-expect, linter gets confused so we
         // turn off jest linting for these files.
         "jest/valid-expect": 0,
-      }
-    }
+      },
+    },
   ],
   ignorePatterns: [
     "app/assets",

--- a/app/javascript/layouts/withAppSetup.tsx
+++ b/app/javascript/layouts/withAppSetup.tsx
@@ -1,5 +1,8 @@
 import React from "react"
 
+import axe from "@axe-core/react"
+import ReactDOM from "react-dom"
+
 import IdleTimeout from "../authentication/components/IdleTimeout"
 import UserProvider from "../authentication/context/UserProvider"
 import { ConfigProvider } from "../lib/ConfigContext"
@@ -14,15 +17,20 @@ interface ObjectWithAssets {
 const withAppSetup = <P extends ObjectWithAssets>(
   Component: React.ComponentType<P>,
   useFormTimeout?: boolean
-) => (props: P) => (
-  <NavigationProvider>
-    <ConfigProvider assetPaths={props.assetPaths}>
-      <UserProvider>
-        <IdleTimeout onTimeout={() => console.log("Logout")} useFormTimeout={useFormTimeout} />
-        <Component {...props} />
-      </UserProvider>
-    </ConfigProvider>
-  </NavigationProvider>
-)
+) => (props: P) => {
+  if (process.env.NODE_ENV !== "production") {
+    void axe(React, ReactDOM, 1000)
+  }
+  return (
+    <NavigationProvider>
+      <ConfigProvider assetPaths={props.assetPaths}>
+        <UserProvider>
+          <IdleTimeout onTimeout={() => console.log("Logout")} useFormTimeout={useFormTimeout} />
+          <Component {...props} />
+        </UserProvider>
+      </ConfigProvider>
+    </NavigationProvider>
+  )
+}
 
 export default withAppSetup

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "DAHLIA is the affordable housing portal for the City and County of San Francisco.",
   "license": "GPL-3.0",
   "dependencies": {
+    "@axe-core/react": "^4.2.2",
     "@babel/plugin-transform-modules-commonjs": "^7.12.13",
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
@@ -33,7 +34,6 @@
     "webpacker-react": "^0.3.2"
   },
   "devDependencies": {
-    "@axe-core/react": "^4.2.2",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "webpacker-react": "^0.3.2"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.2.2",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.2",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,14 @@
     ora "5.3.0"
     rxjs "6.6.3"
 
+"@axe-core/react@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@axe-core/react/-/react-4.2.2.tgz#a595df8150cf9b8c5758a7b76c58dae418458d66"
+  integrity sha512-qmh/1DGFrN9G7NqTNARA4aT1k37mUfyb5syWkEQN7iqo77VoO2GCsvVyfLystr8uwJYYihW17+Lgl0UTiz8q2Q==
+  dependencies:
+    axe-core "^4.2.3"
+    requestidlecallback "^0.3.0"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"
@@ -3442,7 +3450,7 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.0.2:
+axe-core@^4.0.2, axe-core@^4.2.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
   integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
@@ -13270,6 +13278,11 @@ request@^2.87.0, request@^2.88.0, request@^2.88.2:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,6 +3345,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz"
@@ -3437,12 +3442,22 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axe-core@^4.0.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
+  integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
+
 axios@0.21.1, axios@^0.21.0, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
+
+axobject-query@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
+  integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -5309,6 +5324,11 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
+damerau-levenshtein@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz#64368003512a1a6992593741a09a9d31a836f55d"
+  integrity sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
@@ -5829,6 +5849,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.0.0:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz"
@@ -6200,6 +6225,23 @@ eslint-plugin-jest@^24.3.6:
   integrity sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
+
+eslint-plugin-jsx-a11y@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd"
+  integrity sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    aria-query "^4.2.2"
+    array-includes "^3.1.1"
+    ast-types-flow "^0.0.7"
+    axe-core "^4.0.2"
+    axobject-query "^2.2.0"
+    damerau-levenshtein "^1.0.6"
+    emoji-regex "^9.0.0"
+    has "^1.0.3"
+    jsx-ast-utils "^3.1.0"
+    language-tags "^1.0.5"
 
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
@@ -9360,7 +9402,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-"jsx-ast-utils@^2.4.1 || ^3.0.0":
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz"
   integrity sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
@@ -9448,6 +9490,18 @@ klona@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
+language-subtag-registry@~0.3.2:
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz#04ac218bea46f04cb039084602c6da9e788dd45a"
+  integrity sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
+  dependencies:
+    language-subtag-registry "~0.3.2"
 
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR targets [this issue](https://sfgovdt.jira.com/browse/DAH-891).

It adds `eslint-plugin-jsx-a11y` for static linting which now runs on `yarn lint`. This one came up with no errors. I tested to make sure it was actually working by adding a header with no content (`<h1 />`) to one of the react files, as this throws an error.

It also adds `@axe-core/react` for dynamic "linting" which comes in the form of console errors when you run the app. It only runs on React pages. You can see there are some existing errors when you open the home page and directory page in React.