### PR TITLE
DAH-835 eligibility data v2

### DIFF
--- a/app/javascript/api/listingsApiService.ts
+++ b/app/javascript/api/listingsApiService.ts
@@ -3,8 +3,48 @@ import RailsRentalListing from "./types/rails/listings/RailsRentalListing"
 
 type ListingsResponse = { listings: RailsRentalListing[] }
 
-export const getRentalListings = async (): Promise<RailsRentalListing[]> =>
-  get<ListingsResponse>("/api/v1/listings.json?type=rental").then(({ data }) => data.listings)
+export type EligibilityFilters = {
+  household_size: string
+  income_timeframe: string
+  income_total: number
+  include_children_under_6: boolean
+  children_under_6: string
+  type: string
+}
+
+export type QueryParams = { [key: string]: string | boolean | number }
+
+const formatQueryString = (params: QueryParams) => {
+  return Object.keys(params)
+    .map((key) => {
+      return encodeURIComponent(key) + "=" + encodeURIComponent(params[key])
+    })
+    .join("&")
+}
+
+export const getRentalListings = async (
+  filters?: EligibilityFilters
+): Promise<RailsRentalListing[]> => {
+  const getIncomeLevel = () => {
+    return filters.income_timeframe === "per_month"
+      ? filters.income_total * 12
+      : filters.income_total
+  }
+
+  const appliedFilters = {
+    householdsize: filters.household_size ?? "",
+    incomelevel: getIncomeLevel() ?? "",
+    includeChildrenUnder6: filters.include_children_under_6 ?? false,
+    childrenUnder6: filters.children_under_6 ?? "",
+    listingsType: "rental",
+  }
+
+  return Object.keys(filters).length > 0
+    ? get<ListingsResponse>(
+        `/api/v1/listings/eligibility.json?${formatQueryString(appliedFilters)}`
+      ).then(({ data }) => data.listings)
+    : get<ListingsResponse>("/api/v1/listings.json?type=rental").then(({ data }) => data.listings)
+}
 
 export const getSaleListings = async (): Promise<RailsRentalListing[]> =>
   get<ListingsResponse>("/api/v1/listings.json?type=ownership").then(({ data }) => data.listings)

--- a/app/javascript/api/types/rails/listings/BaseRailsListing.d.ts
+++ b/app/javascript/api/types/rails/listings/BaseRailsListing.d.ts
@@ -23,6 +23,7 @@ type BaseRailsListing = {
   Lottery_Status: string
   RecordTypeId: string
   imageURL?: string
+  Does_Match?: boolean
 }
 
 export default BaseRailsListing


### PR DESCRIPTION
[DAH-835](https://sfgovdt.jira.com/browse/DAH-835)

Fetches data on the React rental directory page according to what the Angular eligibility calculator sets in localStorage

I've been testing this by having the react flavor and the angular flavor both open at the same time, and from angular setting the eligibility to a number of different settings, and just refreshing the react page. The open listings section should match, but we still have other visual pieces once we have these filters.
