### PR TITLE
Fix missing feedback url on angular blue bar DAH-946

### DIFF
--- a/app/assets/javascripts/shared/templates/version.html.slim
+++ b/app/assets/javascripts/shared/templates/version.html.slim
@@ -1,4 +1,4 @@
 .version-bar.bar.bg-primary
   .row
     .medium-12.columns
-      p.text-right.t-small.c-white.no-margin translate="nav.get_feedback" translate-value-research-url="{{researchUrl}}"
+      p.text-right.t-small.c-white.no-margin translate="nav.get_feedback" translate-value-research-url="{{researchUrl}}" translate-value-feedback-url="{{feedbackUrl}}"


### PR DESCRIPTION
DAH-946

Found during our bug bash, the feedback url was missing from the bar at the top of the angular page so it was just linking back to the homepage. 
![image](https://user-images.githubusercontent.com/11825994/133863389-94ba9ccb-79df-4207-91be-82ece7da53fa.png)
