### PR TITLE
uptake bloom fix for image card padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "5.0.1-alpha.4",
+    "@bloom-housing/ui-components": "5.0.1-alpha.7",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,10 +1205,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@5.0.1-alpha.4":
-  version "5.0.1-alpha.4"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-5.0.1-alpha.4.tgz#c80421011853a6e898d49922e474d9a28ac198be"
-  integrity sha512-ePXlsbWaCxGMXjI23NwzNRw4jSXRu/BXU8dLZB3x+IazGHrIxVCsFD53DTe7sR2J+ABNtDwiamrkJQSoqsyw0Q==
+"@bloom-housing/ui-components@5.0.1-alpha.7":
+  version "5.0.1-alpha.7"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-5.0.1-alpha.7.tgz#557ea4b41103b3809298a28b2f432060c7cf4c7a"
+  integrity sha512-OQlCDSFPx+Gz2FWKUpIDFpQeXG94rdJsYGnO9AGQ/B5FWJVFo15MPiJ2VyhVNTT+ihNUmPrbuYD8/q648BYMkQ==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"


### PR DESCRIPTION
The wonky placeholder image size appears to have been caused by a mistaken bloom change during the 2nd gen refactor of the styles — this version should address the necessary fix 🤞

![Screen Shot 2022-07-13 at 2 32 51 PM](https://user-images.githubusercontent.com/3513225/178840409-d455f2c8-e132-4def-a996-df3c6b5f6e51.png)

Navigating to [our imageless listing](https://dahlia-webapp-pr-1678.herokuapp.com/listings/a0W4U00000KnHO6UAN?react=true), looks like it's fixed!
 