### PR TITLE
Remove "suggested address" from address verification page DAH-1025

### DIFF
--- a/app/assets/javascripts/short-form/directives/address-verification-form.html.slim
+++ b/app/assets/javascripts/short-form/directives/address-verification-form.html.slim
@@ -1,8 +1,6 @@
 .form
   .app-inner.inset
     .form-group.margin-bottom--2x ng-class="{ error: inputInvalid('confirmed_home_address')}"
-      label.form-label.caps
-        | {{'label.suggested_address' | translate}}:
       .form-item.has-edit
         .radio-group.left role="radiogroup" aria-label="{{'label.suggested_address' | translate}}"
           radio-block-item value='Yes' user='user' name='confirmed_home_address' ng-required='true' aria-describedby="confirmed_home_address_error"


### PR DESCRIPTION
DAH-1025

Removes "suggested address:" from the verified address page per Yindi's request.

Doesn't remove it based on whether the address was found or not because we don't have access to that info in the scope of the page. 
![image](https://user-images.githubusercontent.com/11825994/146083310-7cbd8a86-3295-43f7-8422-a1b02534cf0b.png)
