### PR TITLE
DAH-1229 add option to allow tags in specified cases

### DIFF
--- a/app/javascript/modules/listings/DirectoryHelpers.tsx
+++ b/app/javascript/modules/listings/DirectoryHelpers.tsx
@@ -379,19 +379,19 @@ export const eligibilityHeader = (
       size: filters.household_size,
       people: filters.household_size === "1" ? t("listings.person") : t("listings.people"),
     })
-    const childrenContent = ` ${t("listings.includingChildren", {
+    const childrenContent = t("listings.includingChildren", {
       number: filters.children_under_6,
       children: filters.children_under_6 === "1" ? t("t.child") : t("t.children"),
-    })}`
-    const incomeContent = ` ${t("listings.atTotalIncome", {
+    })
+    const incomeContent = t("listings.atTotalIncome", {
       income: filters.income_total.toLocaleString(),
       per: getYearString(),
-    })}`
+    })
     return (
       <>
-        {renderInlineMarkup(householdSizeContent)}
-        {filters.include_children_under_6 && renderInlineMarkup(childrenContent)}
-        {renderInlineMarkup(incomeContent)}
+        {renderInlineMarkup(householdSizeContent, "<span>")}{" "}
+        {filters.include_children_under_6 && renderInlineMarkup(childrenContent, "<span>")}{" "}
+        {renderInlineMarkup(incomeContent, "<span>")}
       </>
     )
   }

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -143,12 +143,16 @@ export const getCurrentLanguage = (path?: string | undefined): LanguagePrefix =>
 /**
  * Get a renderable version of a translated string with e.g. a link in it as an alternative to using <Markdown />
  */
-export function renderMarkup(translatedString: string) {
-  return <Markdown options={{ forceBlock: true }}>{stripMostTags(translatedString)}</Markdown>
+export function renderMarkup(translatedString: string, allowedTags?: string) {
+  return (
+    <Markdown options={{ forceBlock: true }}>
+      {stripMostTags(translatedString, allowedTags)}
+    </Markdown>
+  )
 }
 
-export function renderInlineMarkup(translatedString: string) {
-  return <Markdown>{stripMostTags(translatedString)}</Markdown>
+export function renderInlineMarkup(translatedString: string, allowedTags?: string) {
+  return <Markdown>{stripMostTags(translatedString, allowedTags)}</Markdown>
 }
 
 // Get the translated community type


### PR DESCRIPTION
Yindi found [another issue](https://sfgovdt.jira.com/browse/DAH-1229?focusedCommentId=72314) that trickled into our new markdown approach at some point 😓 hopefully this addition adds some helpful control over how we sanitize.

In this case, we are being explicit about the content coming in, and want to display <span>s, so this shouldn't open any vulnerabilities.