### PR TITLE
DAH-1337 update markdown-to-jsx version

### DIFF
--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
@@ -107,17 +107,29 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                household size
+                <span
+                  className=""
+                >
+                  household size
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per month
+                <span
+                  className=""
+                >
+                  maximum income per month
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per year
+                <span
+                  className=""
+                >
+                  maximum income per year
+                </span>
               </th>
             </tr>
           </thead>
@@ -159,12 +171,20 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                Unit Type
+                <span
+                  className=""
+                >
+                  Unit Type
+                </span>
               </th>
               <th
                 className=""
               >
-                Occupancy
+                <span
+                  className=""
+                >
+                  Occupancy
+                </span>
               </th>
             </tr>
           </thead>
@@ -272,10 +292,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application.
             </p>
             <p>
-              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required.
             </p>
             <p>
               Collection accounts...
@@ -307,10 +327,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted.
             </p>
             <p>
-              Previous rental history will be reviewed and must exhibit no derogatory references. 
+              Previous rental history will be reviewed and must exhibit no derogatory references.
             </p>
             <p>
               Landlord references will only check for...
@@ -472,17 +492,29 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                household size
+                <span
+                  className=""
+                >
+                  household size
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per month
+                <span
+                  className=""
+                >
+                  maximum income per month
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per year
+                <span
+                  className=""
+                >
+                  maximum income per year
+                </span>
               </th>
             </tr>
           </thead>
@@ -524,12 +556,20 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                Unit Type
+                <span
+                  className=""
+                >
+                  Unit Type
+                </span>
               </th>
               <th
                 className=""
               >
-                Occupancy
+                <span
+                  className=""
+                >
+                  Occupancy
+                </span>
               </th>
             </tr>
           </thead>
@@ -637,10 +677,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application.
             </p>
             <p>
-              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required.
             </p>
             <p>
               Collection accounts...
@@ -672,10 +712,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted.
             </p>
             <p>
-              Previous rental history will be reviewed and must exhibit no derogatory references. 
+              Previous rental history will be reviewed and must exhibit no derogatory references.
             </p>
             <p>
               Landlord references will only check for...
@@ -932,17 +972,29 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                household size
+                <span
+                  className=""
+                >
+                  household size
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per month
+                <span
+                  className=""
+                >
+                  maximum income per month
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per year
+                <span
+                  className=""
+                >
+                  maximum income per year
+                </span>
               </th>
             </tr>
           </thead>
@@ -984,12 +1036,20 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                Unit Type
+                <span
+                  className=""
+                >
+                  Unit Type
+                </span>
               </th>
               <th
                 className=""
               >
-                Occupancy
+                <span
+                  className=""
+                >
+                  Occupancy
+                </span>
               </th>
             </tr>
           </thead>
@@ -1151,17 +1211,29 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                household size
+                <span
+                  className=""
+                >
+                  household size
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per month
+                <span
+                  className=""
+                >
+                  maximum income per month
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per year
+                <span
+                  className=""
+                >
+                  maximum income per year
+                </span>
               </th>
             </tr>
           </thead>
@@ -1203,12 +1275,20 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                Unit Type
+                <span
+                  className=""
+                >
+                  Unit Type
+                </span>
               </th>
               <th
                 className=""
               >
-                Occupancy
+                <span
+                  className=""
+                >
+                  Occupancy
+                </span>
               </th>
             </tr>
           </thead>
@@ -1316,10 +1396,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application.
             </p>
             <p>
-              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required.
             </p>
             <p>
               Collection accounts...
@@ -1351,10 +1431,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted.
             </p>
             <p>
-              Previous rental history will be reviewed and must exhibit no derogatory references. 
+              Previous rental history will be reviewed and must exhibit no derogatory references.
             </p>
             <p>
               Landlord references will only check for...
@@ -1524,17 +1604,29 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                household size
+                <span
+                  className=""
+                >
+                  household size
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per month
+                <span
+                  className=""
+                >
+                  maximum income per month
+                </span>
               </th>
               <th
                 className=""
               >
-                maximum income per year
+                <span
+                  className=""
+                >
+                  maximum income per year
+                </span>
               </th>
             </tr>
           </thead>
@@ -1576,12 +1668,20 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                Unit Type
+                <span
+                  className=""
+                >
+                  Unit Type
+                </span>
               </th>
               <th
                 className=""
               >
-                Occupancy
+                <span
+                  className=""
+                >
+                  Occupancy
+                </span>
               </th>
             </tr>
           </thead>
@@ -1689,10 +1789,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application. 
+              Provide a credit report with score from Equifax, Experian, or TransUnion dated within thirty (30) days of the application.
             </p>
             <p>
-              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required. 
+              Accounts that are not current or that are derogatory will negatively affect the overall scoring, which could result in the denial of the application or an additional deposit may be required.
             </p>
             <p>
               Collection accounts...
@@ -1724,10 +1824,10 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
            
           <div>
             <p>
-              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted. 
+              Provide minimum of 4 years rental history with at least two prior rentals in which you were responsible for paying the rent.  Applicants without rental history will still be considered. No Guarantors permitted.
             </p>
             <p>
-              Previous rental history will be reviewed and must exhibit no derogatory references. 
+              Previous rental history will be reviewed and must exhibit no derogatory references.
             </p>
             <p>
               Landlord references will only check for...
@@ -1939,12 +2039,20 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
               <th
                 className=""
               >
-                Unit Type
+                <span
+                  className=""
+                >
+                  Unit Type
+                </span>
               </th>
               <th
                 className=""
               >
