### PR TITLE
DAH-1223 Leasing Agent padding fixes

### DIFF
--- a/app/javascript/__tests__/components/__snapshots__/BeforeApplyingForSale.test.tsx.snap
+++ b/app/javascript/__tests__/components/__snapshots__/BeforeApplyingForSale.test.tsx.snap
@@ -8,11 +8,11 @@ exports[`BeforeApplyingForSale display Before Applying when type is Habitat list
     className="list-section__header custom-counter__header"
   >
     <hgroup>
-      <h4
+      <h3
         className="custom-counter__title"
       >
         Before applying
-      </h4>
+      </h3>
       <span
         className="custom-counter__subtitle"
       >
@@ -141,11 +141,11 @@ exports[`BeforeApplyingForSale display Before Applying when type is listing deta
     className="list-section__header custom-counter__header"
   >
     <hgroup>
-      <h4
+      <h3
         className="custom-counter__title"
       >
         Before applying
-      </h4>
+      </h3>
       <span
         className="custom-counter__subtitle"
       >

--- a/app/javascript/__tests__/components/__snapshots__/BeforeApplyingForSale.test.tsx.snap
+++ b/app/javascript/__tests__/components/__snapshots__/BeforeApplyingForSale.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`BeforeApplyingForSale display Before Applying when type is directory 1`
   className="mb-8"
 >
   <h2
-    className="text-caps-underline mb-5"
+    className="text__underline-weighted mb-5"
   >
     Before applying
   </h2>

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
@@ -1314,89 +1314,6 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
       </span>
     </div>
   </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Rental Assistance
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
-        </span>
-      </hgroup>
-    </header>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Additional Eligibility Rules
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Applicants must also qualify under the rules of the building.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Criminal Background
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <span>
-          Qualified applicants with criminal history will be considered for housing in compliance with 
-          <a
-            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
-            target="_blank"
-          >
-            Article 49
-          </a>
-           of the San Francisco Police Code: 
-          <a
-            href="https://sfgov.org/olse/fair-chance-ordinance-fco"
-            target="_blank"
-          >
-            Fair Chance Ordinance
-          </a>
-          .
-        </span>
-      </div>
-    </div>
-    <p>
-      <a
-        href="https://sfmohcd.org/homebuyer-program-eligibility"
-        target="_blank"
-      >
-        Find out more about Building Selection Criteria
-      </a>
-    </p>
-  </li>
 </li>
 `;
 
@@ -2406,8 +2323,56 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Before applying
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Make sure you:
+        </span>
+      </hgroup>
+    </header>
+    <ol
+      className="numbered-list my-5 bg-white p-4 pt-6 text-sm"
+    >
+      <li>
+        <p>
+          Go to a 
+          <a
+            href="https://habitatgsf.org/amber-drive-info/"
+            target="_blank"
+          >
+            Habitat for Humanity information session
+          </a>
+        </p>
+      </li>
+      <li>
+        Haven't owned residential property in the past 3 years
+      </li>
+      <li>
+        <p>
+          Meet the 
+          <a
+            href="https://sfmohcd.org/sites/default/files/Documents/MOH/Inclusionary%20Manuals/Inclusionary%20Affordable%20Housing%20Program%20Manual%2010.15.2018.pdf"
+            target="_blank"
+          >
+            income requirements
+          </a>
+        </p>
+      </li>
+      <li>
+        Have a 650 credit score or higher
+      </li>
+    </ol>
+    <p>
+      Read 
+      <a
+        href="https://habitatgsf.org/amber-drive-info/"
+        target="_blank"
       >
         <hgroup>
           <h4
@@ -2468,72 +2433,55 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Occupancy
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            A minimum of one person per bedroom is required.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Occupancy
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          A minimum of one person per bedroom is required.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
         }
       >
-        <table
-          className="w-full text-sm"
-        >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                Unit Type
-              </th>
-              <th
-                className=""
-              >
-                Occupancy
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              Unit Type
+            </th>
+            <th
+              className=""
+            >
+              Occupancy
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Lottery Preferences
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        className="flex justify-center"
-      >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Lottery Preferences
+        </h3>
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
@@ -44,156 +44,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Household Maximum Income
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            <div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  For income calculations, household size includes everyone (all ages) living in the unit.
-                </p>
-              </div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  People in your household may need 
-                  <a
-                    href="https://sfmohcd.org/special-calculations-household-income"
-                    target="_blank"
-                  >
-                    special income calculations
-                  </a>
-                   if they:
-                </p>
-              </div>
-              <ul
-                className="list-disc ml-5"
-              >
-                <li>
-                  Are full-time students (but not the primary applicant).
-                </li>
-                <li>
-                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
-                </li>
-              </ul>
-            </div>
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
+      <hgroup>
+        <h3
+          className="custom-counter__title"
         >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                household size
-              </th>
-              <th
-                className=""
-              >
-                maximum income per month
-              </th>
-              <th
-                className=""
-              >
-                maximum income per year
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Occupancy
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Occupancy limits for this building differ from household size, and do not include children under 6.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
-        >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                Unit Type
-              </th>
-              <th
-                className=""
-              >
-                Occupancy
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Lottery Preferences
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        className="flex justify-center"
-      >
+          Household Maximum Income
+        </h3>
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -281,9 +137,262 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-          <span
-            className="button-toggle ml-4"
-            onClick={[Function]}
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              household size
+            </th>
+            <th
+              className=""
+            >
+              maximum income per month
+            </th>
+            <th
+              className=""
+            >
+              maximum income per year
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Occupancy
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Occupancy limits for this building differ from household size, and do not include children under 6.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              Unit Type
+            </th>
+            <th
+              className=""
+            >
+              Occupancy
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Lottery Preferences
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="flex justify-center"
+    >
+      <span
+        className="ui-icon ui-large spinner-animation"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            cx="50"
+            cy="50"
+            fill="none"
+            r="32"
+            stroke="currentColor"
+            strokeDasharray="150.79644737231007 52.26548245743669"
+            strokeWidth="9"
+          />
+        </svg>
+      </span>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Rental Assistance
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
+        </span>
+      </hgroup>
+    </header>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Additional Eligibility Rules
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Applicants must also qualify under the rules of the building.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Credit History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+          </p>
+          <p>
+            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+          </p>
+          <p>
+            Collection accounts...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Rental History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+          </p>
+          <p>
+            Previous rental history will be reviewed and must exhibit no derogatory references. 
+          </p>
+          <p>
+            Landlord references will only check for...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Criminal Background
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <span>
+          Qualified applicants with criminal history will be considered for housing in compliance with 
+          <a
+            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
+            target="_blank"
           >
             More
           </span>
@@ -416,156 +525,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Household Maximum Income
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            <div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  For income calculations, household size includes everyone (all ages) living in the unit.
-                </p>
-              </div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  People in your household may need 
-                  <a
-                    href="https://sfmohcd.org/special-calculations-household-income"
-                    target="_blank"
-                  >
-                    special income calculations
-                  </a>
-                   if they:
-                </p>
-              </div>
-              <ul
-                className="list-disc ml-5"
-              >
-                <li>
-                  Are full-time students (but not the primary applicant).
-                </li>
-                <li>
-                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
-                </li>
-              </ul>
-            </div>
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
+      <hgroup>
+        <h3
+          className="custom-counter__title"
         >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                household size
-              </th>
-              <th
-                className=""
-              >
-                maximum income per month
-              </th>
-              <th
-                className=""
-              >
-                maximum income per year
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Occupancy
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Occupancy for this building is limited to 1 person per unit.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
-        >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                Unit Type
-              </th>
-              <th
-                className=""
-              >
-                Occupancy
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Lottery Preferences
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        className="flex justify-center"
-      >
+          Household Maximum Income
+        </h3>
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -653,9 +618,262 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-          <span
-            className="button-toggle ml-4"
-            onClick={[Function]}
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              household size
+            </th>
+            <th
+              className=""
+            >
+              maximum income per month
+            </th>
+            <th
+              className=""
+            >
+              maximum income per year
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Occupancy
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Occupancy for this building is limited to 1 person per unit.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              Unit Type
+            </th>
+            <th
+              className=""
+            >
+              Occupancy
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Lottery Preferences
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="flex justify-center"
+    >
+      <span
+        className="ui-icon ui-large spinner-animation"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            cx="50"
+            cy="50"
+            fill="none"
+            r="32"
+            stroke="currentColor"
+            strokeDasharray="150.79644737231007 52.26548245743669"
+            strokeWidth="9"
+          />
+        </svg>
+      </span>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Rental Assistance
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
+        </span>
+      </hgroup>
+    </header>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Additional Eligibility Rules
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Applicants must also qualify under the rules of the building.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Credit History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+          </p>
+          <p>
+            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+          </p>
+          <p>
+            Collection accounts...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Rental History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+          </p>
+          <p>
+            Previous rental history will be reviewed and must exhibit no derogatory references. 
+          </p>
+          <p>
+            Landlord references will only check for...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Criminal Background
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <span>
+          Qualified applicants with criminal history will be considered for housing in compliance with 
+          <a
+            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
+            target="_blank"
           >
             More
           </span>
@@ -788,34 +1006,91 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Before applying
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Make sure you:
+        </span>
+      </hgroup>
+    </header>
+    <ol
+      className="numbered-list my-5 bg-white p-4 pt-6 text-sm"
+    >
+      <li>
+        Haven't owned residential property in the past 3 years
+      </li>
+      <li>
+        <p>
+          Meet our 
+          <a
+            href="https://sfmohcd.org/homebuyer-program-eligibility"
+            target="_blank"
           >
-            Before applying
-          </h4>
-          <span
-            className="custom-counter__subtitle"
+            income requirements
+          </a>
+        </p>
+      </li>
+      <li>
+        <p>
+          Complete 
+          <a
+            href="https://sfmohcd.org/homebuyer-application-requirements#education"
+            target="_blank"
           >
-            Make sure you:
-          </span>
-        </hgroup>
-      </header>
-      <ol
-        className="numbered-list my-5 bg-white p-4 pt-6 text-sm"
+            homebuyer education
+          </a>
+        </p>
+      </li>
+      <li>
+        <p>
+          Get pre-approved for a mortgage loan by a 
+          <a
+            href="https://sfmohcd.org/lender-list"
+            target="_blank"
+          >
+            lender on our list
+          </a>
+        </p>
+      </li>
+      <li>
+        Have enough in savings for closing costs and downpayment
+      </li>
+    </ol>
+    <p>
+      Read 
+      <a
+        href="https://sfmohcd.org/homebuyer-program-eligibility"
+        target="_blank"
       >
-        <li>
-          Haven't owned residential property in the past 3 years
-        </li>
-        <li>
-          <p>
-            Meet our 
-            <a
-              href="https://sfmohcd.org/homebuyer-program-eligibility"
-              target="_blank"
+        our full list of requirements
+      </a>
+       for more details.
+    </p>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Household Maximum Income
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          <div>
+            <div
+              className="mb-4"
             >
               income requirements
             </a>
@@ -945,72 +1220,55 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Occupancy
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            A minimum of one person per bedroom is required.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Occupancy
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          A minimum of one person per bedroom is required.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
         }
       >
-        <table
-          className="w-full text-sm"
-        >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                Unit Type
-              </th>
-              <th
-                className=""
-              >
-                Occupancy
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              Unit Type
+            </th>
+            <th
+              className=""
+            >
+              Occupancy
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Lottery Preferences
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        className="flex justify-center"
-      >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Lottery Preferences
+        </h3>
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -1030,9 +1288,115 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             />
           </svg>
         </span>
+      </hgroup>
+    </header>
+    <div
+      className="flex justify-center"
+    >
+      <span
+        className="ui-icon ui-large spinner-animation"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            cx="50"
+            cy="50"
+            fill="none"
+            r="32"
+            stroke="currentColor"
+            strokeDasharray="150.79644737231007 52.26548245743669"
+            strokeWidth="9"
+          />
+        </svg>
+      </span>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Rental Assistance
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
+        </span>
+      </hgroup>
+    </header>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Additional Eligibility Rules
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Applicants must also qualify under the rules of the building.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Criminal Background
+        </h3>
       </div>
-    </li>
-  </ul>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <span>
+          Qualified applicants with criminal history will be considered for housing in compliance with 
+          <a
+            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
+            target="_blank"
+          >
+            Article 49
+          </a>
+           of the San Francisco Police Code: 
+          <a
+            href="https://sfgov.org/olse/fair-chance-ordinance-fco"
+            target="_blank"
+          >
+            Fair Chance Ordinance
+          </a>
+          .
+        </span>
+      </div>
+    </div>
+    <p>
+      <a
+        href="https://sfmohcd.org/homebuyer-program-eligibility"
+        target="_blank"
+      >
+        Find out more about Building Selection Criteria
+      </a>
+    </p>
+  </li>
 </li>
 `;
 
@@ -1080,156 +1444,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Household Maximum Income
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            <div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  For income calculations, household size includes everyone (all ages) living in the unit.
-                </p>
-              </div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  People in your household may need 
-                  <a
-                    href="https://sfmohcd.org/special-calculations-household-income"
-                    target="_blank"
-                  >
-                    special income calculations
-                  </a>
-                   if they:
-                </p>
-              </div>
-              <ul
-                className="list-disc ml-5"
-              >
-                <li>
-                  Are full-time students (but not the primary applicant).
-                </li>
-                <li>
-                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
-                </li>
-              </ul>
-            </div>
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
+      <hgroup>
+        <h3
+          className="custom-counter__title"
         >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                household size
-              </th>
-              <th
-                className=""
-              >
-                maximum income per month
-              </th>
-              <th
-                className=""
-              >
-                maximum income per year
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Occupancy
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Occupancy for this building varies by unit type. SROs are limited to 1 person per unit, regardless of age. For all other unit types, occupancy limits do not count children under 6.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
-        >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                Unit Type
-              </th>
-              <th
-                className=""
-              >
-                Occupancy
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Lottery Preferences
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        className="flex justify-center"
-      >
+          Household Maximum Income
+        </h3>
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -1317,9 +1537,262 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-          <span
-            className="button-toggle ml-4"
-            onClick={[Function]}
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              household size
+            </th>
+            <th
+              className=""
+            >
+              maximum income per month
+            </th>
+            <th
+              className=""
+            >
+              maximum income per year
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Occupancy
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Occupancy for this building varies by unit type. SROs are limited to 1 person per unit, regardless of age. For all other unit types, occupancy limits do not count children under 6.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              Unit Type
+            </th>
+            <th
+              className=""
+            >
+              Occupancy
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Lottery Preferences
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="flex justify-center"
+    >
+      <span
+        className="ui-icon ui-large spinner-animation"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            cx="50"
+            cy="50"
+            fill="none"
+            r="32"
+            stroke="currentColor"
+            strokeDasharray="150.79644737231007 52.26548245743669"
+            strokeWidth="9"
+          />
+        </svg>
+      </span>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Rental Assistance
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
+        </span>
+      </hgroup>
+    </header>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Additional Eligibility Rules
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Applicants must also qualify under the rules of the building.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Credit History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+          </p>
+          <p>
+            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+          </p>
+          <p>
+            Collection accounts...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Rental History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+          </p>
+          <p>
+            Previous rental history will be reviewed and must exhibit no derogatory references. 
+          </p>
+          <p>
+            Landlord references will only check for...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Criminal Background
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <span>
+          Qualified applicants with criminal history will be considered for housing in compliance with 
+          <a
+            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
+            target="_blank"
           >
             More
           </span>
@@ -1452,156 +1925,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Household Maximum Income
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            <div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  For income calculations, household size includes everyone (all ages) living in the unit.
-                </p>
-              </div>
-              <div
-                className="mb-4"
-              >
-                <p>
-                  People in your household may need 
-                  <a
-                    href="https://sfmohcd.org/special-calculations-household-income"
-                    target="_blank"
-                  >
-                    special income calculations
-                  </a>
-                   if they:
-                </p>
-              </div>
-              <ul
-                className="list-disc ml-5"
-              >
-                <li>
-                  Are full-time students (but not the primary applicant).
-                </li>
-                <li>
-                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
-                </li>
-              </ul>
-            </div>
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
+      <hgroup>
+        <h3
+          className="custom-counter__title"
         >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                household size
-              </th>
-              <th
-                className=""
-              >
-                maximum income per month
-              </th>
-              <th
-                className=""
-              >
-                maximum income per year
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Occupancy
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Occupancy for this building is limited to 1 person per unit.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        style={
-          Object {
-            "overflowX": "auto",
-          }
-        }
-      >
-        <table
-          className="w-full text-sm"
-        >
-          <thead>
-            <tr>
-              <th
-                className=""
-              >
-                Unit Type
-              </th>
-              <th
-                className=""
-              >
-                Occupancy
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-      </div>
-    </li>
-    <li
-      className="list-section custom-counter__item"
-    >
-      <header
-        className="list-section__header custom-counter__header"
-      >
-        <hgroup>
-          <h4
-            className="custom-counter__title"
-          >
-            Lottery Preferences
-          </h4>
-          <span
-            className="custom-counter__subtitle"
-          >
-            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-          </span>
-        </hgroup>
-      </header>
-      <div
-        className="flex justify-center"
-      >
+          Household Maximum Income
+        </h3>
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -1689,9 +2018,262 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-          <span
-            className="button-toggle ml-4"
-            onClick={[Function]}
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              household size
+            </th>
+            <th
+              className=""
+            >
+              maximum income per month
+            </th>
+            <th
+              className=""
+            >
+              maximum income per year
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Occupancy
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Occupancy for this building is limited to 1 person per unit.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      style={
+        Object {
+          "overflowX": "auto",
+        }
+      }
+    >
+      <table
+        className="w-full text-sm"
+      >
+        <thead>
+          <tr>
+            <th
+              className=""
+            >
+              Unit Type
+            </th>
+            <th
+              className=""
+            >
+              Occupancy
+            </th>
+          </tr>
+        </thead>
+        <tbody />
+      </table>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Lottery Preferences
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="flex justify-center"
+    >
+      <span
+        className="ui-icon ui-large spinner-animation"
+        data-test-id={null}
+      >
+        <svg
+          fill="currentColor"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            cx="50"
+            cy="50"
+            fill="none"
+            r="32"
+            stroke="currentColor"
+            strokeDasharray="150.79644737231007 52.26548245743669"
+            strokeWidth="9"
+          />
+        </svg>
+      </span>
+    </div>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Rental Assistance
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
+        </span>
+      </hgroup>
+    </header>
+  </li>
+  <li
+    className="list-section custom-counter__item"
+  >
+    <header
+      className="list-section__header custom-counter__header"
+    >
+      <hgroup>
+        <h3
+          className="custom-counter__title"
+        >
+          Additional Eligibility Rules
+        </h3>
+        <span
+          className="custom-counter__subtitle"
+        >
+          Applicants must also qualify under the rules of the building.
+        </span>
+      </hgroup>
+    </header>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Credit History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+          </p>
+          <p>
+            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+          </p>
+          <p>
+            Collection accounts...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Rental History
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <div>
+          <p>
+            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+          </p>
+          <p>
+            Previous rental history will be reviewed and must exhibit no derogatory references. 
+          </p>
+          <p>
+            Landlord references will only check for...
+          </p>
+        </div>
+        <button
+          className="button-toggle ml-4"
+          onClick={[Function]}
+        >
+          More
+        </button>
+      </div>
+    </div>
+    <div
+      className="info-card"
+    >
+      <div
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Criminal Background
+        </h3>
+      </div>
+      <div
+        className="expandable-text text-sm text-gray-700"
+      >
+         
+        <span>
+          Qualified applicants with criminal history will be considered for housing in compliance with 
+          <a
+            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
+            target="_blank"
           >
             More
           </span>

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
@@ -44,12 +44,156 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Household Maximum Income
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            <div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  For income calculations, household size includes everyone (all ages) living in the unit.
+                </p>
+              </div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  People in your household may need 
+                  <a
+                    href="https://sfmohcd.org/special-calculations-household-income"
+                    target="_blank"
+                  >
+                    special income calculations
+                  </a>
+                   if they:
+                </p>
+              </div>
+              <ul
+                className="list-disc ml-5"
+              >
+                <li>
+                  Are full-time students (but not the primary applicant).
+                </li>
+                <li>
+                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
+                </li>
+              </ul>
+            </div>
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
         >
-          Household Maximum Income
-        </h3>
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                household size
+              </th>
+              <th
+                className=""
+              >
+                maximum income per month
+              </th>
+              <th
+                className=""
+              >
+                maximum income per year
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Occupancy
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Occupancy limits for this building differ from household size, and do not include children under 6.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
+        >
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                Unit Type
+              </th>
+              <th
+                className=""
+              >
+                Occupancy
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Lottery Preferences
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        className="flex justify-center"
+      >
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -78,11 +222,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Rental Assistance
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -98,11 +242,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Additional Eligibility Rules
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -137,265 +281,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              household size
-            </th>
-            <th
-              className=""
-            >
-              maximum income per month
-            </th>
-            <th
-              className=""
-            >
-              maximum income per year
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Occupancy
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Occupancy limits for this building differ from household size, and do not include children under 6.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              Unit Type
-            </th>
-            <th
-              className=""
-            >
-              Occupancy
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Lottery Preferences
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="flex justify-center"
-    >
-      <span
-        className="ui-icon ui-large spinner-animation"
-        data-test-id={null}
-      >
-        <svg
-          fill="currentColor"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            cx="50"
-            cy="50"
-            fill="none"
-            r="32"
-            stroke="currentColor"
-            strokeDasharray="150.79644737231007 52.26548245743669"
-            strokeWidth="9"
-          />
-        </svg>
-      </span>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Rental Assistance
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
-        </span>
-      </hgroup>
-    </header>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Additional Eligibility Rules
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Applicants must also qualify under the rules of the building.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Credit History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
-          </p>
-          <p>
-            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
-          </p>
-          <p>
-            Collection accounts...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Rental History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
-          </p>
-          <p>
-            Previous rental history will be reviewed and must exhibit no derogatory references. 
-          </p>
-          <p>
-            Landlord references will only check for...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Criminal Background
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <span>
-          Qualified applicants with criminal history will be considered for housing in compliance with 
-          <a
-            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
-            target="_blank"
+          <button
+            className="button-toggle ml-4"
+            onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -425,12 +316,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Landlord references will only check for...
             </p>
           </div>
-          <span
+          <button
             className="button-toggle ml-4"
             onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -525,12 +416,156 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Household Maximum Income
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            <div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  For income calculations, household size includes everyone (all ages) living in the unit.
+                </p>
+              </div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  People in your household may need 
+                  <a
+                    href="https://sfmohcd.org/special-calculations-household-income"
+                    target="_blank"
+                  >
+                    special income calculations
+                  </a>
+                   if they:
+                </p>
+              </div>
+              <ul
+                className="list-disc ml-5"
+              >
+                <li>
+                  Are full-time students (but not the primary applicant).
+                </li>
+                <li>
+                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
+                </li>
+              </ul>
+            </div>
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
         >
-          Household Maximum Income
-        </h3>
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                household size
+              </th>
+              <th
+                className=""
+              >
+                maximum income per month
+              </th>
+              <th
+                className=""
+              >
+                maximum income per year
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Occupancy
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Occupancy for this building is limited to 1 person per unit.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
+        >
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                Unit Type
+              </th>
+              <th
+                className=""
+              >
+                Occupancy
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Lottery Preferences
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        className="flex justify-center"
+      >
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -559,11 +594,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Rental Assistance
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -579,11 +614,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Additional Eligibility Rules
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -618,265 +653,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              household size
-            </th>
-            <th
-              className=""
-            >
-              maximum income per month
-            </th>
-            <th
-              className=""
-            >
-              maximum income per year
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Occupancy
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Occupancy for this building is limited to 1 person per unit.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              Unit Type
-            </th>
-            <th
-              className=""
-            >
-              Occupancy
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Lottery Preferences
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="flex justify-center"
-    >
-      <span
-        className="ui-icon ui-large spinner-animation"
-        data-test-id={null}
-      >
-        <svg
-          fill="currentColor"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            cx="50"
-            cy="50"
-            fill="none"
-            r="32"
-            stroke="currentColor"
-            strokeDasharray="150.79644737231007 52.26548245743669"
-            strokeWidth="9"
-          />
-        </svg>
-      </span>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Rental Assistance
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
-        </span>
-      </hgroup>
-    </header>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Additional Eligibility Rules
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Applicants must also qualify under the rules of the building.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Credit History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
-          </p>
-          <p>
-            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
-          </p>
-          <p>
-            Collection accounts...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Rental History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
-          </p>
-          <p>
-            Previous rental history will be reviewed and must exhibit no derogatory references. 
-          </p>
-          <p>
-            Landlord references will only check for...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Criminal Background
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <span>
-          Qualified applicants with criminal history will be considered for housing in compliance with 
-          <a
-            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
-            target="_blank"
+          <button
+            className="button-toggle ml-4"
+            onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -906,12 +688,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Landlord references will only check for...
             </p>
           </div>
-          <span
+          <button
             className="button-toggle ml-4"
             onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -1006,91 +788,34 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Before applying
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Make sure you:
-        </span>
-      </hgroup>
-    </header>
-    <ol
-      className="numbered-list my-5 bg-white p-4 pt-6 text-sm"
-    >
-      <li>
-        Haven't owned residential property in the past 3 years
-      </li>
-      <li>
-        <p>
-          Meet our 
-          <a
-            href="https://sfmohcd.org/homebuyer-program-eligibility"
-            target="_blank"
-          >
-            income requirements
-          </a>
-        </p>
-      </li>
-      <li>
-        <p>
-          Complete 
-          <a
-            href="https://sfmohcd.org/homebuyer-application-requirements#education"
-            target="_blank"
-          >
-            homebuyer education
-          </a>
-        </p>
-      </li>
-      <li>
-        <p>
-          Get pre-approved for a mortgage loan by a 
-          <a
-            href="https://sfmohcd.org/lender-list"
-            target="_blank"
-          >
-            lender on our list
-          </a>
-        </p>
-      </li>
-      <li>
-        Have enough in savings for closing costs and downpayment
-      </li>
-    </ol>
-    <p>
-      Read 
-      <a
-        href="https://sfmohcd.org/homebuyer-program-eligibility"
-        target="_blank"
+      <header
+        className="list-section__header custom-counter__header"
       >
-        our full list of requirements
-      </a>
-       for more details.
-    </p>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Household Maximum Income
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          <div>
-            <div
-              className="mb-4"
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Before applying
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Make sure you:
+          </span>
+        </hgroup>
+      </header>
+      <ol
+        className="numbered-list my-5 bg-white p-4 pt-6 text-sm"
+      >
+        <li>
+          Haven't owned residential property in the past 3 years
+        </li>
+        <li>
+          <p>
+            Meet our 
+            <a
+              href="https://sfmohcd.org/homebuyer-program-eligibility"
+              target="_blank"
             >
               income requirements
             </a>
@@ -1140,11 +865,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Household Maximum Income
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -1220,55 +945,72 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Occupancy
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          A minimum of one person per bedroom is required.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Occupancy
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            A minimum of one person per bedroom is required.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
         }
       >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              Unit Type
