### PR TITLE
DAH-1192 format time according to sf.gov guidelines

### DIFF
--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -1006,7 +1006,7 @@
   "lottery.anyRemainingUnits": "Any remaining units",
   "lottery.applicationsThatQualifyForPreference": "Applications that qualify for this preference will be given a higher priority in the lottery.",
   "lottery.bucketsIntro": "Lottery results are divided into multiple lists. Please see below for general information about each preference. For your specific results, please enter your lottery number.",
-  "lottery.completeResultsWillBePosted": "Complete lottery results will be posted on this date by 5pm.",
+  "lottery.completeResultsWillBePosted": "Complete lottery results will be posted on this date by 5 pm.",
   "lottery.enterLotteryNo": "Enter Your Lottery Number",
   "lottery.enterLotteryNumber": "Enter Your Lottery Number",
   "lottery.generalPool": "General Pool",

--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -993,7 +993,7 @@
   "lottery.anyRemainingUnits": "Todas las unidades restantes",
   "lottery.applicationsThatQualifyForPreference": "Las solicitudes elegibles para esta preferencia tendrán mayor prioridad en el sorteo.",
   "lottery.bucketsIntro": "Los resultados del sorteo se dividen en distintas listas. Abajo encontrará información general de cada preferencia. Si desea ver su resultado, ingrese su número de sorteo.",
-  "lottery.completeResultsWillBePosted": "Los resultados completos del sorteo se publicarán en esta fecha antes de las 5 p. m.",
+  "lottery.completeResultsWillBePosted": "Los resultados completos del sorteo se publicarán en esta fecha antes de las 5 pm",
   "lottery.enterLotteryNo": "Ingrese su número de sorteo",
   "lottery.enterLotteryNumber": "Ingrese su número de sorteo",
   "lottery.generalPool": "Pozo general",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -993,7 +993,7 @@
   "lottery.anyRemainingUnits": "Anumang natitira pang unit",
   "lottery.applicationsThatQualifyForPreference": "Bibigyan ng mas mataas na prayoridad sa lottery ang mga aplikasyong kuwalipikado para sa preperensiyang ito. ",
   "lottery.bucketsIntro": "Hinahati-hati ang mga resulta ng lottery sa iba't ibang listahan. Pakitingnan sa ibaba ang pangkalahatang impormasyon ukol sa bawat preperensiya. Para sa mga resultang espisipiko sa inyo, pakilagay ang numero ninyo sa lottery.",
-  "lottery.completeResultsWillBePosted": "Ipapaskil ang mga kumpletong resulta ng lottery sa petsang ito bago sumapit ang 5pm. ",
+  "lottery.completeResultsWillBePosted": "Ipapaskil ang mga kumpletong resulta ng lottery sa petsang ito bago sumapit ang 5 pm. ",
   "lottery.enterLotteryNo": "Ipasok ang inyong numero sa loterya o palabunutan",
   "lottery.enterLotteryNumber": "Ilagay ang Numero ng Inyong Lottery",
   "lottery.generalPool": "Pangkalahatang Pool o Mga Kasali",

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
@@ -25,7 +25,7 @@ Array [
           <span
             className="font-bold"
           >
-            6:00 PM
+            6:00 pm
           </span>
         </p>
         <div
@@ -69,7 +69,7 @@ Array [
         <p
           className="text-gray-700"
         >
-          Complete lottery results will be posted on this date by 5pm.
+          Complete lottery results will be posted on this date by 5 pm.
         </p>
       </div>
     </section>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ListingDetailsLotteryResults displays if lottery is complete 1`] = `
       Lottery Results
     </h4>
     <p
-      class="mb-4 text-sm uppercase"
+      class="mb-4 text-sm"
     >
       January 26, 2022
     </p>
@@ -73,7 +73,7 @@ exports[`ListingDetailsLotteryResults displays with summary if lottery is comple
       Lottery Results
     </h4>
     <p
-      class="mb-4 text-sm uppercase"
+      class="mb-4 text-sm"
     >
       December 22, 2021
     </p>

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryResults.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryResults.tsx
@@ -39,9 +39,7 @@ export const ListingDetailsLotteryResults = ({ listing }: ListingDetailsLotteryR
           <Heading className="mb-4" priority={4}>
             {t("lottery.lotteryResults")}
           </Heading>
-          <p className="mb-4 text-sm uppercase">
-            {localizedFormat(listing.Lottery_Results_Date, "LL")}
-          </p>
+          <p className="mb-4 text-sm">{localizedFormat(listing.Lottery_Results_Date, "LL")}</p>
           <div className="bg-gray-100 py-4">
             {listing.Lottery_Summary && (
               <div className="mb-3 mx-2 text-gray-700 text-sm">

--- a/app/javascript/modules/listingDetailsLottery/LotteryDetailsLotteryInfo.tsx
+++ b/app/javascript/modules/listingDetailsLottery/LotteryDetailsLotteryInfo.tsx
@@ -19,7 +19,7 @@ export const ListingDetailsLotteryInfo = ({ listing }: ListingDetailsLotteryInfo
         <SidebarBlock title={t("label.lottery")}>
           <p className="flex justify-between mb-4">
             <span>{localizedFormat(listing.Lottery_Date, "LL")}</span>
-            <span className="font-bold">{localizedFormat(listing.Lottery_Date, "LT")}</span>
+            <span className="font-bold">{localizedFormat(listing.Lottery_Date, "h:mm a")}</span>
           </p>
           <div className="text-gray-700">
             {listing.Lottery_Venue && renderWithInnerHTML(listing.Lottery_Venue)}


### PR DESCRIPTION
DAH-1192

PA testing feedback (2 small changes)
-use the same time format as sf.gov. display times in 12 hour clock format (1:00 pm) rather than 24 hour clock (13:00). Use proper spacing and case.
-as per previous convo's, removing uppercase styling from lottery results date