### PR TITLE
Add back listing-results anchor tag DAH-840

### DIFF
--- a/app/javascript/pages/ListingDirectory/GenericDirectory.tsx
+++ b/app/javascript/pages/ListingDirectory/GenericDirectory.tsx
@@ -66,10 +66,10 @@ export const GenericDirectory = (props: RentalDirectoryProps) => {
   return (
     <LoadingOverlay isLoading={loading}>
       <div>
-        <div>
-          {!loading && (
-            <>
-              {props.getPageHeader(filters, setFilters, match)}
+        {!loading && (
+          <>
+            {props.getPageHeader(filters, setFilters, match)}
+            <div id="listing-results">
               {openListingsView(
                 listings.open,
                 props.directoryType,
@@ -89,9 +89,9 @@ export const GenericDirectory = (props: RentalDirectoryProps) => {
                 )}
               {upcomingLotteriesView(listings.upcoming, props.directoryType, props.getSummaryTable)}
               {lotteryResultsView(listings.results, props.directoryType, props.getSummaryTable)}
-            </>
-          )}
-        </div>
+            </div>
+          </>
+        )}
         {signUpActionBlock(listingsAlertUrl)}
       </div>
     </LoadingOverlay>


### PR DESCRIPTION
Fixes a bug caused by merge issues with DAH-840

To QA:
This "See the listings" button should scroll down to the start of the listings, both on desktop and mobile
![image](https://user-images.githubusercontent.com/11825994/150220902-4d17da42-9706-417e-87ec-1acc09c328ab.png)
