### PR TITLE
DAH-1101 Prevent users with South SF addresses from getting NRHP preference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,11 @@ public/assets/
 public/packs
 public/packs-test
 
-# VS Code
+# IDE
 TAGS
 .vscode/*
 !.vscode-default/*
+.idea/*
 
 # Byebug command history
 .byebug_history

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To run E2E tests:
 - Installation (needs to be run once): `./node_modules/protractor/bin/webdriver-manager update --versions.chrome 2.41 --versions.standalone 3.141.59` to get the selenium webdriver installed
 - On one tab have your Rails server running: `rails s`
 - On another tab, run `yarn protractor` to run the selenium webdriver and protractor tests. A Chrome browser will pop up and you will see it step through each of the tests.
+- If you get errors starting selenium, make sure you have [java](https://java.com/en/download/) installed
 
 Note: These tests will run on [CircleCi](https://app.circleci.com/pipelines/github/SFDigitalServices/sf-dahlia-web) as well for every review app and QA deploy.
 

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -514,8 +514,8 @@ ShortFormApplicationService = (
   Service.liveInTheNeighborhoodMembers = ->
     # used by both NRHP / ADHP
     Service.fullHousehold().filter (member) ->
-      # find all household members that match NRHP
-      member.preferenceAddressMatch == 'Matched'
+      # find all household members that match NRHP and only for sf to avoid south san francisco
+      member.preferenceAddressMatch == 'Matched' && member.home_address && _.lowerCase(member.home_address.city) == 'san francisco'
 
   Service.fullHousehold = ->
     # return an array with the Household and Primary Applicant

--- a/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationService.js.coffee
@@ -515,7 +515,9 @@ ShortFormApplicationService = (
     # used by both NRHP / ADHP
     Service.fullHousehold().filter (member) ->
       # find all household members that match NRHP and only for sf to avoid south san francisco
-      member.preferenceAddressMatch == 'Matched' && member.home_address && _.lowerCase(member.home_address.city) == 'san francisco'
+      member.preferenceAddressMatch == 'Matched' &&
+        ((member.hasSameAddressAsApplicant == 'Yes' && _.lowerCase(Service.applicant.home_address.city) == 'san francisco') ||
+        (member.home_address && _.lowerCase(member.home_address.city) == 'san francisco'))
 
   Service.fullHousehold = ->
     # return an array with the Household and Primary Applicant


### PR DESCRIPTION
DAH-1101

-Explicitly check for household members to have city 'San Francisco' to avoid false positives for NRHP preference
-Misc housekeeping/docs 
