### PR TITLE
DAH-1126 fix link text

### DIFF
--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -451,7 +451,7 @@
       "accessible_only_anyone": "At least one member of your household must need an accessible unit.",
       "address": "Please enter an address",
       "address_validation": {
-        "not_found": "This address was not found. Please check the house number, street, and city entered. PO Boxes are not allowed.<br><br>If the address you entered is correct, email us at <a href={{mailInfo}} target=\"_blank\">email us at lotteryappeals@sfgov.org</a> for help.",
+        "not_found": "This address was not found. Please check the house number, street, and city entered. PO Boxes are not allowed.<br><br>If the address you entered is correct, <a href={{mailInfo}} target=\"_blank\">email us at lotteryappeals@sfgov.org</a> for help.",
         "not_found_subject": "Unable to enter my address in DAHLIA application",
         "not_found_body": "Dear MOHCD,\n\nI am unable to complete my application for {{listing_name}}. My address is {{home_address}} and the form is telling me there is an error. Please advise me on what to do next.\n\nThank you,\n{{first_name}} {{last_name}}\n{{email}}\n{{phone_number}}"
       },


### PR DESCRIPTION
DAH-1126

Quick fix for the link text. It had 'email us at' twice. Design would like it to be part of the link.

![image](https://user-images.githubusercontent.com/98352600/164063663-c11f284d-b9c3-4c54-9580-30af0e962e18.png)
