### PR TITLE
Add missing external prop to external links DAH-839

### DIFF
--- a/app/javascript/layouts/Layout.tsx
+++ b/app/javascript/layouts/Layout.tsx
@@ -199,10 +199,11 @@ const Layout = (props: LayoutProps) => {
             className="text-gray-500"
             href="https://airtable.com/shrw64DubWTQfRkdo"
             target="_blank"
+            external={true}
           >
             {t("footer.giveFeedback")}
           </Link>
-          <Link className="text-gray-500" href="mailto:sfhousinginfo@sfgov.org">
+          <Link className="text-gray-500" external={true} href="mailto:sfhousinginfo@sfgov.org">
             {t("footer.contact")}
           </Link>
           <Link className="text-gray-500" href={getDisclaimerPath()}>

--- a/app/javascript/pages/ListingDirectory/DirectoryPage.tsx
+++ b/app/javascript/pages/ListingDirectory/DirectoryPage.tsx
@@ -362,7 +362,7 @@ export const DirectoryPage = (props: DirectoryProps) => {
           background="primary-lighter"
           icon={<Icon size="3xl" symbol="mail" />}
           actions={[
-            <Link className="button" key="action-1" href={listingsAlertUrl}>
+            <Link className="button" key="action-1" external={true} href={listingsAlertUrl}>
               {t("welcome.signUpToday")}
             </Link>,
           ]}


### PR DESCRIPTION
DAH-839

This PR is a release bug fix for some react links that were missing the `external={true}` prop after it was added on bloom