### PR TITLE
DAH-1153 events support markdown; clean up style for readability

### DIFF
--- a/app/javascript/__tests__/components/OpenHouses.test.tsx
+++ b/app/javascript/__tests__/components/OpenHouses.test.tsx
@@ -9,7 +9,7 @@ describe("OpenHouses", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it("doesn't display OpenHouses with Listing not containing Open_Houses", () => {
+  it("doesn't display anything with Listing not containing Open_Houses", () => {
     const listing = { ...lotteryCompleteRentalListing, Open_Houses: [] }
     const tree = renderer.create(<OpenHouses listing={listing} />).toJSON()
     expect(tree).toMatchSnapshot()

--- a/app/javascript/__tests__/components/OpenHouses.test.tsx
+++ b/app/javascript/__tests__/components/OpenHouses.test.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import renderer from "react-test-renderer"
+import { lotteryCompleteRentalListing } from "../data/RailsRentalListing/listing-rental-lottery-complete"
+import OpenHouses from "../../components/OpenHouses"
+
+describe("OpenHouses", () => {
+  it("displays OpenHouses with Listing containing Open_Houses", () => {
+    const tree = renderer.create(<OpenHouses listing={lotteryCompleteRentalListing} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("doesn't display OpenHouses with Listing not containing Open_Houses", () => {
+    const listing = { ...lotteryCompleteRentalListing, Open_Houses: [] }
+    const tree = renderer.create(<OpenHouses listing={listing} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/javascript/__tests__/components/__snapshots__/OpenHouses.test.tsx.snap
+++ b/app/javascript/__tests__/components/__snapshots__/OpenHouses.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OpenHouses displays OpenHouses with Listing containing Open_Houses 1`] = `
+<section
+  className="aside-block"
+>
+  <h4
+    className="text-caps-underline undefined"
+  >
+    Open Houses
+  </h4>
+  <div
+    className="false"
+  >
+    <p
+      className="text text-gray-800 pb-2 flex justify-between items-center"
+    >
+      <span
+        className="inline-block text-tiny uppercase"
+      >
+        January 7, 2022
+      </span>
+      <span
+        className="inline-block text-sm font-bold ml-5 font-alt-sans"
+      >
+        5:00PM - 7:00PM
+      </span>
+    </p>
+    <p
+      className="text-tiny text-gray-700 false"
+    >
+      <div
+        className="flex flex-col"
+      />
+    </p>
+  </div>
+</section>
+`;
+
+exports[`OpenHouses doesn't display OpenHouses with Listing not containing Open_Houses 1`] = `null`;

--- a/app/javascript/__tests__/components/__snapshots__/OpenHouses.test.tsx.snap
+++ b/app/javascript/__tests__/components/__snapshots__/OpenHouses.test.tsx.snap
@@ -37,4 +37,4 @@ exports[`OpenHouses displays OpenHouses with Listing containing Open_Houses 1`] 
 </section>
 `;
 
-exports[`OpenHouses doesn't display OpenHouses with Listing not containing Open_Houses 1`] = `null`;
+exports[`OpenHouses doesn't display anything with Listing not containing Open_Houses 1`] = `null`;

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
@@ -25,6 +25,40 @@ exports[`ListingDetailsLotteryResults displays if lottery is complete 1`] = `
       </button>
     </div>
   </div>
+  <section
+    class="aside-block"
+  >
+    <h4
+      class="text-caps-underline undefined"
+    >
+      Open Houses
+    </h4>
+    <div
+      class="false"
+    >
+      <p
+        class="text text-gray-800 pb-2 flex justify-between items-center"
+      >
+        <span
+          class="inline-block text-tiny uppercase"
+        >
+          January 7, 2022
+        </span>
+        <span
+          class="inline-block text-sm font-bold ml-5 font-alt-sans"
+        >
+          5:00PM - 7:00PM
+        </span>
+      </p>
+      <p
+        class="text-tiny text-gray-700 false"
+      />
+      <div
+        class="flex flex-col"
+      />
+      <p />
+    </div>
+  </section>
 </DocumentFragment>
 `;
 

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
@@ -96,5 +96,82 @@ exports[`ListingDetailsLotteryResults displays with summary if lottery is comple
       </button>
     </div>
   </div>
+  <section
+    class="aside-block"
+  >
+    <h4
+      class="text-caps-underline undefined"
+    >
+      Open Houses
+    </h4>
+    <div
+      class="pb-3"
+    >
+      <p
+        class="text-tiny text-gray-700 pb-3"
+      />
+      <div
+        class="flex flex-col"
+      >
+        <span>
+          <p>
+            <strong>
+              FIRST COME, FIRST SERVED LISTING
+            </strong>
+          </p>
+          <p>
+            <br />
+          </p>
+          <p>
+            To view the listing & instructions on how to submit an application, please click on this 
+            <a
+              href="https://sfmohcd.org/bmr-resale-55-page-street-unit-211"
+              target="_blank"
+            >
+              link
+            </a>
+            .
+          </p>
+          <p>
+            <br />
+          </p>
+          <p>
+            <br />
+          </p>
+          <p>
+            Individual viewings may be available by appointment only. Please contact the listing agent, Trista Bernasconi, for assistance.
+          </p>
+        </span>
+      </div>
+      <p />
+    </div>
+    <div
+      class="false"
+    >
+      <p
+        class="text-tiny text-gray-700 false"
+      />
+      <div
+        class="flex flex-col"
+      >
+        <span>
+          <p>
+            <br />
+          </p>
+          <p>
+            To view the virtual tour, please click on this 
+            <a
+              href="https://my.matterport.com/show/?m=bfGPnSQLVhk&amp;mls=1"
+              target="_blank"
+            >
+              link
+            </a>
+            .
+          </p>
+        </span>
+      </div>
+      <p />
+    </div>
+  </section>
 </DocumentFragment>
 `;

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -79,7 +79,7 @@ describe("listingUtil", () => {
   })
 
   describe("getEventTimeString", () => {
-    it("should return 5:00PM - 7:00PM", () => {
+    it("should return 5:00PM - 7:00PM when event has start and end time", () => {
       expect(getEventTimeString(lotteryCompleteRentalListing.Open_Houses[0])).toBe(
         "5:00PM - 7:00PM"
       )

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -5,6 +5,7 @@ import {
   isOpen,
   isRental,
   isSale,
+  getEventTimeString,
 } from "../../util/listingUtil"
 import { openSaleListing } from "../data/RailsSaleListing/listing-sale-open"
 import { closedRentalListing } from "../data/RailsRentalListing/listing-rental-closed"
@@ -74,6 +75,24 @@ describe("listingUtil", () => {
 
     it("should return true when listing is a habitat listing", () => {
       expect(isHabitatListing(habitatListing)).toBe(true)
+    })
+  })
+
+  describe("getEventTimeString", () => {
+    it("should return 5:00PM - 7:00PM", () => {
+      expect(getEventTimeString(lotteryCompleteRentalListing.Open_Houses[0])).toBe(
+        "5:00PM - 7:00PM"
+      )
+    })
+
+    it("should return only start time with no end time", () => {
+      const event = { ...lotteryCompleteRentalListing.Open_Houses[0], End_Time: "" }
+      expect(getEventTimeString(event)).toBe("5:00PM")
+    })
+
+    it("should return empty string with no date", () => {
+      const event = { ...lotteryCompleteRentalListing.Open_Houses[0], Start_Time: "" }
+      expect(getEventTimeString(event)).toBe("")
     })
   })
 })

--- a/app/javascript/components/OpenHouses.tsx
+++ b/app/javascript/components/OpenHouses.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { getEventNote, RailsListing } from "../modules/listings/SharedHelpers"
+import { EventSection, t } from "@bloom-housing/ui-components"
+import { ListingEvent } from "../api/types/rails/listings/BaseRailsListing"
+import { localizedFormat } from "../util/languageUtil"
+import { listingEventHasDate, getEventTimeString } from "../util/listingUtil"
+
+export interface OpenHousesProps {
+  listing: RailsListing
+}
+
+const OpenHouses = ({ listing }: OpenHousesProps) => {
+  return (
+    <>
+      {listing.Open_Houses?.filter((openHouse: ListingEvent) => {
+        return listingEventHasDate(openHouse)
+      }).length ? (
+        <EventSection
+          events={listing.Open_Houses?.filter((openHouse: ListingEvent) => {
+            return listingEventHasDate(openHouse)
+          }).map((openHouse: ListingEvent) => {
+            return {
+              dateString: localizedFormat(openHouse.Date, "LL"),
+              timeString: getEventTimeString(openHouse),
+              note: getEventNote(openHouse),
+            }
+          })}
+          sectionHeader={true}
+          headerText={t("label.openHouses")}
+        />
+      ) : null}
+    </>
+  )
+}
+
+export default OpenHouses

--- a/app/javascript/components/OpenHouses.tsx
+++ b/app/javascript/components/OpenHouses.tsx
@@ -3,7 +3,7 @@ import { getEventNote, RailsListing } from "../modules/listings/SharedHelpers"
 import { EventSection, t } from "@bloom-housing/ui-components"
 import { ListingEvent } from "../api/types/rails/listings/BaseRailsListing"
 import { localizedFormat } from "../util/languageUtil"
-import { listingEventHasDate, getEventTimeString } from "../util/listingUtil"
+import { getEventTimeString } from "../util/listingUtil"
 
 export interface OpenHousesProps {
   listing: RailsListing
@@ -12,15 +12,11 @@ export interface OpenHousesProps {
 const OpenHouses = ({ listing }: OpenHousesProps) => {
   return (
     <>
-      {listing.Open_Houses?.filter((openHouse: ListingEvent) => {
-        return listingEventHasDate(openHouse)
-      }).length ? (
+      {listing.Open_Houses?.length ? (
         <EventSection
-          events={listing.Open_Houses?.filter((openHouse: ListingEvent) => {
-            return listingEventHasDate(openHouse)
-          }).map((openHouse: ListingEvent) => {
+          events={listing.Open_Houses?.map((openHouse: ListingEvent) => {
             return {
-              dateString: localizedFormat(openHouse.Date, "LL"),
+              dateString: openHouse.Date && localizedFormat(openHouse.Date, "LL"),
               timeString: getEventTimeString(openHouse),
               note: getEventNote(openHouse),
             }

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import { getEventNote, RailsListing } from "../listings/SharedHelpers"
 import { EventSection, t } from "@bloom-housing/ui-components"
-import { ListingEvent } from "../../api/types/rails/listings/BaseRailsListing"
-import { localizedFormat, listingEventHasDate, getEventTimeString } from "../../util/languageUtil"
+import { localizedFormat } from "../../util/languageUtil"
+import { getEventTimeString } from "../../util/listingUtil"
 import OpenHouses from "../../components/OpenHouses"
 
 export interface ListingDetailsInfoSessionProps {
@@ -12,14 +12,10 @@ export interface ListingDetailsInfoSessionProps {
 export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSessionProps) => {
   return (
     <>
-      {listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
-        return listingEventHasDate(informationSession)
-      })?.length > 0 ? (
+      {listing.Information_Sessions?.length > 0 ? (
         <EventSection
           sectionHeader={true}
-          events={listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
-            return listingEventHasDate(informationSession)
-          }).map((informationSession) => {
+          events={listing.Information_Sessions?.map((informationSession) => {
             return {
               dateString: localizedFormat(informationSession.Date, "LL"),
               timeString: getEventTimeString(informationSession),

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
@@ -2,36 +2,23 @@ import React from "react"
 import { getEventNote, RailsListing } from "../listings/SharedHelpers"
 import { EventSection, t } from "@bloom-housing/ui-components"
 import { ListingEvent } from "../../api/types/rails/listings/BaseRailsListing"
-import { localizedFormat } from "../../util/languageUtil"
+import { localizedFormat, listingEventHasDate, getEventTimeString } from "../../util/languageUtil"
 import OpenHouses from "../../components/OpenHouses"
 
 export interface ListingDetailsInfoSessionProps {
   listing: RailsListing
 }
 
-const getEventTimeString = (listingEvent: ListingEvent) => {
-  if (listingEvent.Start_Time) {
-    return listingEvent.End_Time
-      ? `${listingEvent.Start_Time} - ${listingEvent.End_Time}`
-      : listingEvent.Start_Time
-  }
-  return ""
-}
-
-const filterListingEventsWithoutDates = (listingEvent: ListingEvent) => {
-  return listingEvent?.Date
-}
-
 export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSessionProps) => {
   return (
     <>
       {listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
-        return filterListingEventsWithoutDates(informationSession)
+        return listingEventHasDate(informationSession)
       })?.length > 0 ? (
         <EventSection
           sectionHeader={true}
           events={listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
-            return filterListingEventsWithoutDates(informationSession)
+            return listingEventHasDate(informationSession)
           }).map((informationSession) => {
             return {
               dateString: localizedFormat(informationSession.Date, "LL"),

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
@@ -23,6 +23,7 @@ export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSession
       {listing.Information_Sessions?.map((informationSession) => {
         return (
           <EventSection
+            sectionHeader={true}
             events={[
               {
                 dateString: localizedFormat(informationSession.Date, "LL"),
@@ -43,6 +44,7 @@ export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSession
               note: getEventNote(openHouse),
             }
           })}
+          sectionHeader={true}
           headerText={t("label.openHouses")}
         />
       )}

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
@@ -17,27 +17,37 @@ const getEventTimeString = (listingEvent: ListingEvent) => {
   return ""
 }
 
+const filterListingEventsWithoutDates = (listingEvent: ListingEvent) => {
+  return listingEvent?.Date
+}
+
 export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSessionProps) => {
   return (
     <>
-      {listing.Information_Sessions?.map((informationSession) => {
-        return (
-          <EventSection
-            sectionHeader={true}
-            events={[
-              {
-                dateString: localizedFormat(informationSession.Date, "LL"),
-                timeString: getEventTimeString(informationSession),
-                note: getEventNote(informationSession),
-              },
-            ]}
-            headerText={t("listings.process.informationSessions")}
-          />
-        )
-      })}
-      {listing.Open_Houses?.length && (
+      {listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
+        return filterListingEventsWithoutDates(informationSession)
+      })?.length > 0 && (
         <EventSection
-          events={listing.Open_Houses?.map((openHouse) => {
+          sectionHeader={true}
+          events={listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
+            return filterListingEventsWithoutDates(informationSession)
+          }).map((informationSession) => {
+            return {
+              dateString: localizedFormat(informationSession.Date, "LL"),
+              timeString: getEventTimeString(informationSession),
+              note: getEventNote(informationSession),
+            }
+          })}
+          headerText={t("listings.process.informationSessions")}
+        />
+      )}
+      {listing.Open_Houses?.filter((informationSession: ListingEvent) => {
+        return filterListingEventsWithoutDates(informationSession)
+      }).length && (
+        <EventSection
+          events={listing.Open_Houses?.filter((informationSession: ListingEvent) => {
+            return filterListingEventsWithoutDates(informationSession)
+          }).map((openHouse) => {
             return {
               dateString: localizedFormat(openHouse.Date, "LL"),
               timeString: getEventTimeString(openHouse),

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
@@ -3,6 +3,7 @@ import { getEventNote, RailsListing } from "../listings/SharedHelpers"
 import { EventSection, t } from "@bloom-housing/ui-components"
 import { ListingEvent } from "../../api/types/rails/listings/BaseRailsListing"
 import { localizedFormat } from "../../util/languageUtil"
+import OpenHouses from "../../components/OpenHouses"
 
 export interface ListingDetailsInfoSessionProps {
   listing: RailsListing
@@ -26,7 +27,7 @@ export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSession
     <>
       {listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
         return filterListingEventsWithoutDates(informationSession)
-      })?.length > 0 && (
+      })?.length > 0 ? (
         <EventSection
           sectionHeader={true}
           events={listing.Information_Sessions?.filter((informationSession: ListingEvent) => {
@@ -40,24 +41,8 @@ export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSession
           })}
           headerText={t("listings.process.informationSessions")}
         />
-      )}
-      {listing.Open_Houses?.filter((informationSession: ListingEvent) => {
-        return filterListingEventsWithoutDates(informationSession)
-      }).length && (
-        <EventSection
-          events={listing.Open_Houses?.filter((informationSession: ListingEvent) => {
-            return filterListingEventsWithoutDates(informationSession)
-          }).map((openHouse) => {
-            return {
-              dateString: localizedFormat(openHouse.Date, "LL"),
-              timeString: getEventTimeString(openHouse),
-              note: getEventNote(openHouse),
-            }
-          })}
-          sectionHeader={true}
-          headerText={t("label.openHouses")}
-        />
-      )}
+      ) : null}
+      <OpenHouses listing={listing} />
       {/* TODO: Bloom prop changes for get and submit application sections */}
     </>
   )

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsInfoSession.tsx
@@ -17,7 +17,7 @@ export const ListingDetailsInfoSession = ({ listing }: ListingDetailsInfoSession
           sectionHeader={true}
           events={listing.Information_Sessions?.map((informationSession) => {
             return {
-              dateString: localizedFormat(informationSession.Date, "LL"),
+              dateString: informationSession.Date && localizedFormat(informationSession.Date, "LL"),
               timeString: getEventTimeString(informationSession),
               note: getEventNote(informationSession),
             }

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryResults.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryResults.tsx
@@ -14,6 +14,7 @@ import { RailsLotteryResult } from "../../api/types/rails/listings/RailsLotteryR
 import { ListingDetailsLotterySearchForm } from "./ListingDetailsLotterySearchForm"
 import { localizedFormat, renderInlineWithInnerHTML } from "../../util/languageUtil"
 import ErrorBoundary, { BoundaryScope } from "../../components/ErrorBoundary"
+import OpenHouses from "../../components/OpenHouses"
 
 export interface ListingDetailsLotteryResultsProps {
   listing: RailsListing
@@ -33,8 +34,8 @@ export const ListingDetailsLotteryResults = ({ listing }: ListingDetailsLotteryR
 
   return (
     isLotteryComplete(listing) && (
-      <div className="border-b pt-4 text-center">
-        <ErrorBoundary boundaryScope={BoundaryScope.component}>
+      <ErrorBoundary boundaryScope={BoundaryScope.component}>
+        <div className="border-b pt-4 text-center">
           <Heading className="mb-4" priority={4}>
             {t("lottery.lotteryResults")}
           </Heading>
@@ -74,8 +75,9 @@ export const ListingDetailsLotteryResults = ({ listing }: ListingDetailsLotteryR
               />
             </Modal>
           )}
-        </ErrorBoundary>
-      </div>
+        </div>
+        <OpenHouses listing={listing} />
+      </ErrorBoundary>
     )
   )
 }

--- a/app/javascript/modules/listings/SharedHelpers.tsx
+++ b/app/javascript/modules/listings/SharedHelpers.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import Markdown from "markdown-to-jsx"
 import { ApplicationStatusType, StatusBarType, t } from "@bloom-housing/ui-components"
 import { areLotteryResultsShareable } from "../../util/listingUtil"
 import { getReservedCommunityType, localizedFormat } from "../../util/languageUtil"
@@ -76,7 +77,7 @@ export const getImageCardProps = (listing, hasFiltersSet?: boolean) => {
 export const getEventNote = (listingEvent: ListingEvent) => {
   return (
     <div className="flex flex-col">
-      {listingEvent.Venue && <span>{listingEvent.Venue}</span>}
+      {listingEvent.Venue && <Markdown>{listingEvent.Venue}</Markdown>}
       {listingEvent.Street_Address && listingEvent.City && (
         <span>{`${listingEvent.Street_Address}, ${listingEvent.City}`}</span>
       )}

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -74,10 +74,6 @@ export const getListingAddressString = (listing: RailsListing): string => {
   )
 }
 
-export const listingEventHasDate = (listingEvent: ListingEvent) => {
-  return listingEvent?.Date
-}
-
 export const getEventTimeString = (listingEvent: ListingEvent) => {
   if (listingEvent.Start_Time) {
     return listingEvent.End_Time

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -1,5 +1,6 @@
 import RailsRentalListing from "../api/types/rails/listings/RailsRentalListing"
 import RailsSaleListing from "../api/types/rails/listings/RailsSaleListing"
+import { ListingEvent } from "../api/types/rails/listings/BaseRailsListing"
 import dayjs from "dayjs"
 import { RESERVED_COMMUNITY_TYPES, TENURE_TYPES } from "../modules/constants"
 import { RailsListing } from "../modules/listings/SharedHelpers"
@@ -71,4 +72,17 @@ export const getListingAddressString = (listing: RailsListing): string => {
       `${listing.Building_Street_Address}, ${listing.Building_City}, ${listing.Building_State} ${listing.Building_Zip_Code}`) ||
     ""
   )
+}
+
+export const listingEventHasDate = (listingEvent: ListingEvent) => {
+  return listingEvent?.Date
+}
+
+export const getEventTimeString = (listingEvent: ListingEvent) => {
+  if (listingEvent.Start_Time) {
+    return listingEvent.End_Time
+      ? `${listingEvent.Start_Time} - ${listingEvent.End_Time}`
+      : listingEvent.Start_Time
+  }
+  return ""
 }


### PR DESCRIPTION
[DAH-1153](https://sfgovdt.jira.com/jira/software/c/projects/DAH/boards/122?modal=detail&selectedIssue=DAH-1153)

**Review Instructions**
Compare branch-deployed netlify (with updates) and https://dahlia-full.herokuapp.com/listings/a0W4U00000KRHeEUAX?react=true (without updates) and check the following items:

- There's only one information sessions containing two events
<img width="586" alt="Screen Shot 2022-07-14 at 7 49 18 PM" src="https://user-images.githubusercontent.com/5691923/179130884-d6860431-30db-4e36-9c87-1b252394ab1a.png">
- There's an underline in the section titles Open Houses and Information Sessions
 and There's extra vertical margin between events within a section, e.g. July 16th and July 21st

![Screen Shot 2022-07-13 at 1 44 47 PM](https://user-images.githubusercontent.com/5691923/178818570-8cfe7524-ccd5-47f2-a64e-816dec0cc99f.png)

- Markup isn't showing up in the content within Open Houses and Information Sessions
![Screen Shot 2022-07-13 at 1 03 48 PM](https://user-images.githubusercontent.com/5691923/178815893-174821fe-8428-4a8a-ba13-9f0876d0d129.png)
- Click around app and make sure markup isn't showing up on any of the Open Houses or Information Sessions within focused listings
- Events without dates don't show Date. The event will still show up though. Users are using a date-less event for static events, like virtual tours. Here's an example on this particular listing. 
<img width="323" alt="Screen Shot 2022-07-21 at 12 44 09 PM" src="https://user-images.githubusercontent.com/5691923/180290244-714e050f-e0e2-4cdf-87cb-b10c7ebcaa33.png">

Compare branch-deployed netlify (with updates) and https://dahlia-full.herokuapp.com/listings/listings/a0W4U00000KnHO6UAN?react=true (without updates) and check the following items:
- Open Houses are showing up. Feel free to click around other listings with completed lotteries that have open houses and ensure that open houses are displaying.