### PR TITLE
DAH-1077 give time for invalid listing id lookup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,8 @@ jobs:
       - setup
       - start-server
       - run: yarn test:e2e
+      - store_test_results:
+          path: cypress/results
   e2e-legacy:
     <<: *defaults
     parallelism: 4

--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,9 @@
   "defaultCommandTimeout": 100000,
   "projectId": "dahlia-housing-portal",
   "pageLoadTimeout": 100000,
+  "reporterOptions": {
+    "mochaFile": "cypress/results/tests-[hash].xml",
+    "toConsole": true
+  },
   "video": false
 }

--- a/spec/e2e/features/listings/listing.feature
+++ b/spec/e2e/features/listings/listing.feature
@@ -1,24 +1,26 @@
 Feature: Listings
-    As a web user
-    I should be able to view a listing
+  As a web user
+  I should be able to view a listing
 
-    Scenario: Attempting to go to a listing page using an invalid ID
-      Given I try to go to a listing page with an invalid ID
-      Then I should be redirected to the welcome page
+  Scenario: Attempting to go to a listing page using an invalid ID
+    Given I try to go to a listing page with an invalid ID
+    #give time for the lookup failure and redirect
+    And I wait "5" seconds
+    Then I should be redirected to the welcome page
 
-    Scenario: Viewing and interacting with a listing page
-      Given I go to the "Test Listing" listing page
-      And I click the Download Application button
-      Then I should see at least one paper application download link
+  Scenario: Viewing and interacting with a listing page
+    Given I go to the "Test Listing" listing page
+    And I click the Download Application button
+    Then I should see at least one paper application download link
 
-    Scenario: Going to the Ownership listings page from the welcome page
-      Given I go to the welcome page
-      Then I should see the Buy link
-      And I click the Buy link
-      Then I should be on the Ownership listings page
+  Scenario: Going to the Ownership listings page from the welcome page
+    Given I go to the welcome page
+    Then I should see the Buy link
+    And I click the Buy link
+    Then I should be on the Ownership listings page
 
-    Scenario: Going to the Rental listings page from the welcome page
-      Given I go to the welcome page
-      Then I should see the Rent link
-      And I click the Rent link
-      Then I should be on the Rental listings page
+  Scenario: Going to the Rental listings page from the welcome page
+    Given I go to the welcome page
+    Then I should see the Rent link
+    And I click the Rent link
+    Then I should be on the Rental listings page

--- a/spec/e2e/features/listings/listing.feature
+++ b/spec/e2e/features/listings/listing.feature
@@ -4,8 +4,6 @@ Feature: Listings
 
   Scenario: Attempting to go to a listing page using an invalid ID
     Given I try to go to a listing page with an invalid ID
-    #give time for the lookup failure and redirect
-    And I wait "5" seconds
     Then I should be redirected to the welcome page
 
   Scenario: Viewing and interacting with a listing page

--- a/spec/e2e/step_definitions/listing_steps.coffee
+++ b/spec/e2e/step_definitions/listing_steps.coffee
@@ -1,4 +1,5 @@
 World = require('../world.coffee')
+EC = protractor.ExpectedConditions
 Utils = require('../utils')
 { Given, When, Then, setWorldConstructor } = require('cucumber')
 
@@ -40,7 +41,7 @@ When 'I click the Rent link', ->
 
 Then 'I should be redirected to the welcome page', ->
   welcomeComponent = element(By.tagName('welcome-component'))
-  @expect(welcomeComponent.isPresent()).to.eventually.equal(true)
+  browser.wait(EC.presenceOf(welcomeComponent), 5000)
 
 Then 'I should see available units', ->
   propertyCard = element(By.tagName('property-card'))


### PR DESCRIPTION
- The "Attempting to go to a listing page using an invalid ID" test has been flaky. Looks like it can sometimes take ~1 sec for the salesforce lookup and miss, along with the redirects so adding some wait time before checking for the welcome component
- Setup test stats in circleci for new e2e tests 