-                Occupancy
+                <span
+                  className=""
+                >
+                  Occupancy
+                </span>
               </th>
             </tr>
           </thead>

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsFeatures.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsFeatures.test.tsx.snap
@@ -132,35 +132,48 @@ exports[`ListingDetailsFeatures displays listing details features section when r
     <div
       className="info-card bg-gray-100 border-0"
     >
-      <p
-        className="info-card__title mb-2"
-      >
-        Additional Fees
-      </p>
       <div
-        className="info-card__columns text-sm"
+        className="info-card__header"
+      >
+        <h3
+          className="info-card__title"
+        >
+          Additional Fees
+        </h3>
+      </div>
+      <section
+        className="grid-section"
       >
         <div
-          className="info-card__column-2 null"
+          className="grid-section__inner md:grid md:grid-cols-2 md:gap-8 mb-5"
         >
-          <div
-            className="text-base"
+          <article
+            aria-label=""
+            className="grid-item"
           >
-            Deposit
-          </div>
-          <div
-            className="text-xl font-bold"
-          >
-            $2,102 - $2,355
-          </div>
-          <div>
-            or one month's rent
-          </div>
-          <div>
-            May be higher for lower credit scores
-          </div>
+            <div
+              className="text-base"
+            >
+              Deposit
+            </div>
+            <div
+              className="text-xl font-bold"
+            >
+              $2,102 - $2,355
+            </div>
+            <div
+              className="text-sm"
+            >
+              or one month's rent
+            </div>
+            <div
+              className="text-sm"
+            >
+              May be higher for lower credit scores
+            </div>
+          </article>
         </div>
-      </div>
+      </section>
       <div
         className="info-card__columns text-sm"
       >

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "core-js": "^3.19",
     "dayjs": "^1.10.7",
     "dotenv": "2.0.0",
-    "markdown-to-jsx": "^6.11.4",
+    "markdown-to-jsx": "7.1.8",
     "postcss": "^8.2.13",
     "postcss-loader": "^4.2.0",
     "postcss-nested": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/plugin-transform-react-jsx": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@bloom-housing/ui-components": "7.0.5",
+    "@bloom-housing/ui-components": "7.3.2",
     "@rails/webpacker": "5.2.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^16.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9609,6 +9609,11 @@ mapbox-gl@^2.3.0:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
 
+markdown-to-jsx@7.1.8:
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.8.tgz#49c3bb3c122aa714324034142c8829b93c889338"
+  integrity sha512-rRSa1aFmFnpDRFAhv5vIkWM4nPaoB9vnzIjuIKa1wGupfn2hdCNeaQHKpu4/muoc8n8J7yowjTP2oncA4/Rbgg==
+
 markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,10 +1212,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@7.0.5":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-7.0.5.tgz#922f67c75589c4492919b2b41cd800162dd91543"
-  integrity sha512-Yd5TUB4W8GV++CI0PFWDohDPIN81hf/kUya9o9Q25mkn40dcmYs4rAP5GONiiFNYOqcEfU15u2J0tfKn38SJYw==
+"@bloom-housing/ui-components@7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-7.3.2.tgz#b8a74ca564ebb847fc930ca15f09523eaa8fd7bf"
+  integrity sha512-5Dgfm5KrvX516LhXAbFglHSssL51xKGnH7BwzPZshp1EMwaON142qVrV/TBS/PEbnzSUSyLWXAX8vQKxvEP7bw==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"
@@ -1223,7 +1223,6 @@
     "@fortawesome/react-fontawesome" "^0.1.18"
     "@mapbox/mapbox-sdk" "^0.13.0"
     "@types/jwt-decode" "^2.2.1"
-    "@types/markdown-to-jsx" "^6.11.2"
     "@types/mdx" "^2.0.1"
     "@types/node" "^12.12.67"
     "@types/node-polyglot" "^2.4.1"
@@ -1237,7 +1236,7 @@
     axios "0.21.2"
     dayjs "^1.10.7"
     jwt-decode "^2.2.0"
-    markdown-to-jsx "^6.11.4"
+    markdown-to-jsx "7.1.8"
     nanoid "^3.1.12"
     node-polyglot "^2.4.0"
     react "^17.0.2"
@@ -1246,6 +1245,7 @@
     react-dom "^17.0.2"
     react-dropzone "^11.3.2"
     react-focus-lock "^2.5.2"
+    react-hook-form "^6.15.5"
     react-map-gl "^6.1.16"
     react-media "^1.10.0"
     react-remove-scroll "2.5.4"
@@ -9614,14 +9614,6 @@ markdown-to-jsx@7.1.8:
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.8.tgz#49c3bb3c122aa714324034142c8829b93c889338"
   integrity sha512-rRSa1aFmFnpDRFAhv5vIkWM4nPaoB9vnzIjuIKa1wGupfn2hdCNeaQHKpu4/muoc8n8J7yowjTP2oncA4/Rbgg==
 
-markdown-to-jsx@^6.11.4:
-  version "6.11.4"
-  resolved "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz"
-  integrity sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==
-  dependencies:
-    prop-types "^15.6.2"
-    unquote "^1.1.0"
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz"
@@ -14693,7 +14685,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-unquote@^1.1.0, unquote@~1.1.1:
+unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=


### PR DESCRIPTION
[DAH-1337](https://sfgovdt.jira.com/browse/DAH-1337)

There was a bloom/ui-components uptake needed, but it has no breaking changes and includes a couple improvements:

1.[ Additional Fees Alignment Issue](https://github.com/bloom-housing/ui-components/pull/8)
2. [Accessibility improvements](https://github.com/bloom-housing/ui-components/pull/12)

[DAH-1337]: https://sfgovdt.jira.com/browse/DAH-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Review Instructions should be updated to reflect these improvements!