### PR TITLE
DAH-1178 do not display Adaptable priority type in unit features

### DIFF
--- a/app/assets/javascripts/listings/components/listing/features-section.html.slim
+++ b/app/assets/javascripts/listings/components/listing/features-section.html.slim
@@ -67,7 +67,7 @@ accordion-heading
                 | {{ $ctrl.formatBaths(unit.Number_of_Bathrooms) }}
               td
                 | {{::unit.Unit_Floor}}
-              td
+              td ng-if="::unit.Priority_Type != 'Adaptable'"
                 | {{::unit.Priority_Type}}
 
   .content-tile.feature-tile ng-if="$ctrl.parent.isRental($ctrl.parent.listing)"


### PR DESCRIPTION
DAH-1178

Ignore 'Adaptable' Priority Type on the Unit Features table

![image](https://user-images.githubusercontent.com/98352600/174913896-59f9ace1-ff99-468e-b935-36ff25f95d16.png)
