### PR TITLE
Translate units in habitat listing dir, fix income range styling

### DIFF
--- a/app/assets/javascripts/listings/components/listing/habitat-property-hero.html.slim
+++ b/app/assets/javascripts/listings/components/listing/habitat-property-hero.html.slim
@@ -37,6 +37,6 @@ ul.bullet-list.margin-bottom
   li.margin-bottom-none translate="listings.income_exceptions.nontaxable" translate-value-tooltip="{{'listings.income_exceptions.nontaxable_tooltip' | translate }}" translate-compile="true"
 p.margin-bottom-none
   | {{'listings.habitat.income_range.p4' | translate}}
-ul.inline-list.padding-bottom
+ul.inline-list.habitat-income-list.padding-bottom
   li ng-repeat="range in $ctrl.translatedIncomeRanges()"
     | {{range}}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,3 +33,7 @@ body .goog-te-banner-frame {
   color: inherit;
   font-weight: 700;
 }
+
+.habitat-income-list li {
+  float: none;
+}

--- a/app/javascript/pages/ListingDirectory/HabitatForHumanity.tsx
+++ b/app/javascript/pages/ListingDirectory/HabitatForHumanity.tsx
@@ -29,7 +29,7 @@ export const getHabitatContent = (listing, stackedDataFxn) => {
       <div className={"font-alt-sans font-semibold text-base mb-2 text-gray-900"}>
         {t("listings.availableUnits")}
       </div>
-      {getHeader("Units")}
+      {getHeader(t("t.units"))}
       {stackedData.map((row) =>
         getHabitatContentRow(
           `${row.unitType.cellText}:`,

--- a/public/ie-deprecated.html
+++ b/public/ie-deprecated.html
@@ -82,7 +82,6 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      height: 100%;
     }
 
     .message-container {


### PR DESCRIPTION
DAH-1064

This fixes issues Yindi found while testing:
- Unit header not translated for habtiat
- Income ranges going onto two columns in habitat listing in chinese
- Reduced the gap on the ie11 page