-            </th>
-            <th
-              className=""
-            >
-              Occupancy
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
+        <table
+          className="w-full text-sm"
         >
-          Lottery Preferences
-        </h3>
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                Unit Type
+              </th>
+              <th
+                className=""
+              >
+                Occupancy
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Lottery Preferences
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        className="flex justify-center"
+      >
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -1288,32 +1030,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             />
           </svg>
         </span>
-      </hgroup>
-    </header>
-    <div
-      className="flex justify-center"
-    >
-      <span
-        className="ui-icon ui-large spinner-animation"
-        data-test-id={null}
-      >
-        <svg
-          fill="currentColor"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            cx="50"
-            cy="50"
-            fill="none"
-            r="32"
-            stroke="currentColor"
-            strokeDasharray="150.79644737231007 52.26548245743669"
-            strokeWidth="9"
-          />
-        </svg>
-      </span>
-    </div>
-  </li>
+      </div>
+    </li>
+  </ul>
 </li>
 `;
 
@@ -1361,12 +1080,156 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Household Maximum Income
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            <div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  For income calculations, household size includes everyone (all ages) living in the unit.
+                </p>
+              </div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  People in your household may need 
+                  <a
+                    href="https://sfmohcd.org/special-calculations-household-income"
+                    target="_blank"
+                  >
+                    special income calculations
+                  </a>
+                   if they:
+                </p>
+              </div>
+              <ul
+                className="list-disc ml-5"
+              >
+                <li>
+                  Are full-time students (but not the primary applicant).
+                </li>
+                <li>
+                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
+                </li>
+              </ul>
+            </div>
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
         >
-          Household Maximum Income
-        </h3>
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                household size
+              </th>
+              <th
+                className=""
+              >
+                maximum income per month
+              </th>
+              <th
+                className=""
+              >
+                maximum income per year
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Occupancy
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Occupancy for this building varies by unit type. SROs are limited to 1 person per unit, regardless of age. For all other unit types, occupancy limits do not count children under 6.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
+        >
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                Unit Type
+              </th>
+              <th
+                className=""
+              >
+                Occupancy
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Lottery Preferences
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        className="flex justify-center"
+      >
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -1395,11 +1258,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Rental Assistance
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -1415,11 +1278,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Additional Eligibility Rules
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -1454,265 +1317,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              household size
-            </th>
-            <th
-              className=""
-            >
-              maximum income per month
-            </th>
-            <th
-              className=""
-            >
-              maximum income per year
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Occupancy
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Occupancy for this building varies by unit type. SROs are limited to 1 person per unit, regardless of age. For all other unit types, occupancy limits do not count children under 6.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              Unit Type
-            </th>
-            <th
-              className=""
-            >
-              Occupancy
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Lottery Preferences
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="flex justify-center"
-    >
-      <span
-        className="ui-icon ui-large spinner-animation"
-        data-test-id={null}
-      >
-        <svg
-          fill="currentColor"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            cx="50"
-            cy="50"
-            fill="none"
-            r="32"
-            stroke="currentColor"
-            strokeDasharray="150.79644737231007 52.26548245743669"
-            strokeWidth="9"
-          />
-        </svg>
-      </span>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Rental Assistance
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
-        </span>
-      </hgroup>
-    </header>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Additional Eligibility Rules
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Applicants must also qualify under the rules of the building.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Credit History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
-          </p>
-          <p>
-            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
-          </p>
-          <p>
-            Collection accounts...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Rental History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
-          </p>
-          <p>
-            Previous rental history will be reviewed and must exhibit no derogatory references. 
-          </p>
-          <p>
-            Landlord references will only check for...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Criminal Background
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <span>
-          Qualified applicants with criminal history will be considered for housing in compliance with 
-          <a
-            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
-            target="_blank"
+          <button
+            className="button-toggle ml-4"
+            onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -1742,12 +1352,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Landlord references will only check for...
             </p>
           </div>
-          <span
+          <button
             className="button-toggle ml-4"
             onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -1842,12 +1452,156 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Household Maximum Income
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            <div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  For income calculations, household size includes everyone (all ages) living in the unit.
+                </p>
+              </div>
+              <div
+                className="mb-4"
+              >
+                <p>
+                  People in your household may need 
+                  <a
+                    href="https://sfmohcd.org/special-calculations-household-income"
+                    target="_blank"
+                  >
+                    special income calculations
+                  </a>
+                   if they:
+                </p>
+              </div>
+              <ul
+                className="list-disc ml-5"
+              >
+                <li>
+                  Are full-time students (but not the primary applicant).
+                </li>
+                <li>
+                  Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).
+                </li>
+              </ul>
+            </div>
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
         >
-          Household Maximum Income
-        </h3>
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                household size
+              </th>
+              <th
+                className=""
+              >
+                maximum income per month
+              </th>
+              <th
+                className=""
+              >
+                maximum income per year
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Occupancy
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Occupancy for this building is limited to 1 person per unit.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
+        }
+      >
+        <table
+          className="w-full text-sm"
+        >
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                Unit Type
+              </th>
+              <th
+                className=""
+              >
+                Occupancy
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Lottery Preferences
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        className="flex justify-center"
+      >
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}
@@ -1876,11 +1630,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Rental Assistance
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -1896,11 +1650,11 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Additional Eligibility Rules
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -1935,265 +1689,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Collection accounts...
             </p>
           </div>
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              household size
-            </th>
-            <th
-              className=""
-            >
-              maximum income per month
-            </th>
-            <th
-              className=""
-            >
-              maximum income per year
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Occupancy
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Occupancy for this building is limited to 1 person per unit.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
-        }
-      }
-    >
-      <table
-        className="w-full text-sm"
-      >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              Unit Type
-            </th>
-            <th
-              className=""
-            >
-              Occupancy
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Lottery Preferences
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="flex justify-center"
-    >
-      <span
-        className="ui-icon ui-large spinner-animation"
-        data-test-id={null}
-      >
-        <svg
-          fill="currentColor"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            cx="50"
-            cy="50"
-            fill="none"
-            r="32"
-            stroke="currentColor"
-            strokeDasharray="150.79644737231007 52.26548245743669"
-            strokeWidth="9"
-          />
-        </svg>
-      </span>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Rental Assistance
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Section 8 housing vouchers and other valid rental assistance programs can be used for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.
-        </span>
-      </hgroup>
-    </header>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Additional Eligibility Rules
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Applicants must also qualify under the rules of the building.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Credit History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
-          </p>
-          <p>
-            Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
-          </p>
-          <p>
-            Collection accounts...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Rental History
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <div>
-          <p>
-            Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
-          </p>
-          <p>
-            Previous rental history will be reviewed and must exhibit no derogatory references. 
-          </p>
-          <p>
-            Landlord references will only check for...
-          </p>
-        </div>
-        <button
-          className="button-toggle ml-4"
-          onClick={[Function]}
-        >
-          More
-        </button>
-      </div>
-    </div>
-    <div
-      className="info-card"
-    >
-      <div
-        className="info-card__header"
-      >
-        <h3
-          className="info-card__title"
-        >
-          Criminal Background
-        </h3>
-      </div>
-      <div
-        className="expandable-text text-sm text-gray-700"
-      >
-         
-        <span>
-          Qualified applicants with criminal history will be considered for housing in compliance with 
-          <a
-            href="https://sfgov.org/olse/sites/default/files/FileCenter/Documents/12136-FCO%20FAQs%20Final.pdf"
-            target="_blank"
+          <button
+            className="button-toggle ml-4"
+            onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -2223,12 +1724,12 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               Landlord references will only check for...
             </p>
           </div>
-          <span
+          <button
             className="button-toggle ml-4"
             onClick={[Function]}
           >
             More
-          </span>
+          </button>
         </div>
       </div>
       <div
@@ -2323,63 +1824,15 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Before applying
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          Make sure you:
-        </span>
-      </hgroup>
-    </header>
-    <ol
-      className="numbered-list my-5 bg-white p-4 pt-6 text-sm"
-    >
-      <li>
-        <p>
-          Go to a 
-          <a
-            href="https://habitatgsf.org/amber-drive-info/"
-            target="_blank"
-          >
-            Habitat for Humanity information session
-          </a>
-        </p>
-      </li>
-      <li>
-        Haven't owned residential property in the past 3 years
-      </li>
-      <li>
-        <p>
-          Meet the 
-          <a
-            href="https://sfmohcd.org/sites/default/files/Documents/MOH/Inclusionary%20Manuals/Inclusionary%20Affordable%20Housing%20Program%20Manual%2010.15.2018.pdf"
-            target="_blank"
-          >
-            income requirements
-          </a>
-        </p>
-      </li>
-      <li>
-        Have a 650 credit score or higher
-      </li>
-    </ol>
-    <p>
-      Read 
-      <a
-        href="https://habitatgsf.org/amber-drive-info/"
-        target="_blank"
+      <header
+        className="list-section__header custom-counter__header"
       >
         <hgroup>
-          <h4
+          <h3
             className="custom-counter__title"
           >
             Before applying
-          </h4>
+          </h3>
           <span
             className="custom-counter__subtitle"
           >
@@ -2433,55 +1886,72 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
     <li
       className="list-section custom-counter__item"
     >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
-        >
-          Occupancy
-        </h3>
-        <span
-          className="custom-counter__subtitle"
-        >
-          A minimum of one person per bedroom is required.
-        </span>
-      </hgroup>
-    </header>
-    <div
-      style={
-        Object {
-          "overflowX": "auto",
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Occupancy
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            A minimum of one person per bedroom is required.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        style={
+          Object {
+            "overflowX": "auto",
+          }
         }
       >
-        <thead>
-          <tr>
-            <th
-              className=""
-            >
-              Unit Type
-            </th>
-            <th
-              className=""
-            >
-              Occupancy
-            </th>
-          </tr>
-        </thead>
-        <tbody />
-      </table>
-    </div>
-  </li>
-  <li
-    className="list-section custom-counter__item"
-  >
-    <header
-      className="list-section__header custom-counter__header"
-    >
-      <hgroup>
-        <h3
-          className="custom-counter__title"
+        <table
+          className="w-full text-sm"
         >
-          Lottery Preferences
-        </h3>
+          <thead>
+            <tr>
+              <th
+                className=""
+              >
+                Unit Type
+              </th>
+              <th
+                className=""
+              >
+                Occupancy
+              </th>
+            </tr>
+          </thead>
+          <tbody />
+        </table>
+      </div>
+    </li>
+    <li
+      className="list-section custom-counter__item"
+    >
+      <header
+        className="list-section__header custom-counter__header"
+      >
+        <hgroup>
+          <h3
+            className="custom-counter__title"
+          >
+            Lottery Preferences
+          </h3>
+          <span
+            className="custom-counter__subtitle"
+          >
+            Anyone may enter the housing lottery for this listing. If your household has one of the following preferences, you will be considered in the order shown here. Each preference holder will be reviewed in lottery rank order.
+          </span>
+        </hgroup>
+      </header>
+      <div
+        className="flex justify-center"
+      >
         <span
           className="ui-icon ui-large spinner-animation"
           data-test-id={null}

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsHabitat.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsHabitat.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
   className="md:pr-8 md:w-2/3 mt-4 mx-2 w-full"
 >
   <h4
-    className="text-caps-underline undefined"
+    className="text__underline-weighted"
   >
     Payments
   </h4>
@@ -13,7 +13,7 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
     Your monthly housing payment will be 30% of your gross monthly income. The housing payment includes your mortgage, property tax, insurance, HOA fee, and utilities.
   </p>
   <h4
-    className="text-caps-underline mt-8"
+    className="text__underline-weighted mt-8"
   >
     Sweat Equity
   </h4>
@@ -26,7 +26,7 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
     If you are concerned about your ability to complete 500 hours of sweat equity, reach out to Habitat for Humanity Greater San Francisco to ask how they can help.
   </p>
   <h4
-    className="text-caps-underline mt-8"
+    className="text__underline-weighted mt-8"
   >
     Application Process
   </h4>
@@ -86,7 +86,7 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
     </li>
   </ol>
   <h4
-    className="text-caps-underline mt-8"
+    className="text__underline-weighted mt-8"
   >
     Income Range
   </h4>

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsImageCard.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsImageCard.test.tsx.snap
@@ -18,12 +18,12 @@ exports[`ListingDetailsImageCard displays image card when no tag 1`] = `
         className="image-card__inner"
       >
         <img
