### PR TITLE
features/DAH-1154-preference-ordinal-updates

### DIFF
--- a/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
@@ -19,7 +19,7 @@ export const ListingDetailsPreferences = ({ listingID }: ListingDetailsPreferenc
   return (
     <ListSection title={t("listings.lottery.title")} subtitle={t("listings.lottery.preferences")}>
       {preferences.length === 0 ? (
-        <div className="maxw-full flex justify-center">
+        <div className="flex justify-center">
           <Icon symbol="spinner" />
         </div>
       ) : (

--- a/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { ListSection, LoadingOverlay, PreferencesList, t } from "@bloom-housing/ui-components"
+import { Icon, ListSection, PreferencesList, t } from "@bloom-housing/ui-components"
 import { RailsListingPreference } from "../../api/types/rails/listings/RailsListingPreferences"
 import { PREFERENCES, PREFERENCES_WITH_PROOF } from "../constants"
 import { getPreferences } from "../../api/listingApiService"
@@ -18,7 +18,11 @@ export const ListingDetailsPreferences = ({ listingID }: ListingDetailsPreferenc
 
   return (
     <ListSection title={t("listings.lottery.title")} subtitle={t("listings.lottery.preferences")}>
-      <LoadingOverlay isLoading={preferences.length === 0}>
+      {preferences.length === 0 ? (
+        <div className="maxw-full flex justify-center">
+          <Icon symbol="spinner" />
+        </div>
+      ) : (
         <>
           <PreferencesList
             listingPreferences={preferences.map((preference, index) => {
@@ -60,7 +64,7 @@ export const ListingDetailsPreferences = ({ listingID }: ListingDetailsPreferenc
             </p>
           )}
         </>
-      </LoadingOverlay>
+      )}
     </ListSection>
   )
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "5.0.1-alpha.1",
+    "@bloom-housing/ui-components": "5.0.1-alpha.4",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,10 +1205,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@5.0.1-alpha.1":
-  version "5.0.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-5.0.1-alpha.1.tgz#386d4834d284c4343fe67e906c4be35e19af5141"
-  integrity sha512-W9UZq+CNT7eLl277RSCTwAu9fcZIrlFvGvKiBlJ/njxyWdIvnRxGF9mPEMxoK73BMzKKbEJaw2L5szXTOuwv2w==
+"@bloom-housing/ui-components@5.0.1-alpha.4":
+  version "5.0.1-alpha.4"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-5.0.1-alpha.4.tgz#c80421011853a6e898d49922e474d9a28ac198be"
+  integrity sha512-ePXlsbWaCxGMXjI23NwzNRw4jSXRu/BXU8dLZB3x+IazGHrIxVCsFD53DTe7sR2J+ABNtDwiamrkJQSoqsyw0Q==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"


### PR DESCRIPTION
[DAH-1154](https://sfgovdt.jira.com/jira/software/c/projects/DAH/boards/122?modal=detail&selectedIssue=DAH-1154&assignee=628e5a18f2261e00682a98db)

From ui-component uptake:
- improve contrast of description and subtitle text within Lottery Preference List
- update position of ordinal on mobile devices
- vertically align all lottery preference content (title, subtitle, description, link) and move ordinal to the left (support empty subtitle)

From DAHLIA changes
- update spinner from overlay with white spinner to black spinner

This ticket improves the React UI of Lottery Preferences. It required some Bloom changes, which involved some design work - moving the alignment of all the content within a Lottery Preferences item so empty subtitle's don't improperly indent the description. 

**Review Instructions**
- Mobile screen widths (< 640px) should show improved ordinal layout<img width="684" alt="Screen Shot 2022-06-24 at 12 11 03 PM" src="https://user-images.githubusercontent.com/5691923/175618641-2f31599b-7e41-4471-9cda-af889330405f.png">
- Description and Subtitle text have improved contrast <img width="745" alt="Screen Shot 2022-06-24 at 12 11 30 PM" src="https://user-images.githubusercontent.com/5691923/175618761-eebaf1b2-b53b-4144-a482-ba7d2f994f4d.png">
- ensure on all screen widths vertical alignment of title, subtitle, description, link ![aligned](https://user-images.githubusercontent.com/5691923/175618945-dad2e283-36cb-4ce5-96ba-8487846ef4ac.jpg)
- make sure new spinner exists when loading page (might have to throttle network) ![spinner](https://user-images.githubusercontent.com/5691923/175619161-daeb2dfd-b2c9-4f93-80ee-131b54c70d46.gif)



 