### PR TITLE
DAH-1155 add support for fallback image on listings

### DIFF
--- a/app/javascript/__tests__/data/RailsSaleListing/listing-sale-habitat.ts
+++ b/app/javascript/__tests__/data/RailsSaleListing/listing-sale-habitat.ts
@@ -355,5 +355,6 @@ export const habitatListing: RailsSaleListing = {
     Id: "0120P000000kPURQA2",
     Name: "Ownership",
   },
-  imageURL: null,
+  imageURL:
+    "https://d31h23p2gsu1kr.cloudfront.net/images/listings/a0W0P00000GlKfBUAV-4d20089ed488fce1a695b73a8a4f090d.jpg",
 }

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsImageCard.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsImageCard.test.tsx.snap
@@ -114,8 +114,9 @@ exports[`ListingDetailsImageCard displays tag when listing is habitat for humani
       <figure
         className="image-card"
       >
-        <div
-          className="image-card__placeholder"
+        <img
+          alt="A picture of the building"
+          src="https://d31h23p2gsu1kr.cloudfront.net/images/listings/a0W0P00000GlKfBUAV-4d20089ed488fce1a695b73a8a4f090d.jpg"
         />
       </figure>
     </div>

--- a/app/javascript/__tests__/modules/listings/SharedHelpers.test.tsx
+++ b/app/javascript/__tests__/modules/listings/SharedHelpers.test.tsx
@@ -1,0 +1,25 @@
+import { getImageCardProps } from "../../../modules/listings/SharedHelpers"
+import RailsRentalListing from "../../../api/types/rails/listings/RailsRentalListing"
+
+describe("SharedHelpers", () => {
+  describe("getImageCardProps", () => {
+    describe("with no imageURL", () => {
+      it("returns an object with fallback image", () => {
+        const listing = {
+          imageURL: null,
+        }
+        expect(getImageCardProps(listing as RailsRentalListing)).toMatchObject({
+          href: "/listings/undefined",
+          imageUrl: {},
+          statuses: [
+            {
+              content: "Application Deadline: June 30, 2022",
+              status: 0,
+            },
+          ],
+          tags: undefined,
+        })
+      })
+    })
+  })
+})

--- a/app/javascript/custom.d.ts
+++ b/app/javascript/custom.d.ts
@@ -1,0 +1,1 @@
+declare module "*.jpg"

--- a/app/javascript/modules/listingDetails/ListingDetailsImageCard.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsImageCard.tsx
@@ -6,6 +6,7 @@ import { getShareListingPath } from "../../util/routeUtil"
 import { getListingAddressString } from "../../util/listingUtil"
 import ConfigContext from "../../lib/ConfigContext"
 import { ListingAddress } from "../../components/ListingAddress"
+import fallbackImg from "../../../assets/images/bg@1200.jpg"
 
 export interface ListingDetailsImageCardProps {
   listing: RailsListing
@@ -21,7 +22,7 @@ export const ListingDetailsImageCard = ({ listing }: ListingDetailsImageCardProp
   return (
     <header className="image-card--leader">
       <ImageCard
-        imageUrl={listing?.imageURL}
+        imageUrl={listing?.imageURL ?? fallbackImg}
         href={`/listings/${listing.listingID}`}
         tags={
           listing.Reserved_community_type

--- a/app/javascript/modules/listings/SharedHelpers.tsx
+++ b/app/javascript/modules/listings/SharedHelpers.tsx
@@ -5,6 +5,7 @@ import { getReservedCommunityType, localizedFormat } from "../../util/languageUt
 import RailsSaleListing from "../../api/types/rails/listings/RailsSaleListing"
 import RailsRentalListing from "../../api/types/rails/listings/RailsRentalListing"
 import { ListingEvent } from "../../api/types/rails/listings/BaseRailsListing"
+import fallbackImg from "../../../assets/images/bg@1200.jpg"
 
 export type RailsListing = RailsSaleListing | RailsRentalListing
 
@@ -61,14 +62,16 @@ export const getListingImageCardStatuses = (
 }
 
 // Get imageCardProps for a given listing
-export const getImageCardProps = (listing, hasFiltersSet?: boolean) => ({
-  imageUrl: listing?.imageURL,
-  href: `/listings/${listing.listingID}`,
-  tags: listing.Reserved_community_type
-    ? [{ text: getReservedCommunityType(listing.Reserved_community_type) }]
-    : undefined,
-  statuses: getListingImageCardStatuses(listing, hasFiltersSet),
-})
+export const getImageCardProps = (listing, hasFiltersSet?: boolean) => {
+  return {
+    imageUrl: listing?.imageURL ?? fallbackImg,
+    href: `/listings/${listing.listingID}`,
+    tags: listing.Reserved_community_type
+      ? [{ text: getReservedCommunityType(listing.Reserved_community_type) }]
+      : undefined,
+    statuses: getListingImageCardStatuses(listing, hasFiltersSet),
+  }
+}
 
 export const getEventNote = (listingEvent: ListingEvent) => {
   return (

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
   setupFiles: ["dotenv/config"],
   setupFilesAfterEnv: ["<rootDir>/__tests__/setupTests.ts"],
   moduleNameMapper: {
-    "\\.(scss|css|less)$": "identity-obj-proxy",
+    "\\.(scss|css|less|jpg)$": "identity-obj-proxy",
   },
   "transformIgnorePatterns": ["node_modules/?!(@bloom-housing/ui-components)"]
 }


### PR DESCRIPTION
When a listing doesn't provide an `imageURL`, use the fallback image used on angular in similar cases.

I had to add some support for importing static assets into react/typescript modules as well as for Jest support of the same 🥴 