### PR TITLE
DAH-1156 Prevent overflow of footer links

### DIFF
--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsApplicationDate.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsApplicationDate.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`ListingDetailsApplicationDate displays Applications Closed when listing
     data-test-id={null}
   >
     <svg
-      fill="#E41D3D"
+      fill="var(--bloom-color-red-700)"
       viewBox="0 0 32 32"
     >
       <path

--- a/app/javascript/components/base.scss
+++ b/app/javascript/components/base.scss
@@ -57,7 +57,6 @@ $text: $black;
 $border: 2px solid #ccc; // not sure how this gets used -JW
 $radius-large: 8px;
 $radius: 4px;
-$desktop: $tailwind-screens-md;
 $speed: 86ms;
 $easing: ease-out;
 
@@ -87,6 +86,12 @@ $colors: (
 @import "@bloom-housing/ui-components/src/global/tables.scss";
 @import "@bloom-housing/ui-components/src/global/homepage.scss";
 @import "@bloom-housing/ui-components/src/global/print.scss";
+
+@import "@bloom-housing/ui-components/src/global/tokens/borders.scss";
+@import "@bloom-housing/ui-components/src/global/tokens/colors.scss";
+@import "@bloom-housing/ui-components/src/global/tokens/fonts.scss";
+@import "@bloom-housing/ui-components/src/global/tokens/screens.scss";
+@import "@bloom-housing/ui-components/src/global/tokens/sizes.scss";
 
 // /* ***********/
 // /* Additional stylesheets are contained within individual component folders */

--- a/app/javascript/modules/listingDetails/ListingDetailsFeatures.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsFeatures.tsx
@@ -1,5 +1,5 @@
 import { RailsListing } from "../listings/SharedHelpers"
-import { AdditionalFees, Description, ListingDetailItem, t } from "@bloom-housing/ui-components"
+import { Description, ListingDetailItem, t } from "@bloom-housing/ui-components"
 import React from "react"
 import { isSale } from "../../util/listingUtil"
 
@@ -47,13 +47,14 @@ export const ListingDetailsFeatures = ({ listing, imageSrc }: ListingDetailsFeat
 
           <Description term={t("listings.features.unitFeatures")} description={""} />
         </dl>
-        <AdditionalFees
+        {/* Waiting on new prop uptake from DAH-1133
+          <AdditionalFees
           depositMin={listing.Deposit_Min?.toLocaleString()}
           depositMax={listing.Deposit_Max?.toLocaleString()}
           applicationFee={listing.Fee?.toLocaleString()}
           costsNotIncluded={listing.Costs_Not_Included}
           depositHelperText={"or one month's rent"}
-        />
+        /> */}
       </div>
     </ListingDetailItem>
   )

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "^4.2.2-alpha.25",
+    "@bloom-housing/ui-components": "^4.2.2-alpha.27",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "^4.2.2-alpha.10",
+    "@bloom-housing/ui-components": "^4.2.2-alpha.25",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,10 +1288,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/backend-core@^4.2.2-alpha.2":
-  version "4.2.2-alpha.2"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/backend-core/-/backend-core-4.2.2-alpha.2.tgz#7d256b2597f5447959f86b0fcfc907f0bac59afe"
-  integrity sha512-xPAVQQ7QPfS0xMgZMulecZnEYSYH2skeEODsqAsAoh/Mmh6dH/oFYzhElYhxjL6lGIrWIeTMeHtiAkmWFTcDVg==
+"@bloom-housing/backend-core@^4.2.2-alpha.7":
+  version "4.2.2-alpha.7"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/backend-core/-/backend-core-4.2.2-alpha.7.tgz#5fcf16ba0b31de7786ddfc5397bf616d3402009a"
+  integrity sha512-/IHPbwLxo+dJsXH/ci5hq7otSGd8Cqp7ntwHKUuh3PG+xql0XdeejGPAjqAAQjX8tezyLCo7EDnJ6mUzbACIZw==
   dependencies:
     "@anchan828/nest-sendgrid" "^0.3.25"
     "@google-cloud/translate" "^6.2.6"
@@ -1346,16 +1346,17 @@
     typescript "^3.9.7"
     uuid "^8.3.2"
 
-"@bloom-housing/ui-components@^4.2.2-alpha.10":
-  version "4.2.2-alpha.10"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-4.2.2-alpha.10.tgz#6ccb6cf5ab4c2c522f075eee12d9b674e1434963"
-  integrity sha512-1iy3rxEGMq7uJ+q3Psjx/o0dqNsNuB4WBnyOsKE4ZfWbeWGKqAVL0jRmf5mq30l70po8KBC1kxTmArYrZGZ7Wg==
+"@bloom-housing/ui-components@^4.2.2-alpha.25":
+  version "4.2.2-alpha.25"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-4.2.2-alpha.25.tgz#611457c8a7a29a8e1a5e63f6f9a20b5edace0766"
+  integrity sha512-5lroysh4OOgClGsYPiU8KZuFqJDihvcwMYPPM9svK/QD17JMJJl9RWMFaC4YUU2y+YYFVGRg237zosZjdiD8uw==
   dependencies:
-    "@bloom-housing/backend-core" "^4.2.2-alpha.2"
+    "@bloom-housing/backend-core" "^4.2.2-alpha.7"
     "@mapbox/mapbox-sdk" "^0.13.0"
     "@types/body-scroll-lock" "^2.6.1"
     "@types/jwt-decode" "^2.2.1"
     "@types/markdown-to-jsx" "^6.11.2"
+    "@types/mdx" "^2.0.1"
     "@types/node" "^12.12.67"
     "@types/node-polyglot" "^2.4.1"
     "@types/react-beautiful-dnd" "^13.1.1"
@@ -2438,6 +2439,11 @@
   integrity sha512-30nFYpceM/ZEvhGiqWjm5quLUxNeld0HCzJEXMZZDpq53FPkS85mTwkWtCXzCqq8s5JYLgM5W392a02xn8Bdaw==
   dependencies:
     "@types/react" "*"
+
+"@types/mdx@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.1.tgz#e4c05d355d092d7b58db1abfe460e53f41102ac8"
+  integrity sha512-JPEv4iAl0I+o7g8yVWDwk30es8mfVrjkvh5UeVR2sYPpZCK44vrAPsbJpIS+rJAUxLgaSAMKTEH5Vn5qd9XsrQ==
 
 "@types/minimatch@*":
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,10 +1346,10 @@
     typescript "^3.9.7"
     uuid "^8.3.2"
 
-"@bloom-housing/ui-components@^4.2.2-alpha.25":
-  version "4.2.2-alpha.25"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-4.2.2-alpha.25.tgz#611457c8a7a29a8e1a5e63f6f9a20b5edace0766"
-  integrity sha512-5lroysh4OOgClGsYPiU8KZuFqJDihvcwMYPPM9svK/QD17JMJJl9RWMFaC4YUU2y+YYFVGRg237zosZjdiD8uw==
+"@bloom-housing/ui-components@^4.2.2-alpha.27":
+  version "4.2.2-alpha.27"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-4.2.2-alpha.27.tgz#aa915101590bb68f162754f246f423a51d943d8e"
+  integrity sha512-WMh/Vf2+y9wKO3DR1mXm6xRwP6ONDV4Hnlb6JFWZRIcB8GpIuhRfLKWTL9swekvsirTxqnbM3E02p1VyiUHgUw==
   dependencies:
     "@bloom-housing/backend-core" "^4.2.2-alpha.7"
     "@mapbox/mapbox-sdk" "^0.13.0"


### PR DESCRIPTION
[DAH-1156](https://sfgovdt.jira.com/jira/software/c/projects/DAH/boards/122?modal=detail&selectedIssue=DAH-1156)

Uptakes latest Bloom which includes a fix to allow for overflowing links in the `SiteFooter` component. Due to the breaking changes in the AdditionalFees component (which has a PR out waiting on a string question), I have just commented that out for now. Also adds the new stylesheets coming in from the Bloom theming work. To test, ensure the footer links do not overflow inappropriately on desktop and mobile screens.