### PR TITLE
upgrade ffi for mac m1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.11.1)
+    ffi (1.15.5)
     fog-aws (3.5.1)
       fog-core (~> 2.1)
       fog-json (~> 1.1)


### PR DESCRIPTION
A recent ruby upgrade caused an issue with the ffi dependency on mac's with the m1 chip. This fixes it!