### PR TITLE
DAH-1164 sync up AG dropdown with checklist

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormHelperService.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormHelperService.js.coffee
@@ -268,7 +268,8 @@ ShortFormHelperService = ($translate, $filter, $sce, $state, ListingPreferenceSe
 
   Service.preference_proof_options_alice_griffith = [
     ['Letter from SFHA verifying address', Service.flagForI18n('label.proof.sfha_letter')]
-    ['CA ID or Driver\'s License', Service.flagForI18n('label.proof.ca_license')]
+    ['SFHA Lease', Service.flagForI18n('label.proof.sfha_lease')]
+    ['SF City ID', Service.flagForI18n('label.proof.sf_city_id')]
     ['Telephone bill (landline only)', Service.flagForI18n('label.proof.telephone_bill')]
     ['Cable and internet bill', Service.flagForI18n('label.proof.cable_bill')]
     ['Paystub (listing home address)', Service.flagForI18n('label.proof.paystub_home')]

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -1209,10 +1209,10 @@
     "preferences": {
       "alice_griffith": {
         "address": "Alice Griffith Address",
-                "address_desc": "Your address at Alice Griffith Housing Development, on or after October 26, 2010",
-                "desc": "For households in which at least one member was a resident of the Alice Griffith housing development. This includes baseline and current residents that lived in the targeted redevelopment site on or after the time of application for Choice Neighborhoods of October 26, 2010.",
-                "proof_desc": "You'll need one of the following documents showing your address at Alice Griffith Housing Development, dated on or after October 26, 2010:",
-                "sfha_letter_instructions": "Letter from San Francisco Housing Authority verifying applicant lived at the Alice Griffith address on or after October 26, 2010",
+                "address_desc": "Your address at Alice Griffith Housing Development",
+                "desc": "For households in which at least one member was a resident of the Alice Griffith housing development.",
+                "proof_desc": "You'll need one of the following documents showing your address at Alice Griffith Housing Development:",
+                "sfha_letter_instructions": "Letter from San Francisco Housing Authority verifying applicant lived at the Alice Griffith address",
         "title": "Alice Griffith Housing Development Resident Preference"
       },
       "rtr_sunnydale": {


### PR DESCRIPTION
DAH-1164
-sync up proof form dropdown with doc checklist (remove CA drivers license, add SFHA Lease and SF City ID)
-add back en text changes lost with merge

![image](https://user-images.githubusercontent.com/98352600/167515746-61fd1ac4-3d1a-46c4-a258-6864e0188c5e.png)
