### PR TITLE
Link sale directory action block to correct links DAH-839

### DIFF
--- a/app/javascript/pages/ListingDirectory/DirectoryPage.tsx
+++ b/app/javascript/pages/ListingDirectory/DirectoryPage.tsx
@@ -341,10 +341,20 @@ export const DirectoryPage = (props: DirectoryProps) => {
                       background="primary-darker"
                       layout={ActionBlockLayout.inline}
                       actions={[
-                        <Link className="button" key="action-1" href={getAdditionalResourcesPath()}>
+                        <Link
+                          className="button"
+                          key="action-1"
+                          external
+                          href={"https://sfmohcd.org/current-bmr-homeownership-listings"}
+                        >
                           {t("saleDirectory.callout.firstComeFirstServed")}
                         </Link>,
-                        <Link className="button" key="action-2" href={getAdditionalResourcesPath()}>
+                        <Link
+                          className="button"
+                          key="action-2"
+                          external
+                          href={"https://sfmohcd.org/current-listings-city-second-program"}
+                        >
                           {t("saleDirectory.callout.citySecondLoan")}
                         </Link>,
                       ]}


### PR DESCRIPTION
Fixes bug in DAH-839 where sale directory action block wasn't linking to the right pages
![image](https://user-images.githubusercontent.com/11825994/146060470-4e45defb-6fd2-4864-ad6f-93161be502ec.png)

To test, compare the links for react sale directory page to the links on the angular sale directory