### PR TITLE
feat: uptake latest components DAH-1006

### DIFF
--- a/app/javascript/layouts/Layout.tsx
+++ b/app/javascript/layouts/Layout.tsx
@@ -157,7 +157,7 @@ const Layout = (props: LayoutProps) => {
           flattenSubMenus={true}
           imageOnly={true}
           mobileText={true}
-          logoWidth={"base"}
+          logoWidth={"medium"}
           menuLinks={getMenuLinks(!!profile, signOut)}
         />
 

--- a/app/javascript/layouts/Layout.tsx
+++ b/app/javascript/layouts/Layout.tsx
@@ -157,7 +157,7 @@ const Layout = (props: LayoutProps) => {
           flattenSubMenus={true}
           imageOnly={true}
           mobileText={true}
-          logoWidth={"medium"}
+          logoWidth={"base"}
           menuLinks={getMenuLinks(!!profile, signOut)}
         />
 

--- a/app/javascript/pages/HomePage.tsx
+++ b/app/javascript/pages/HomePage.tsx
@@ -38,7 +38,7 @@ const HomePage = (_props: HomePageProps) => {
         <ActionBlock
           header={t("welcome.newListingEmailAlert")}
           actions={[
-            <Link className="button" key="action-1" external href={listingsAlertUrl}>
+            <Link className="button" key="action-1" external={true} href={listingsAlertUrl}>
               {t("welcome.signUpToday")}
             </Link>,
           ]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17128,5 +17128,9 @@ zen-observable-ts@^1.0.0:
 
 zen-observable@0.8.15:
   version "0.8.15"
+<<<<<<< HEAD
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+=======
+  resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz"
+>>>>>>> feat: uptake latest components
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -17128,9 +17128,5 @@ zen-observable-ts@^1.0.0:
 
 zen-observable@0.8.15:
   version "0.8.15"
-<<<<<<< HEAD
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
-=======
   resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz"
->>>>>>> feat: uptake latest components
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Uptakes the latest components which includes the SiteHeader and ListingCard A11Y updates

I'm not sure of a great solution for maintaining the react query without creating another list of all the URLs we do want to be react-ified, so I haven't done that here