### PR TITLE
DAH-1229 add option to allow tags in specified cases

### DIFF
--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -908,7 +908,7 @@
   "listings.seeUnitInformation": "Consulte la información de la unidad",
   "listings.showingMatchesForRent": "Se muestran las unidades compatibles para alquilar",
   "listings.showingMatchesForSale": "Se muestran las unidades compatibles para alquilar",
-  "listings.singleRoomOccupancy": "Viviendas con habitaciones individuales",
+  "listings.singleRoomOccupancy": "Viviendas con habitaciones individuales (SRO)",
   "listings.singleRoomOccupancyDescription": "Esta propiedad ofrece habitaciones individuales solo para una persona. Los inquilinos podrían tener que compartir los baños y en ocasiones la cocina.",
   "listings.specialNotes": "Notas Especiales",
   "listings.stats.availability": "Disponibilidad",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -886,7 +886,7 @@
   "listings.realtorCommissionHeader": "Ang Inyong Komisyon:",
   "listings.realtorCommissionHowTo": "Kung paano ninyo matatanggap ito:",
   "listings.realtorCommissionNotEligible": "Hindi kuwalipikado ang inyong realtor para sa komisyon sa unit na ito",
-  "listings.realtorCommissionPercentage": "%{percentage}% ng presyo ng pagkakabenta",
+  "listings.realtorCommissionPercentage": " %{percentage}% ng presyo ng pagkakabenta",
   "listings.remainingUnitsAfterPreferenceConsideration": "Matapos maisalang-alang ang lahat ng mayroong preperensiya, puwede nang makuha ang anumang natitirang unit sa mga kuwalipikadong aplikante ayon sa pagkakasunod-sunod nila sa lottery.",
   "listings.rentalUnits": "Mga Paupahang Unit",
   "listings.requiredDocuments": "Mga Kinakailangang Dokumento",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -908,7 +908,7 @@
   "listings.seeUnitInformation": "SEE_UNIT_INFORMATION",
   "listings.showingMatchesForRent": "Ipinapakita ang mga ka-match na unit na pinauupahan",
   "listings.showingMatchesForSale": "Ipinapakita ang mga ka-match na unit na ibinebenta ",
-  "listings.singleRoomOccupancy": "Mga Indibidwal na Kuwarto sa Gusali (Single Room Occupancy)",
+  "listings.singleRoomOccupancy": "Mga Indibidwal na Kuwarto sa Gusali (SRO)",
   "listings.singleRoomOccupancyDescription": "Naghahandog ang gusaling ito ng mga indibidwal na kuwarto na para lamang sa iisang tao. Posibleng may mga banyo, at kung minsan, mga kusina, na komyunal na ginagamit ng mga nangungupahan. ",
   "listings.specialNotes": "Mga Espesyal na Tala",
   "listings.stats.availability": "Kung puwedeng makuha o hindi ",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -937,7 +937,7 @@
   "listings.unitTypes.3 BR": "3 房",
   "listings.unitTypes.4 BR": "4 房",
   "listings.unitTypes.5 BR": "5 房",
-  "listings.unitTypes.SRO": "SRO",
+  "listings.unitTypes.SRO": "單人房住房 (SRO)",
   "listings.unitTypes.Studio": "套房",
   "listings.unitsAreFor": "這些單位適用於 %{type}。",
   "listings.unitsHaveAccessibilityFeaturesFor": "這些單位設有無障礙設施，可供 %{type} 的人使用。",

