### PR TITLE
DAH-1113 Support all statuses for the application sidebar component

### DIFF
--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -21,6 +21,8 @@
   "languages.es": "Español",
   "languages.tl": "Filipino",
   "languages.zh": "中文",
+  "listingDetails.applicationDeadline.open": "Application Deadline %{date} at %{time}",
+  "listingDetails.applicationDeadline.closed": "Applications Closed %{date} at %{time}",
   "listings.additional.hide": "Hide additional listings",
   "listings.additional.show": "Show additional listings",
   "listings.additional.subtitle": "We know you may have options about how many people will live with you. Here are listings for other household sizes and income levels.",

--- a/app/javascript/pages/listings/listing-detail.tsx
+++ b/app/javascript/pages/listings/listing-detail.tsx
@@ -29,8 +29,8 @@ import { getListing } from "../../api/listingApiService"
 import { getReservedCommunityType } from "../../util/languageUtil"
 import { getListingAddressString, RailsListing } from "../../modules/listings/SharedHelpers"
 import { ListingEvent } from "../../api/types/rails/listings/BaseRailsListing"
+import bloomTheme from "../../../../tailwind.config"
 
-const alertIconColor = "#E31C3D"
 const ListingDetail = () => {
   const alertClasses = "flex-grow mt-6 max-w-6xl w-full"
   const { router } = useContext(NavigationContext)
@@ -112,7 +112,7 @@ const ListingDetail = () => {
                   time: dayjs(listing.Application_Due_Date).format("h:mm A"),
                 }
               )}
-              iconColor={!isApplicationOpen && alertIconColor}
+              iconColor={!isApplicationOpen && bloomTheme.theme.colors.red["700"]}
               status={isApplicationOpen ? ApplicationStatusType.Open : ApplicationStatusType.Closed}
             />
 

--- a/app/javascript/pages/listings/listing-detail.tsx
+++ b/app/javascript/pages/listings/listing-detail.tsx
@@ -1,37 +1,36 @@
-import React, { useContext, useState, useEffect } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import dayjs from "dayjs"
 import {
-  SiteAlert,
-  ListingDetails,
-  ListingDetailItem,
-  ImageCard,
-  Message,
-  ApplicationStatus,
-  Waitlist,
-  EventSection,
-  ListSection,
-  PreferencesList,
-  InfoCard,
-  ExpandableText,
-  Description,
   AdditionalFees,
-  MarkdownSection,
-  NavigationContext,
-  LoadingOverlay,
+  ApplicationStatus,
+  ApplicationStatusType,
   ContentAccordion,
+  Description,
+  EventSection,
+  ExpandableText,
+  ImageCard,
+  InfoCard,
+  ListingDetailItem,
+  ListingDetails,
+  ListSection,
+  LoadingOverlay,
+  MarkdownSection,
+  Message,
+  NavigationContext,
+  PreferencesList,
+  SiteAlert,
+  t,
+  Waitlist,
 } from "@bloom-housing/ui-components"
 
 import Layout from "../../layouts/Layout"
 import withAppSetup from "../../layouts/withAppSetup"
 import { getListing } from "../../api/listingApiService"
 import { getReservedCommunityType } from "../../util/languageUtil"
-import {
-  RailsListing,
-  getListingImageCardStatuses,
-  getListingAddressString,
-} from "../../modules/listings/SharedHelpers"
+import { getListingAddressString, RailsListing } from "../../modules/listings/SharedHelpers"
 import { ListingEvent } from "../../api/types/rails/listings/BaseRailsListing"
 
+const alertIconColor = "#E31C3D"
 const ListingDetail = () => {
   const alertClasses = "flex-grow mt-6 max-w-6xl w-full"
   const { router } = useContext(NavigationContext)
@@ -84,13 +83,14 @@ const ListingDetail = () => {
 
   useEffect(() => {
     void getListing(router.pathname.split("/")[2]).then((listing: RailsListing) => {
-      console.log("response", listing)
       setListing(listing)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const getSidebar = () => {
+    const isApplicationOpen = new Date(listing.Application_Due_Date) > new Date()
+
     return (
       <ListingDetailItem
         imageAlt={""}
@@ -102,7 +102,19 @@ const ListingDetail = () => {
       >
         <aside className="w-full static md:absolute md:right-0 md:w-1/3 md:top-0 sm:w-2/3 md:ml-2 h-full md:border border-solid bg-white">
           <div className="hidden md:block">
-            <ApplicationStatus {...getListingImageCardStatuses(listing, false)[0]} />
+            <ApplicationStatus
+              content={t(
+                isApplicationOpen
+                  ? "listingDetails.applicationDeadline.open"
+                  : "listingDetails.applicationDeadline.closed",
+                {
+                  date: dayjs(listing.Application_Due_Date).format("MMM DD, YYYY"),
+                  time: dayjs(listing.Application_Due_Date).format("h:mm A"),
+                }
+              )}
+              iconColor={!isApplicationOpen && alertIconColor}
+              status={isApplicationOpen ? ApplicationStatusType.Open : ApplicationStatusType.Closed}
+            />
 
             {dayjs(listing.Application_Due_Date) > dayjs() && (
               <>


### PR DESCRIPTION
DAH-1113

Supporting two states for the application deadline component on the details page side bar - open (before application deadline) and closed (after application deadline). This should be an improvement over the existing angular component which has hardcoded the english 'at' into the date time

![image](https://user-images.githubusercontent.com/98352600/159814181-cd973db2-af65-41e0-aac2-e88d21469e8f.png)

![image](https://user-images.githubusercontent.com/98352600/159814210-192135c1-905d-4854-8335-f89108997074.png)

