### PR TITLE
DAH-1229 bring back html filter to fix buggy parsing behavior

### DIFF
--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
@@ -31,58 +31,11 @@ Array [
         <div
           className="text-gray-700"
         >
-          <div>
-            <p>
-              <span
-                style={
-                  Object {
-                    "": "",
-                    "backgroundColor": "transparent",
-                    "color": "rgb(0, 0, 0)",
-                    "fontFamily": "Arial",
-                    "fontSize": "10pt",
-                  }
-                }
-              >
-                The lottery will not be in person, but instead will be a virtual lottery.
-              </span>
-            </p>
-            <p>
-              <span
-                style={
-                  Object {
-                    "": "",
-                    "backgroundColor": "transparent",
-                    "color": "rgb(0, 0, 0)",
-                    "fontSize": "12pt",
-                  }
-                }
-              >
-                 
-              </span>
-            </p>
-            <p>
-              <span
-                style={
-                  Object {
-                    "": "",
-                    "backgroundColor": "transparent",
-                    "color": "rgb(0, 0, 0)",
-                    "fontFamily": "Arial",
-                    "fontSize": "10pt",
-                  }
-                }
-              >
-                Come back to this page on the day of the lottery for a link you can click on to watch the lottery live.
-              </span>
-            </p>
-            <p>
-              <br />
-            </p>
-            <p>
-              <br />
-            </p>
-          </div>
+          <p>
+            The lottery will not be in person, but instead will be a virtual lottery. Come back to this page on the day of the lottery for a link you can click on to watch the lottery live.
+            <br />
+            <br />
+          </p>
         </div>
         <p
           className="mt-4 text-gray-700"

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
@@ -49,11 +49,9 @@ exports[`ListingDetailsLotteryResults displays with summary if lottery is comple
       <div
         class="mb-3 mx-2 text-gray-700 text-sm"
       >
-        <p>
-          <strong>
-            Applications are being accepted on a first come, first served basis starting 01/26/2022 at 8:00 AM PST
-          </strong>
-        </p>
+        <strong>
+          Applications are being accepted on a first come, first served basis starting 01/26/2022 at 8:00 AM PST
+        </strong>
       </div>
       <button
         class="button is-primary is-small"

--- a/app/javascript/__tests__/util/filterUtil.test.ts
+++ b/app/javascript/__tests__/util/filterUtil.test.ts
@@ -1,0 +1,13 @@
+import { stripMostTags } from "../../util/filterUtil"
+
+describe("languageUtil", () => {
+  describe("stripMostTags", () => {
+    it("strips and html string of all tags and attributes except <a>'s", () => {
+      expect(
+        stripMostTags(
+          '<p><span style="font-family: Arial, sans-serif; font-size: 10pt;">All BMR renters must review and acknowledge the </span><a href="https://sfmohcd.org/sites/default/files/Documents/MOH/Inclusionary%20Manuals/Inclusionary%20Affordable%20Housing%20Program%20Manual%2010.15.2018.pdf" target="_blank" style="font-family: Arial, sans-serif; font-size: 10pt;">Inclusionary Affordable Housing Program Monitoring and Procedures Manual 2018</a><span style="font-family: Arial, sans-serif; font-size: 10pt;"> that governs this property upon the signing of a lease for a BMR unit.</span></p><p><span style="font-size: 10.5pt;"> </span></p><p><span style="font-family: Arial, sans-serif; font-size: 10pt;">Applicants should be informed that BMR rental units in some buildings may convert to ownership units in the future. In the case of conversion, BMR renters will be afforded certain rights as explained in the </span><a href="https://sfmohcd.org/sites/default/files/Documents/MOH/Inclusionary%20Manuals/Inclusionary%20Affordable%20Housing%20Program%20Manual%2010.15.2018.pdf" target="_blank">Inclusionary Affordable Housing Program Monitoring and Procedures Manual 2018.</a> Applicants should inquire with the building contact person listed above to determine if the building has a minimum number of years that it must remain a rental building. (Some buildings may have such restrictions based on government sources of financing for their building.) Most buildings may have no restrictions on conversion at all.</p><p><span style="font-size: 10.5pt;"> </span></p><p><span style="font-family: Arial, sans-serif; font-size: 10pt;">It is also important to note that units governed by the Inclusionary Housing Program are NOT governed by the San Francisco Rent Ordinance (also known as “rent control”). Among other rules, rents may increase beyond increases allowed under “rent control.” Please see the </span><a href="https://sfmohcd.org/sites/default/files/Documents/MOH/Inclusionary%20Manuals/Inclusionary%20Affordable%20Housing%20Program%20Manual%2010.15.2018.pdf" target="_blank" style="font-family: Arial, sans-serif; font-size: 10pt;">Inclusionary Affordable Housing Program Monitoring and Procedures Manual 2018</a><span style="font-family: Arial, sans-serif; font-size: 10pt;"> for more information.</span></p><p><br></p>'
+        )
+      ).toEqual(expect.not.stringMatching(/<p>|<span>/))
+    })
+  })
+})

--- a/app/javascript/util/filterUtil.tsx
+++ b/app/javascript/util/filterUtil.tsx
@@ -1,0 +1,17 @@
+// This is adapted from the filter implemented in customFilters.js.coffee
+// for doing a barebones sanitization of incoming raw html. Our html/markdown
+// parsing library (markdown-to-jsx) currently has reported issues
+// with nested <span> tags so it's necessary to strip them to
+// avoid buggy parsing behavior.
+
+// https://github.com/probablyup/markdown-to-jsx/issues?q=is%3Aissue+is%3Aopen+span
+
+export const stripMostTags = (input, allowed?: string) => {
+  if (!input) return ""
+  allowed = (((allowed || "<br><a>") + "").toLowerCase().match(/<[a-z][a-z0-9]*>/g) || []).join("")
+  const tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi
+  const res = input.replace(tags, ($0, $1) => (allowed.includes(`<${$1.toLowerCase()}>`) ? $0 : ""))
+
+  // replace any newlines with break tags
+  return res.trim().replace(/\n/g, "<br>")
+}

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -3,6 +3,7 @@ import Markdown from "markdown-to-jsx"
 import dayjs from "dayjs"
 import React from "react"
 
+import { stripMostTags } from "./filterUtil"
 import { cleanPath, getPathWithoutLeadingSlash } from "./urlUtil"
 
 type PhraseBundle = Record<string, unknown>
@@ -139,11 +140,11 @@ export const getCurrentLanguage = (path?: string | undefined): LanguagePrefix =>
  * Get a renderable version of a translated string with e.g. a link in it as an alternative to using <Markdown />
  */
 export function renderMarkup(translatedString: string) {
-  return <Markdown options={{ forceBlock: true }}>{translatedString}</Markdown>
+  return <Markdown options={{ forceBlock: true }}>{stripMostTags(translatedString)}</Markdown>
 }
 
 export function renderInlineMarkup(translatedString: string) {
-  return <Markdown>{translatedString}</Markdown>
+  return <Markdown>{stripMostTags(translatedString)}</Markdown>
 }
 
 // Get the translated community type


### PR DESCRIPTION
This addresses a fix from Emily S's comments in [DAH-1229](https://sfgovdt.jira.com/jira/software/c/projects/DAH/boards/122?modal=detail&selectedIssue=DAH-1229)

There appear to be a few listed issues with our parsing library and nested `<span>`s, particularly [this one](https://github.com/probablyup/markdown-to-jsx/issues/374) 😬 

Reinstantiating the filterUtil should keep us safe from this happening