### PR TITLE
fix: check for general summary, otherwise use reserved

### DIFF
--- a/app/javascript/pages/listings/for-rent.tsx
+++ b/app/javascript/pages/listings/for-rent.tsx
@@ -33,8 +33,9 @@ import {
   eligibilityHeader,
 } from "../../modules/listings/DirectoryHelpers"
 
-const getForRentSummaryTable = (listing: RailsRentalListing) =>
-  listing.unitSummaries.general
+const getForRentSummaryTable = (listing: RailsRentalListing) => {
+  const summary = listing.unitSummaries.general ?? listing.unitSummaries.reserved ?? []
+  return summary
     .filter((summary) => !!summary.unitType)
     .map((summary) => ({
       unitType: {
@@ -55,6 +56,7 @@ const getForRentSummaryTable = (listing: RailsRentalListing) =>
       },
       colFour: { cellText: getRentRangeString(summary), cellSubText: getRentSubText(summary) },
     }))
+}
 
 const getRentalHeader = (
   filters: EligibilityFilters,

--- a/app/javascript/pages/listings/for-rent.tsx
+++ b/app/javascript/pages/listings/for-rent.tsx
@@ -34,7 +34,9 @@ import {
 } from "../../modules/listings/DirectoryHelpers"
 
 const getForRentSummaryTable = (listing: RailsRentalListing) => {
-  const summary = listing.unitSummaries.general ?? listing.unitSummaries.reserved ?? []
+  const summary = listing.unitSummaries.general ?? listing.unitSummaries.reserved
+  if (!summary) return null
+
   return summary
     .filter((summary) => !!summary.unitType)
     .map((summary) => ({


### PR DESCRIPTION
For the unit summary table, first use the general unit summary, then the reserved unit summary, then show no table.