### PR TITLE
fix: add optional on general summary

### DIFF
--- a/app/javascript/pages/listings/for-rent.tsx
+++ b/app/javascript/pages/listings/for-rent.tsx
@@ -35,7 +35,7 @@ import {
 
 const getForRentSummaryTable = (listing: RailsRentalListing) =>
   listing.unitSummaries.general
-    .filter((summary) => !!summary.unitType)
+    ?.filter((summary) => !!summary.unitType)
     .map((summary) => ({
       unitType: {
         cellText: defaultIfNotTranslated(


### PR DESCRIPTION
Allows for a listing with a null general unit summary to still render. It will just not render a unit table at all under the ListingCard.