### PR TITLE
DAH-50 translate studio + unabbreviate CA and BR

### DIFF
--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -143,7 +143,7 @@
   "listings.unitTypes.4 BR": "4 房",
   "listings.unitTypes.5 BR": "5 房",
   "listings.unitTypes.SRO": "SRO",
-  "listings.unitTypes.Studio": "Studio",
+  "listings.unitTypes.Studio": "套房",
   "listings.upcomingLotteries.hide": "隱藏即將進行的抽籤",
   "listings.upcomingLotteries.noResults": "在已關閉的名單中，目前沒有即將進行抽籤的項目。",
   "listings.upcomingLotteries.show": "顯示即將進行的抽籤",

--- a/app/javascript/modules/listingDetails/ListingDetailsPricingTable.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsPricingTable.tsx
@@ -15,7 +15,7 @@ export const ListingDetailsPricingTable = ({ listing }: ListingDetailsPricingTab
       rent: { cellText: "30%", cellSubText: "income" },
     },
     {
-      units: { cellText: "1 BR", cellSubText: "3 available" },
+      units: { cellText: "1 Bedroom", cellSubText: "3 available" },
       income: { cellText: "$2,194 to $6,854", cellSubText: "per month" },
       rent: { cellText: "$1,295", cellSubText: "income" },
     },

--- a/app/javascript/modules/listings/SharedHelpers.tsx
+++ b/app/javascript/modules/listings/SharedHelpers.tsx
@@ -65,8 +65,12 @@ export const getListingAddressString = (listing: RailsListing) => {
     (listing.Building_Street_Address &&
       listing.Building_City &&
       listing.Building_State &&
-      listing.Building_Zip_Code &&
-      `${listing.Building_Street_Address}, ${listing.Building_City} ${listing.Building_State}, ${listing.Building_Zip_Code}`) ??
+      listing.Building_Zip_Code && (
+        <span>
+          {listing.Building_Street_Address}, {listing.Building_City}{" "}
+          <abbr title="California">{listing.Building_State}</abbr>, {listing.Building_Zip_Code}
+        </span>
+      )) ??
     ""
   )
 }


### PR DESCRIPTION
We actually had most of the cases where we were using abbreviations resolved in the React pages, but plz comment if there are spots I missed. 

One we'll have to look out for, when we get to implementing this section in the listing details aside:
<img width="344" alt="Screen Shot 2022-06-10 at 12 42 24 PM" src="https://user-images.githubusercontent.com/3513225/173138894-1d62aa66-306e-498b-a6cb-d93d8c0b2405.png">
