### PR TITLE
Try specifying node in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "engines": {
     "npm": "5.3.0",
     "yarn": "1.x.x",
-    "node" : "14.7.x"
+    "node" : "14.x.x"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
   },
   "engines": {
     "npm": "5.3.0",
-    "yarn": "1.x.x"
+    "yarn": "1.x.x",
+    "node" : "14.7.x"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
Heroku just started defaulting to Node 16.x ([notice of that change](https://devcenter.heroku.com/changelog-items/2349)).

We had to update to specify our node version in the package.json. 