### PR TITLE
DAH-1225 Pass in markdown to contact office hours field

### DIFF
--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
@@ -107,7 +107,13 @@ Array [
     <div
       className="text-gray-800 text-tiny markdown"
     >
-      Monday - Friday 10:00 AM - 6:00 PM
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Monday - Friday 10:00 AM - 6:00 PM",
+          }
+        }
+      />
     </div>
   </section>,
 ]

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsProcess.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsProcess.tsx
@@ -2,7 +2,8 @@ import React from "react"
 import { getEventNote, RailsListing } from "../listings/SharedHelpers"
 import dayjs from "dayjs"
 import { EventSection, Contact, t, ExpandableSection } from "@bloom-housing/ui-components"
-import { localizedFormat } from "../../util/languageUtil"
+import { localizedFormat, renderInlineWithInnerHTML } from "../../util/languageUtil"
+import { stripMostTags } from "../../util/filterUtil"
 
 export interface ListingDetailsProcessProps {
   listing: RailsListing
@@ -62,7 +63,7 @@ export const ListingDetailsProcess = ({ listing }: ListingDetailsProcessProps) =
               ? [
                   {
                     title: t("contactAgent.officeHours"),
-                    content: listing.Office_Hours,
+                    content: renderInlineWithInnerHTML(stripMostTags(listing.Office_Hours)),
                   },
                 ]
               : undefined


### PR DESCRIPTION
[DAH-1225](https://sfgovdt.jira.com/jira/software/c/projects/DAH/boards/122?modal=detail&selectedIssue=DAH-1225)

The Contact section currently does support markdown, we just had to pass it in as markdown. You can test using the listing identified in the ticket (listings/a0W4U00000KnDwWUAV?react=true) that you don't see any tags.