### PR TITLE
DAH-1188 (Fix)  add optional chaining to lisitng.Units

### DIFF
--- a/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
@@ -30,8 +30,8 @@ export const ListingDetailsEligibility = ({
 }: ListingDetailsEligibilityProps) => {
   const priorityUnits = []
 
-  listing.Units.forEach((unit: RailsUnit) => {
-    const priorityUnit = priorityUnits.find((priorityUnit: ReducedUnit) => {
+  listing.Units?.forEach((unit: RailsUnit) => {
+    const priorityUnit = priorityUnits?.find((priorityUnit: ReducedUnit) => {
       return priorityUnit.name === unit.Priority_Type
     })
 


### PR DESCRIPTION
related to [DAH-1188](https://sfgovdt.jira.com/browse/DAH-1188)

- just adding an optional chain for when a listing doesn't have units attached (which I don't even think would ever happen on prod, but there is one listing on full in this state)