### PR TITLE
DAH-1158 add back connection failed error

### DIFF
--- a/app/javascript/api/listingApiService.ts
+++ b/app/javascript/api/listingApiService.ts
@@ -30,7 +30,11 @@ export const getLotteryResults = async (
   listingId: string,
   lotteryId: string
 ): Promise<RailsLotteryResult> =>
-  get<RailsLotteryResult>(lotteryRanking(listingId, lotteryId)).then((response) => response.data)
+  get<RailsLotteryResult>(lotteryRanking(listingId, lotteryId))
+    .then((response) => response.data)
+    .catch(() => {
+      return null
+    })
 
 /**
  * Get the lottery preferences for the given listing


### PR DESCRIPTION
DAH-1158

This scenario got inadvertently removed in previous pr when troubleshooting unit test failures. Add back this error scenario by having the api helper function return null when there's an api failure.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/98352600/169630808-7a6e6f24-07e6-429a-99ba-81753b5acc3b.png">