-          alt="TEST Sale Listing (do not modify) - Homeownership Acres"
+          alt="A picture of the building"
           src="https://d31h23p2gsu1kr.cloudfront.net/images/listings/a0W0P00000GlKfBUAV-4d20089ed488fce1a695b73a8a4f090d.jpg"
         />
       </figure>
       <aside
-        aria-label="TEST Sale Listing (do not modify) - Homeownership Acres Statuses"
+        aria-label="A picture of the building Statuses"
         className="image-card__status"
       />
     </div>
@@ -119,12 +119,12 @@ exports[`ListingDetailsImageCard displays tag when listing is habitat for humani
         className="image-card__inner"
       >
         <img
-          alt="TEST: 36 Amber Drive"
+          alt="A picture of the building"
           src="https://d31h23p2gsu1kr.cloudfront.net/images/listings/a0W0P00000GlKfBUAV-4d20089ed488fce1a695b73a8a4f090d.jpg"
         />
       </figure>
       <aside
-        aria-label="TEST: 36 Amber Drive Statuses"
+        aria-label="A picture of the building Statuses"
         className="image-card__status"
       />
     </div>

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsImageCard.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsImageCard.test.tsx.snap
@@ -18,10 +18,14 @@ exports[`ListingDetailsImageCard displays image card when no tag 1`] = `
         className="image-card__inner"
       >
         <img
-          alt="A picture of the building"
+          alt="TEST Sale Listing (do not modify) - Homeownership Acres"
           src="https://d31h23p2gsu1kr.cloudfront.net/images/listings/a0W0P00000GlKfBUAV-4d20089ed488fce1a695b73a8a4f090d.jpg"
         />
       </figure>
+      <aside
+        aria-label="TEST Sale Listing (do not modify) - Homeownership Acres Statuses"
+        className="image-card__status"
+      />
     </div>
   </a>
   <div
@@ -115,10 +119,14 @@ exports[`ListingDetailsImageCard displays tag when listing is habitat for humani
         className="image-card__inner"
       >
         <img
-          alt="A picture of the building"
+          alt="TEST: 36 Amber Drive"
           src="https://d31h23p2gsu1kr.cloudfront.net/images/listings/a0W0P00000GlKfBUAV-4d20089ed488fce1a695b73a8a4f090d.jpg"
         />
       </figure>
+      <aside
+        aria-label="TEST: 36 Amber Drive Statuses"
+        className="image-card__status"
+      />
     </div>
   </a>
   <div

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsPreferences.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsPreferences.test.tsx.snap
@@ -8,11 +8,11 @@ exports[`ListingDetailsPreferences display 3 default preferences - COP, DTHP, L/
     className="list-section__header custom-counter__header"
   >
     <hgroup>
-      <h4
+      <h3
         className="custom-counter__title"
       >
         Lottery Preferences
-      </h4>
+      </h3>
       <span
         className="custom-counter__subtitle"
       >
@@ -165,11 +165,11 @@ exports[`ListingDetailsPreferences display 6 preferences 1`] = `
     className="list-section__header custom-counter__header"
   >
     <hgroup>
-      <h4
+      <h3
         className="custom-counter__title"
       >
         Lottery Preferences
-      </h4>
+      </h3>
       <span
         className="custom-counter__subtitle"
       >

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
@@ -43,7 +43,7 @@ Array [
       className="aside-block"
     >
       <h4
-        className="text-caps-underline undefined"
+        className="text-caps-underline"
       >
         Contact
       </h4>
@@ -106,17 +106,21 @@ Array [
           Email
         </a>
       </p>
-      <h3
-        className="text-caps-tiny undefined"
-      >
-        Office Hours
-      </h3>
       <div
-        className="text-gray-800 text-tiny markdown"
+        className="my-3"
       >
-        <span>
-          Monday - Friday 10:00 AM - 6:00 PM
-        </span>
+        <h3
+          className="text-caps-tiny"
+        >
+          Office Hours
+        </h3>
+        <div
+          className="text-gray-800 text-tiny markdown"
+        >
+          <span>
+            Monday - Friday 10:00 AM - 6:00 PM
+          </span>
+        </div>
       </div>
     </section>
   </div>,

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
@@ -9,7 +9,7 @@ Array [
       className="aside-block"
     >
       <h4
-        className="text-caps-underline"
+        className="text__underline-weighted"
       >
         What to Expect
       </h4>
@@ -43,7 +43,7 @@ Array [
       className="aside-block"
     >
       <h4
-        className="text-caps-underline"
+        className="text__underline-weighted"
       >
         Contact
       </h4>
@@ -110,7 +110,7 @@ Array [
         className="my-3"
       >
         <h3
-          className="text-caps-tiny"
+          className="text__caps-weighted"
         >
           Office Hours
         </h3>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
@@ -71,7 +71,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline undefined"
+      className="text-caps-underline"
     >
       How to Apply
     </h4>
@@ -100,6 +100,7 @@ Array [
       <a
         className="button is-primary w-full transition"
         href="listings/a0W0P00000GlKfBUAV/apply-welcome/intro"
+        tabIndex={0}
       >
         Apply Online
       </a>
@@ -109,7 +110,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline undefined"
+      className="text-caps-underline"
     >
       Need Help?
     </h4>
@@ -129,7 +130,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline undefined"
+      className="text-caps-underline"
     >
       Expected move-in date
     </h4>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
@@ -71,7 +71,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline"
+      className="text__underline-weighted"
     >
       How to Apply
     </h4>
@@ -110,7 +110,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline"
+      className="text__underline-weighted"
     >
       Need Help?
     </h4>
@@ -130,7 +130,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline"
+      className="text__underline-weighted"
     >
       Expected move-in date
     </h4>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
@@ -6,7 +6,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline undefined"
+      className="text__underline-weighted"
     >
       How to Apply
     </h4>
@@ -35,6 +35,7 @@ Array [
       <a
         className="button is-primary w-full transition"
         href="listings/a0W8H000000HI2uUAG/apply-welcome/intro"
+        tabIndex={0}
       >
         Apply Online
       </a>
@@ -44,7 +45,7 @@ Array [
     className="aside-block "
   >
     <h4
-      className="text-caps-underline undefined"
+      className="text__underline-weighted"
     >
       Need Help?
     </h4>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsOpenHouses.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsOpenHouses.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ListingDetailsOpenHouses displays Open Houses with Listing containing O
     className="aside-block"
   >
     <h4
-      className="text-caps-underline"
+      className="text__underline-weighted"
     >
       Open Houses
     </h4>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsOpenHouses.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsOpenHouses.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ListingDetailsOpenHouses displays Open Houses with Listing containing O
     className="aside-block"
   >
     <h4
-      className="text-caps-underline undefined"
+      className="text-caps-underline"
     >
       Open Houses
     </h4>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsWaitlist.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsWaitlist.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ListingDetailsWaitlist renders waitlist section if listing has waitlist
     className="aside-block is-tinted"
   >
     <h4
-      className="text-caps-tiny"
+      className="text__caps-weighted"
     >
       Available units and waitlist
     </h4>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
@@ -9,7 +9,7 @@ Array [
       className="aside-block "
     >
       <h4
-        className="text-caps-underline"
+        className="text__underline-weighted"
       >
         Lottery
       </h4>
@@ -52,7 +52,7 @@ Array [
       className="aside-block "
     >
       <h4
-        className="text-caps-underline"
+        className="text__underline-weighted"
       >
         Lottery Results
       </h4>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
@@ -9,7 +9,7 @@ Array [
       className="aside-block "
     >
       <h4
-        className="text-caps-underline undefined"
+        className="text-caps-underline"
       >
         Lottery
       </h4>
@@ -52,7 +52,7 @@ Array [
       className="aside-block "
     >
       <h4
-        className="text-caps-underline undefined"
+        className="text-caps-underline"
       >
         Lottery Results
       </h4>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
     className="border-b border-gray-450 mb-4"
   >
     <h2
-      className="text-caps-underline mx-8"
+      className="text__underline-weighted mx-8"
     >
       Housing Preferences
     </h2>
@@ -116,7 +116,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
     className="border-b border-gray-450 mb-4"
   >
     <h2
-      className="text-caps-underline mx-8"
+      className="text__underline-weighted mx-8"
     >
       Housing Preferences
     </h2>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
     className="border-b border-gray-450 mb-4"
   >
     <h2
-      className="undefined text-caps-underline mx-8"
+      className="text-caps-underline mx-8"
     >
       Housing Preferences
     </h2>
@@ -28,7 +28,7 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
       className="px-8 "
     >
       <h3
-        className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold text-tiny tracking-wide uppercase"
       >
         Neighborhood Resident Housing Preference (NRHP)
       </h3>
@@ -52,7 +52,7 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
       className="px-8 "
     >
       <h3
-        className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold text-tiny tracking-wide uppercase"
       >
         Live or Work in San Francisco Preference
       </h3>
@@ -82,7 +82,7 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
     className="px-8"
   >
     <h3
-      className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+      className="font-sans font-semibold text-tiny tracking-wide uppercase"
     >
       General Pool
     </h3>
@@ -116,7 +116,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
     className="border-b border-gray-450 mb-4"
   >
     <h2
-      className="undefined text-caps-underline mx-8"
+      className="text-caps-underline mx-8"
     >
       Housing Preferences
     </h2>
@@ -131,7 +131,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
       className="px-8 "
     >
       <h3
-        className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold text-tiny tracking-wide uppercase"
       >
         Certificate of Preference (COP)
       </h3>
@@ -155,7 +155,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
       className="px-8 "
     >
       <h3
-        className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold text-tiny tracking-wide uppercase"
       >
         Displaced Tenant Housing Preference (DTHP)
       </h3>
@@ -179,7 +179,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
       className="px-8 "
     >
       <h3
-        className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold text-tiny tracking-wide uppercase"
       >
         Live or Work in San Francisco Preference
       </h3>
@@ -209,7 +209,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
     className="px-8"
   >
     <h3
-      className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+      className="font-sans font-semibold text-tiny tracking-wide uppercase"
     >
       General Pool
     </h3>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with o
     className="px-8"
   >
     <h2
-      className="undefined text-caps-underline"
+      className="text-caps-underline"
     >
       Your preference ranking
     </h2>
@@ -57,7 +57,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with o
       className="mx-4"
     >
       <h3
-        className="undefined font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
       >
         Live or Work in San Francisco Preference
       </h3>
@@ -100,7 +100,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with t
     className="px-8"
   >
     <h2
-      className="undefined text-caps-underline"
+      className="text-caps-underline"
     >
       Your preference ranking
     </h2>
@@ -129,7 +129,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with t
       className="mx-4"
     >
       <h3
-        className="undefined font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
       >
         Certificate of Preference (COP)
       </h3>
@@ -164,7 +164,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with t
       className="mx-4"
     >
       <h3
-        className="undefined font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
       >
         Live or Work in San Francisco Preference
       </h3>
@@ -242,7 +242,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for sale with gen
       className="mx-4"
     >
       <h3
-        className="undefined font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
+        className="font-sans font-semibold mb-1 text-tiny tracking-wide uppercase"
       >
         General Pool
       </h3>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with o
     className="px-8"
   >
     <h2
-      className="text-caps-underline"
+      className="text__underline-weighted"
     >
       Your preference ranking
     </h2>
@@ -100,7 +100,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with t
     className="px-8"
   >
     <h2
-      className="text-caps-underline"
+      className="text__underline-weighted"
     >
       Your preference ranking
     </h2>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
@@ -5,11 +5,11 @@ exports[`ListingDetailsLotteryResults displays if lottery is complete 1`] = `
   <div
     class="border-b pt-4 text-center"
   >
-    <h4
-      class="undefined mb-4"
+    <h3
+      class="mb-4"
     >
       Lottery Results
-    </h4>
+    </h3>
     <p
       class="mb-4 text-sm"
     >
@@ -20,6 +20,7 @@ exports[`ListingDetailsLotteryResults displays if lottery is complete 1`] = `
     >
       <button
         class="button is-primary is-small"
+        tabindex="0"
       >
         View Lottery Results
       </button>
@@ -33,11 +34,11 @@ exports[`ListingDetailsLotteryResults displays with summary if lottery is comple
   <div
     class="border-b pt-4 text-center"
   >
-    <h4
-      class="undefined mb-4"
+    <h3
+      class="mb-4"
     >
       Lottery Results
-    </h4>
+    </h3>
     <p
       class="mb-4 text-sm"
     >
@@ -55,6 +56,7 @@ exports[`ListingDetailsLotteryResults displays with summary if lottery is comple
       </div>
       <button
         class="button is-primary is-small"
+        tabindex="0"
       >
         View Lottery Results
       </button>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
         className="border-b border-gray-450 mb-4"
       >
         <h2
-          className="text-caps-underline mx-8"
+          className="text__underline-weighted mx-8"
         >
           Housing Preferences
         </h2>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
     className="pt-8 pb-4 text-center bg-white sticky top-0 z-50"
   >
     <h1
-      className="undefined undefined"
+      className=""
     >
       Lottery Results
     </h1>
@@ -84,7 +84,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
         className="border-b border-gray-450 mb-4"
       >
         <h2
-          className="undefined text-caps-underline mx-8"
+          className="text-caps-underline mx-8"
         >
           Housing Preferences
         </h2>
@@ -99,7 +99,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
           className="px-8 "
         >
           <h3
-            className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+            className="font-sans font-semibold text-tiny tracking-wide uppercase"
           >
             Certificate of Preference (COP)
           </h3>
@@ -123,7 +123,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
           className="px-8 "
         >
           <h3
-            className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+            className="font-sans font-semibold text-tiny tracking-wide uppercase"
           >
             Displaced Tenant Housing Preference (DTHP)
           </h3>
@@ -147,7 +147,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
           className="px-8 "
         >
           <h3
-            className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+            className="font-sans font-semibold text-tiny tracking-wide uppercase"
           >
             Live or Work in San Francisco Preference
           </h3>
@@ -177,7 +177,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
         className="px-8"
       >
         <h3
-          className="undefined font-sans font-semibold text-tiny tracking-wide uppercase"
+          className="font-sans font-semibold text-tiny tracking-wide uppercase"
         >
           General Pool
         </h3>

--- a/app/javascript/components/BeforeApplyingForSale.tsx
+++ b/app/javascript/components/BeforeApplyingForSale.tsx
@@ -111,7 +111,7 @@ export const BeforeApplyingForSale = ({ beforeApplyingType }: BeforeApplyingForS
     </ListSection>
   ) : (
     <div className="mb-8">
-      <Heading className="mb-5" priority={2} style={"sidebarHeader"}>
+      <Heading className="mb-5" priority={2} styleType={"underlineWeighted"}>
         {t("saleDirectory.beforeApplying.title")}
       </Heading>
       <p>{t("saleDirectory.beforeApplying.makeSureYou")}</p>

--- a/app/javascript/modules/listingDetails/ListingDetailsHabitat.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsHabitat.tsx
@@ -13,16 +13,16 @@ export const ListingDetailsHabitat = ({ listing }: ListingDetailsHabitatProps) =
 
   return (
     <div className="md:pr-8 md:w-2/3 mt-4 mx-2 w-full">
-      <Heading priority={4} style="sidebarHeader">
+      <Heading priority={4} styleType="underlineWeighted">
         {t("listings.habitat.payments.title")}
       </Heading>
       <p>{t("listings.habitat.payments.p1")}</p>
-      <Heading className="mt-8" priority={4} style="sidebarHeader">
+      <Heading className="mt-8" priority={4} styleType="underlineWeighted">
         {t("listings.habitat.sweatEquity.title")}
       </Heading>
       <p>{t("listings.habitat.sweatEquity.p1")}</p>
       <p className="mt-4">{t("listings.habitat.sweatEquity.p2")}</p>
-      <Heading className="mt-8" priority={4} style="sidebarHeader">
+      <Heading className="mt-8" priority={4} styleType="underlineWeighted">
         {t("listings.habitat.applicationProcess.title")}
       </Heading>
       <p>
@@ -50,7 +50,7 @@ export const ListingDetailsHabitat = ({ listing }: ListingDetailsHabitatProps) =
         <li>{t("listings.habitat.applicationProcess.ol9")}</li>
         <li>{t("listings.habitat.applicationProcess.ol10")}</li>
       </ol>
-      <Heading className="mt-8" priority={4} style="sidebarHeader">
+      <Heading className="mt-8" priority={4} styleType="underlineWeighted">
         {t("listings.habitat.incomeRange.title")}
       </Heading>
       <p>{t("listings.habitat.incomeRange.p1")}</p>

--- a/app/javascript/modules/listingDetails/ListingDetailsImageCard.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsImageCard.tsx
@@ -29,7 +29,7 @@ export const ListingDetailsImageCard = ({ listing }: ListingDetailsImageCardProp
             ? [{ text: getReservedCommunityType(listing.Reserved_community_type) }]
             : undefined
         }
-        description={listing?.Name}
+        description={"A picture of the building"}
       />
       <div className="flex flex-col md:items-start md:text-left p-3 text-center">
         <h1 className="font-sans font-semibold text-3xl">{listing.Name}</h1>

--- a/app/javascript/modules/listingDetails/ListingDetailsImageCard.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsImageCard.tsx
@@ -29,6 +29,7 @@ export const ListingDetailsImageCard = ({ listing }: ListingDetailsImageCardProp
             ? [{ text: getReservedCommunityType(listing.Reserved_community_type) }]
             : undefined
         }
+        description={listing?.Name}
       />
       <div className="flex flex-col md:items-start md:text-left p-3 text-center">
         <h1 className="font-sans font-semibold text-3xl">{listing.Name}</h1>

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
@@ -121,7 +121,7 @@ export const ListingDetailsApply = ({ listing }: ListingDetailsApplyProps) => {
       </SidebarBlock>
       <SidebarBlock
         className={"bg-blue-200"}
-        style={"sidebarSubHeader"}
+        styleType={"capsWeighted"}
         title={t("listings.apply.sendByUsMail")}
       >
         <div className={"mb-2 text-gray-900 text-base"}>

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.tsx
@@ -14,7 +14,7 @@ export const ListingDetailsLotteryPreferences = ({
     <div className="text-tiny">
       <p className="px-8 pb-4 text-sm">{t("lottery.bucketsIntro")}</p>
       <header className="border-b border-gray-450 mb-4">
-        <Heading className="text-caps-underline mx-8" priority={2}>
+        <Heading styleType="underlineWeighted" className="mx-8" priority={2}>
           {t("lottery.housingPreferences")}
         </Heading>
         <p className="pb-4 text-gray-700 text-sm mx-8">{t("lottery.rankingOrderNote")}</p>

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryRanking.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryRanking.tsx
@@ -42,7 +42,7 @@ export const ListingDetailsLotteryRanking = ({
       <div className="lottery-ranking text-tiny">
         {applicantSelectedForPreference && (
           <header className="px-8">
-            <Heading className="text-caps-underline" priority={2}>
+            <Heading styleType="underlineWeighted" priority={2}>
               {t("lottery.rankingTitle")}
             </Heading>
             <p className="border-b border-gray-450 pb-4 text-gray-700">

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryResults.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryResults.tsx
@@ -35,7 +35,7 @@ export const ListingDetailsLotteryResults = ({ listing }: ListingDetailsLotteryR
     isLotteryComplete(listing) && (
       <ErrorBoundary boundaryScope={BoundaryScope.component}>
         <div className="border-b pt-4 text-center">
-          <Heading className="mb-4" priority={4}>
+          <Heading className="mb-4" priority={3}>
             {t("lottery.lotteryResults")}
           </Heading>
           <p className="mb-4 text-sm">{localizedFormat(listing.Lottery_Results_Date, "LL")}</p>

--- a/app/javascript/modules/listings/BuyHeader.tsx
+++ b/app/javascript/modules/listings/BuyHeader.tsx
@@ -6,7 +6,7 @@ import { BeforeApplyingForSale, BeforeApplyingType } from "../../components/Befo
 
 const GetHelp = () => (
   <div className="md:bg-white md:p-4">
-    <Heading className="mb-5" priority={2} underline>
+    <Heading styleType="underlineWeighted" className="mb-5" priority={2}>
       {t("saleDirectory.getHelp.title")}
     </Heading>
     <p className="mb-4">{t("saleDirectory.getHelp.somePeopleMayQualify")}</p>

--- a/app/javascript/modules/listings/HabitatForHumanity.tsx
+++ b/app/javascript/modules/listings/HabitatForHumanity.tsx
@@ -27,15 +27,15 @@ export const getHabitatContent = (listing, stackedDataFxn) => {
 
   return (
     <>
-      <Heading priority={2} style={"cardHeader"} className={"order-1"}>
+      <Heading priority={2} styleType={"largePrimary"} className={"order-1"}>
         {listing.Name}
       </Heading>
-      <Heading priority={3} style={"cardSubheader"} className={"order-2"}>
+      <Heading priority={3} styleType={"mediumNormal"} className={"order-2"}>
         <ListingAddress listing={listing} />
       </Heading>
       <hr className={"mb-2"} />
       <div className={"text-gray-750"}>
-        <Heading priority={3} style={"tableHeader"}>
+        <Heading priority={3} styleType={"smallWeighted"}>
           {t("listings.availableUnits")}
         </Heading>
         {getHeader(t("t.units"))}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "^5.1.1-alpha.8",
+    "@bloom-housing/ui-components": "^6.0.1-alpha.2",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "^6.0.1-alpha.2",
+    "@bloom-housing/ui-components": "^6.0.1-alpha.3",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,10 +1205,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@^5.1.1-alpha.8":
-  version "5.1.1-alpha.8"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-5.1.1-alpha.8.tgz#e8364bbe9d3bb2673a13d00247e254269c643076"
-  integrity sha512-sutBNeh4Cb4Kc+IOeb2CvSGExacmCIVH0Hq9sqbyLC4uk+tr67DLiD+GoEBkYFoNQPIaw8gAr4UiUYr+PqzXlw==
+"@bloom-housing/ui-components@^6.0.1-alpha.2":
+  version "6.0.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-6.0.1-alpha.2.tgz#321f20e47d2e8cf01a00e8c2791e2dc25550ce1a"
+  integrity sha512-Uv2Z3yr8Fi0P1mNTWTPJ9HQaj41dmSPWPvi7fbi31GO8Uv5lxn/TTZMUwIlZ2ndNaApXUnzxUwWb6RMBGdchDA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,10 +1205,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@^6.0.1-alpha.2":
-  version "6.0.1-alpha.2"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-6.0.1-alpha.2.tgz#321f20e47d2e8cf01a00e8c2791e2dc25550ce1a"
-  integrity sha512-Uv2Z3yr8Fi0P1mNTWTPJ9HQaj41dmSPWPvi7fbi31GO8Uv5lxn/TTZMUwIlZ2ndNaApXUnzxUwWb6RMBGdchDA==
+"@bloom-housing/ui-components@^6.0.1-alpha.3":
+  version "6.0.1-alpha.3"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-6.0.1-alpha.3.tgz#afe3fb81b65ce65b29e5c45d2155c669e03f8035"
+  integrity sha512-8x7M2YGXww7oKLJlUus04Bwx4v+wfSMs0ecty4pTJXBWUyZgjvVk2jsSpDoI7DTLOiig1wAtjqYbp1FMW2DATg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"


### PR DESCRIPTION
This PR uptakes latest ui-components which includes the fixes in [DAH-1223](https://sfgovdt.jira.com/jira/software/c/projects/DAH/boards/122?modal=detail&selectedIssue=DAH-1223).

For testing DAH-1223:
To test the padding issue where there is no email, see this listing `listings/a0W4U00000KnazlUAB` ([link](https://dahlia-webapp-pr-1728.herokuapp.com/listings/a0W4U00000KnazlUAB?react=true))
To test the empty phone issue, see this listing `listings/a0W4U00000KnScyUAF` ([link](https://dahlia-webapp-pr-1728.herokuapp.com/listings/a0W4U00000KnScyUAF?react=true))

In terms of other changes that have gone into Bloom that we are picking up:
A number of accessibility improvements which include updating spans with onClicks to buttons, updating the heading priority level of the list sections on the detail page so that they don't increase by 2 levels, and adding a tab index to some focusable elements. We also removed some class names from being sent as `undefined` if its prop was empty, and renamed our text styles which was a breaking change for the `Heading` component ([context](https://exygy.slack.com/archives/C040EKUAKTK/p1664839936759559)).