### PR TITLE
Add dependabot yml, to ignore dev dependency updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -496,4 +496,4 @@ RUBY VERSION
    ruby 2.5.9p229
 
 BUNDLED WITH
-   2.2.31
+   2.2.32

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      -dependency-type: "production"


### PR DESCRIPTION
Pulled from [this documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow)

Right now dependabot automatically creates PRs (and raises other issues) for packages that are in our devDependencies section that are not deployed to production. 

I think we should seriously consider tryin to turn that off because they pose a much lower threat. 

This was a bigger rabbit hole than I expected...so I might just leave this as is for now for something for @christine-sfg and others to consider when I'm gone. 