--- a/app/javascript/__tests__/modules/listingDetails/ListingDetailsAdditionalInformation.test.tsx
+++ b/app/javascript/__tests__/modules/listingDetails/ListingDetailsAdditionalInformation.test.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import renderer from "react-test-renderer"
+import { ListingDetailsAdditionalInformation } from "../../../modules/listingDetails/ListingDetailsAdditionalInformation"
+import { closedRentalListing } from "../../data/RailsRentalListing/listing-rental-closed"
+import { openSaleListing } from "../../data/RailsSaleListing/listing-sale-open"
+
+describe("ListingDetailsAdditionalInformation", () => {
+  it("displays additional information section for a sale listing", () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }
+    })
+    const tree = renderer
+      .create(
+        <ListingDetailsAdditionalInformation listing={openSaleListing} imageSrc={"/image-url"} />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it("displays additional information section for a rental listing", () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }
+    })
+    const tree = renderer
+      .create(
+        <ListingDetailsAdditionalInformation
+          listing={closedRentalListing}
+          imageSrc={"/image-url"}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsAdditionalInformation.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsAdditionalInformation.test.tsx.snap
@@ -1,0 +1,328 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListingDetailsAdditionalInformation displays additional information section for a rental listing 1`] = `
+<li
+  className="responsive-content-item "
+>
+  <header
+    className="detail-header"
+  >
+    <img
+      alt=""
+      className="detail-header__image "
+      src="/image-url"
+    />
+    <hgroup
+      className="detail-header__hgroup"
+    >
+      <h2
+        className="detail-header__title"
+      >
+        Additional Information
+      </h2>
+      <span
+        className="detail-header__subtitle"
+      >
+        Required documents and selection criteria
+      </span>
+      <span
+        className="ui-icon ui-medium"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 32 32"
+        >
+          <path
+            d="M28.267 6.133l-12.267 12.267-12.267-12.267-3.733 3.733 16 16 16-16z"
+          />
+        </svg>
+      </span>
+    </hgroup>
+  </header>
+  <div
+    className="listing-detail-panel"
+  >
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Required Documents
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            Lottery winners will be required to fill out a building application and provide a copy of your current credit report, 3 most recent paystubs, current tax returns and W-2, and 3 most recent bank statements.
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Important Program Rules
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            All BMR renters must review and acknowledge the 
+            <a
+              href="http://sf-moh.org/index.aspx?page=295"
+              target="_blank"
+            >
+              Inclusionary Affordable Housing Program Monitoring and Procedures Manual 2013
+            </a>
+             that governs this property upon the signing of a lease for a BMR unit. 
+            <br />
+             
+            <br />
+            Applicants should be informed that BMR rental units in some buildings may convert to ownership units in the future.  In the case of conversion, BMR renters will be afforded certain rights as explained in ...
+          </span>
+          <span
+            className="button-toggle ml-1"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            More
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</li>
+`;
+
+exports[`ListingDetailsAdditionalInformation displays additional information section for a sale listing 1`] = `
+<li
+  className="responsive-content-item "
+>
+  <header
+    className="detail-header"
+  >
+    <img
+      alt=""
+      className="detail-header__image "
+      src="/image-url"
+    />
+    <hgroup
+      className="detail-header__hgroup"
+    >
+      <h2
+        className="detail-header__title"
+      >
+        Additional Information
+      </h2>
+      <span
+        className="detail-header__subtitle"
+      >
+        Required documents and selection criteria
+      </span>
+      <span
+        className="ui-icon ui-medium"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 32 32"
+        >
+          <path
+            d="M28.267 6.133l-12.267 12.267-12.267-12.267-3.733 3.733 16 16 16-16z"
+          />
+        </svg>
+      </span>
+    </hgroup>
+  </header>
+  <div
+    className="listing-detail-panel"
+  >
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Special Notes
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <span>
+          Some other excessively formatted listing notes.
+        </span>
+      </div>
+    </div>
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Required Documents
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            Proof of residence
+
+            <br />
+            Bank statements
+
+            <br />
+            Concert tickets
+          </span>
+        </div>
+      </div>
+      <div
+        className="text-sm mt-4"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            Should your application be chosen from the lottery, be prepared to fill out a more detailed application and provide 
+            <a
+              href="https://sfmohcd.org/after-homebuyer-lottery"
+              target="_blank"
+            >
+              required supporting documents
+            </a>
+             within 5 business days of being contacted.
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Important Program Rules
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            Some important program rules with bullets:
+            <br />
+            Rule oneRule two
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Covenants, Conditions and Restrictions (CC&R's)
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            The CC&R's explain the rules of the homeowners' association, and restrict how you can modify the property.
+          </span>
+        </div>
+        <a
+          className="button mt-4"
+          href="http://www.duckduckgo.com"
+          target="_blank"
+        >
+          Download PDF
+        </a>
+      </div>
+    </div>
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        For the Buyer's Realtor
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <span
+          className="font-bold"
+        >
+          Your Commission: 
+        </span>
+         3% of the sales price
+        <div
+          className="flex mt-4"
+        >
+          <span
+            className="font-bold mr-1"
+          >
+            How to receive it: 
+          </span>
+          <span>
+            <div
+              className="text-sm"
+            >
+              <span>
+                Register with the Leasing Agent
+              </span>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="info-card bg-gray-100 border-0"
+    >
+      <h3
+        className="text-serif-lg"
+      >
+        Resale Price Restrictions
+      </h3>
+      <div
+        className="text-sm"
+      >
+        <div
+          className="text-sm"
+        >
+          <span>
+            A BMR unit will be resold at a restricted price to a household that meets the first‐time homebuyer and income qualifications for the program. Please review the 
+            <a
+              href="http://sf-moh.org/index.aspx?page=295"
+              target="_blank"
+            >
+              Inclusionary Housing Procedures Manual
+            </a>
+             for specific information.
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</li>
+`;

--- a/app/javascript/components/TextTruncate.tsx
+++ b/app/javascript/components/TextTruncate.tsx
@@ -15,7 +15,7 @@ export interface TextTruncateProps {
 export const TextTruncate = ({ text }: TextTruncateProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
-  truncate.setup({ ellipsis: " ... ", length: 400, reserveLastWord: true })
+  truncate.setup({ ellipsis: " ... ", length: 400, reserveLastWord: true, keepWhitespaces: true })
   const truncatedText = text ? renderInlineMarkup(truncate(text)) : ""
   const untruncatedText = renderInlineMarkup(text)
 

--- a/app/javascript/modules/listingDetails/ListingDetailsAdditionalInformation.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsAdditionalInformation.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { ListingDetailItem, t } from "@bloom-housing/ui-components"
+import { LinkButton, ListingDetailItem, t } from "@bloom-housing/ui-components"
 import { RailsListing } from "../listings/SharedHelpers"
 import { TextTruncate } from "../../components/TextTruncate"
+import { isHabitatListing, isSale } from "../../util/listingUtil"
 
 export interface ListingDetailsAdditionalInformationProps {
   listing: RailsListing
@@ -12,6 +13,14 @@ export const ListingDetailsAdditionalInformation = ({
   listing,
   imageSrc,
 }: ListingDetailsAdditionalInformationProps) => {
+  const getCommissionString = () => {
+    return listing.Realtor_Commission_Unit === "percent"
+      ? t("listings.realtorCommissionPercentage", {
+          percentage: listing.Realtor_Commission_Amount,
+        })
+      : `$${listing.Realtor_Commission_Amount.toLocaleString()}`
+  }
+
   return (
     <ListingDetailItem
       imageAlt={""}
@@ -26,21 +35,62 @@ export const ListingDetailsAdditionalInformation = ({
             <TextTruncate text={listing.Listing_Other_Notes} />
           </div>
         )}
-        <div className="info-card bg-gray-100 border-0">
-          <h3 className="text-serif-lg">{t("listings.requiredDocuments")}</h3>
-          <div className="text-sm">
-            <TextTruncate text={listing.Required_Documents} />
+        {(!!listing.Required_Documents || isSale(listing)) && (
+          <div className="info-card bg-gray-100 border-0">
+            <h3 className="text-serif-lg">{t("listings.requiredDocuments")}</h3>
+            <div className="text-sm">
+              <TextTruncate text={listing.Required_Documents} />
+            </div>
+            {isSale(listing) && !isHabitatListing(listing) && (
+              <div className="text-sm mt-4">
+                <TextTruncate
+                  text={t("listings.requiredDocumentsAfterApplying", {
+                    url: "https://sfmohcd.org/after-homebuyer-lottery",
+                  })}
+                />
+              </div>
+            )}
           </div>
-        </div>
-        <div className="info-card bg-gray-100 border-0">
-          <h3 className="text-serif-lg">{t("listings.importantProgramRules")}</h3>
-          <TextTruncate text={listing.Legal_Disclaimers} />
-        </div>
+        )}
+        {listing.Legal_Disclaimers && (
+          <div className="info-card bg-gray-100 border-0">
+            <h3 className="text-serif-lg">{t("listings.importantProgramRules")}</h3>
+            <div className="text-sm">
+              <TextTruncate text={listing.Legal_Disclaimers} />
+            </div>
+          </div>
+        )}
         {listing.CC_and_R_URL && (
           <div className="info-card bg-gray-100 border-0">
             <h3 className="text-serif-lg">{t("listings.cc&r")}</h3>
             <div className="text-sm">
-              <TextTruncate text={listing.CC_and_R_URL} />
+              <TextTruncate text={t("listings.cc&rDescription")} />
+              <LinkButton href={listing.CC_and_R_URL} className={"mt-4"} newTab={true}>
+                {t("listings.downloadPdf")}
+              </LinkButton>
+            </div>
+          </div>
+        )}
+        {isSale(listing) && (
+          <div className="info-card bg-gray-100 border-0">
+            <h3 className="text-serif-lg">{t("listings.realtorCommission")}</h3>
+            <div className="text-sm">
+              {listing.Allows_Realtor_Commission ? (
+                <>
+                  <span className={"font-bold"}>{t("listings.realtorCommissionHeader")}</span>
+                  {getCommissionString()}
+                </>
+              ) : (
+                t("listings.realtorCommissionNotEligible")
+              )}
+              {listing.Realtor_Commission_Info && (
+                <div className={"flex mt-4"}>
+                  <span className={"font-bold mr-1"}>{t("listings.realtorCommissionHowTo")}</span>
+                  <span>
+                    <TextTruncate text={listing.Realtor_Commission_Info} />
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/app/javascript/modules/listings/DirectoryHelpers.tsx
+++ b/app/javascript/modules/listings/DirectoryHelpers.tsx
@@ -379,19 +379,19 @@ export const eligibilityHeader = (
       size: filters.household_size,
       people: filters.household_size === "1" ? t("listings.person") : t("listings.people"),
     })
-    const childrenContent = ` ${t("listings.includingChildren", {
+    const childrenContent = t("listings.includingChildren", {
       number: filters.children_under_6,
       children: filters.children_under_6 === "1" ? t("t.child") : t("t.children"),
-    })}`
-    const incomeContent = ` ${t("listings.atTotalIncome", {
+    })
+    const incomeContent = t("listings.atTotalIncome", {
       income: filters.income_total.toLocaleString(),
       per: getYearString(),
-    })}`
+    })
     return (
       <>
-        {renderInlineMarkup(householdSizeContent)}
-        {filters.include_children_under_6 && renderInlineMarkup(childrenContent)}
-        {renderInlineMarkup(incomeContent)}
+        {renderInlineMarkup(householdSizeContent, "<span>")}{" "}
+        {filters.include_children_under_6 && renderInlineMarkup(childrenContent, "<span>")}{" "}
+        {renderInlineMarkup(incomeContent, "<span>")}
       </>
     )
   }

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -143,12 +143,16 @@ export const getCurrentLanguage = (path?: string | undefined): LanguagePrefix =>
 /**
  * Get a renderable version of a translated string with e.g. a link in it as an alternative to using <Markdown />
  */
-export function renderMarkup(translatedString: string) {
-  return <Markdown options={{ forceBlock: true }}>{stripMostTags(translatedString)}</Markdown>
+export function renderMarkup(translatedString: string, allowedTags?: string) {
+  return (
+    <Markdown options={{ forceBlock: true }}>
+      {stripMostTags(translatedString, allowedTags)}
+    </Markdown>
+  )
 }
 
-export function renderInlineMarkup(translatedString: string) {
-  return <Markdown>{stripMostTags(translatedString)}</Markdown>
+export function renderInlineMarkup(translatedString: string, allowedTags?: string) {
+  return <Markdown>{stripMostTags(translatedString, allowedTags)}</Markdown>
 }
 
 // Get the translated community type


### PR DESCRIPTION
Yindi found [another issue](https://sfgovdt.jira.com/browse/DAH-1229?focusedCommentId=72314) that trickled into our new markdown approach at some point 😓 hopefully this addition adds some helpful control over how we sanitize.

In this case, we are being explicit about the content coming in, and want to display `<span>`s, so this shouldn't open any vulnerabilities.