### PR TITLE
DAH-1382 handle no units on directory page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/web
   docker:
-    - image: cimg/ruby:2.6.10-browsers
+    - image: cimg/ruby:2.6.8-browsers
       environment:
         RAILS_ENV: development
         PGHOST: 127.0.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/web
   docker:
-    - image: cimg/ruby:2.5.9-browsers
+    - image: cimg/ruby:2.6.10-browsers
       environment:
         RAILS_ENV: development
         PGHOST: 127.0.0.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.9'
+ruby '2.6.6'
 
 # same method is used in https://github.com/rails/rails/blob/master/Gemfile
 git_source(:github) do |repo_name|

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.6'
+ruby '2.6.10'
 
 # same method is used in https://github.com/rails/rails/blob/master/Gemfile
 git_source(:github) do |repo_name|

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.10'
+ruby '2.6.8'
 
 # same method is used in https://github.com/rails/rails/blob/master/Gemfile
 git_source(:github) do |repo_name|

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.6.10p210
 
 BUNDLED WITH
    2.2.31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.6.10p210
+   ruby 2.6.8p205
 
 BUNDLED WITH
    2.2.31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.5.9p229
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.2.31

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains the source code for [housing.sfgov.org](https://housing
 Before you install DAHLIA, your system should have the following:
 
 - [Homebrew](http://brew.sh)
-- [Ruby](https://www.ruby-lang.org/en/documentation/installation/) 2.6.10 (Use [RVM]
+- [Ruby](https://www.ruby-lang.org/en/documentation/installation/) 2.6.8 (Use [RVM]
   (https://rvm.io/rvm/install) or [rbenv](https://github.com/rbenv/rbenv))
 - [Bundler](https://github.com/bundler/bundler) `gem install bundler`
 - [PostgreSQL](https://postgresapp.com/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This repository contains the source code for [housing.sfgov.org](https://housing
 Before you install DAHLIA, your system should have the following:
 
 - [Homebrew](http://brew.sh)
-- [Ruby](https://www.ruby-lang.org/en/documentation/installation/) 2.5.9 (Use [RVM](https://rvm.io/rvm/install) or [rbenv](https://github.com/rbenv/rbenv))
+- [Ruby](https://www.ruby-lang.org/en/documentation/installation/) 2.6.10 (Use [RVM]
+  (https://rvm.io/rvm/install) or [rbenv](https://github.com/rbenv/rbenv))
 - [Bundler](https://github.com/bundler/bundler) `gem install bundler`
 - [PostgreSQL](https://postgresapp.com/)
 - [Node.js](https://nodejs.org/en/) 14.19.3

--- a/app/javascript/pages/listings/for-sale.tsx
+++ b/app/javascript/pages/listings/for-sale.tsx
@@ -21,8 +21,11 @@ import {
 import BuyHeader from "../../modules/listings/BuyHeader"
 import { defaultIfNotTranslated } from "../../util/languageUtil"
 
-const getForSaleSummaryTable = (listing: RailsSaleListing) =>
-  listing.unitSummaries.general
+const getForSaleSummaryTable = (listing: RailsSaleListing) => {
+  const summary = listing.unitSummaries.general ?? listing.unitSummaries.reserved
+  if (!summary) return null
+
+  return listing.unitSummaries.general
     .filter((summary) => !!summary.unitType)
     .map((summary) => ({
       unitType: {
@@ -53,6 +56,7 @@ const getForSaleSummaryTable = (listing: RailsSaleListing) =>
         ),
       },
     }))
+}
 
 const getBuyHeader = (
   filters: EligibilityFilters,


### PR DESCRIPTION
There was a sale listing on full with no units which was causing the directory page to not display any listings. Applying same fix for now as rental directory page until we discuss how we want to handle no units listings.

Also ran into some non-related build failures. Upgrading ruby 2.5.9 → 2.6.8 