### PR TITLE
hotfix: check if general summary exists, otherwise use reserved

### DIFF
--- a/app/javascript/pages/RentDirectory.tsx
+++ b/app/javascript/pages/RentDirectory.tsx
@@ -33,8 +33,11 @@ import {
   eligibilityHeader,
 } from "./ListingDirectory/DirectoryHelpers"
 
-const getForRentSummaryTable = (listing: RailsRentalListing) =>
-  listing.unitSummaries.general
+const getForRentSummaryTable = (listing: RailsRentalListing) => {
+  const summary = listing.unitSummaries.general ?? listing.unitSummaries.reserved
+  if (!summary) return null
+
+  return summary
     .filter((summary) => !!summary.unitType)
     .map((summary) => ({
       unitType: {
@@ -55,6 +58,7 @@ const getForRentSummaryTable = (listing: RailsRentalListing) =>
       },
       colFour: { cellText: getRentRangeString(summary), cellSubText: getRentSubText(summary) },
     }))
+}
 
 const getRentalHeader = (
   filters: EligibilityFilters,


### PR DESCRIPTION
[DAH-1102](https://sfgovdt.jira.com/browse/DAH-1102)

For the unit summary table, first use the general unit summary, then the reserved unit summary, then show no table.