### PR TITLE
update id and text for machine translations

### DIFF
--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -34,7 +34,7 @@ const CREDIT_HISTORY_TEXT = {
     "Proporcione un informe de crédito con puntaje de Equifax, Experian o TransUnion fechado dentro de los treinta (30) días posteriores a la solicitud.",
   tl:
     "Magbigay ng credit report na may marka mula sa Equifax, Experian, o TransUnion na may petsa sa loob ng tatlumpung (30) araw ng aplikasyon.",
-  zh: "提供 Equifax、Experian 或 TransUnion 在申請後三十",
+  zh: "非最新或貶損的賬戶將對整體評分產生負面影響",
 }
 
 const PARKING_TEXT = {

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -21,11 +21,12 @@ const INFORMATION_SESSION_RENTAL_TEXT = {
   es: "sesión de información de prueba",
   tl: "sesyon ng impormasyon ng pagsubok",
   zh: "測試信息會話",
+
 }
 
 const INFORMATION_SESSION_SALE_TEXT = {
-  es: "La asistencia a una sesión informativa de un solicitante es obligatoria.",
-  tl: "Ang pagdalo sa isang sesyon ng impormasyon ng isang aplikante ay sapilitan.",
+  es: "La asistencia a una sesión informativa.",
+  tl: "Ang pagdalo sa isang sesyon ng impormasyon",
   zh: "必須由一名申請人參加信息發布會。",
 }
 
@@ -34,7 +35,7 @@ const CREDIT_HISTORY_TEXT = {
     "Proporcione un informe de crédito con puntaje de Equifax, Experian o TransUnion fechado dentro de los treinta (30) días posteriores a la solicitud.",
   tl:
     "Magbigay ng credit report na may marka mula sa Equifax, Experian, o TransUnion na may petsa sa loob ng tatlumpung (30) araw ng aplikasyon.",
-  zh: "提供 Equifax、Experian 或 TransUnion 在申請後三十 (30) 天內提供的帶有評分的信用報告",
+  zh: "提供 Equifax、Experian 或 TransUnion 在申請後三十",
 }
 
 const PARKING_TEXT = {

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -10,10 +10,10 @@ const listings = {
     id: "a0W0P00000F8YG4UAN",
     title: "TEST Automated Listing (do not modify)",
   },
-  HABITAT_SALE: {
+  OPEN_SALE: {
     id: "a0W0P00000GlKfB",
-    address: "36 Amber Drive, San Francisco, CA 94131",
-    title: "Habitat Amber Drive",
+    address: "1 South Van Ness Ave, San Francisco, CA 94103",
+    title: "TEST Sale Listing (do not modify) - Homeownership Acres",
   },
 }
 
@@ -83,7 +83,7 @@ describe("Listing Details Machine Translations", () => {
     })
   })
 
-  describe("Sale Listing " + listings.HABITAT_SALE.id, () => {
+  describe("Sale Listing " + listings.OPEN_SALE.id, () => {
     /*
      * If any of these machine translation tests are failing, it could be due to:
      * 1. Google Translate updated the translation
@@ -95,21 +95,21 @@ describe("Listing Details Machine Translations", () => {
      */
 
     it("machine translations works in Filipino", () => {
-      verifyMachineTranslations("tl", listings.HABITAT_SALE.id, [
+      verifyMachineTranslations("tl", listings.OPEN_SALE.id, [
         INFORMATION_SESSION_SALE_TEXT.tl,
         PARKING_TEXT.tl,
       ])
     })
 
     it("machine translations works in Chinese", () => {
-      verifyMachineTranslations("zh", listings.HABITAT_SALE.id, [
+      verifyMachineTranslations("zh", listings.OPEN_SALE.id, [
         INFORMATION_SESSION_SALE_TEXT.zh,
         PARKING_TEXT.zh,
       ])
     })
 
     it("machine translations work in Spanish", () => {
-      verifyMachineTranslations("es", listings.HABITAT_SALE.id, [
+      verifyMachineTranslations("es", listings.OPEN_SALE.id, [
         INFORMATION_SESSION_SALE_TEXT.es,
         PARKING_TEXT.es,
       ])

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -21,7 +21,6 @@ const INFORMATION_SESSION_RENTAL_TEXT = {
   es: "sesión de información de prueba",
   tl: "sesyon ng impormasyon ng pagsubok",
   zh: "測試信息會話",
-
 }
 
 const INFORMATION_SESSION_SALE_TEXT = {

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -11,7 +11,7 @@ const listings = {
     title: "TEST Automated Listing (do not modify)",
   },
   HABITAT_SALE: {
-    id: "a0W4U00000KnMyXUAV",
+    id: "a0W0P00000GlKfB",
     address: "36 Amber Drive, San Francisco, CA 94131",
     title: "Habitat Amber Drive",
   },
@@ -24,9 +24,9 @@ const INFORMATION_SESSION_RENTAL_TEXT = {
 }
 
 const INFORMATION_SESSION_SALE_TEXT = {
-  es: "La asistencia a una sesión informativa por parte de un solicitante es obligatoria.",
+  es: "La asistencia a una sesión informativa de un solicitante es obligatoria.",
   tl: "Ang pagdalo sa isang sesyon ng impormasyon ng isang aplikante ay sapilitan.",
-  zh: "必須由一名申請人參加信息發布會。請",
+  zh: "必須由一名申請人參加信息發布會。",
 }
 
 const CREDIT_HISTORY_TEXT = {
@@ -38,9 +38,9 @@ const CREDIT_HISTORY_TEXT = {
 }
 
 const PARKING_TEXT = {
-  es: "Garaje para un auto por unidad y está incluido en el precio de venta.",
-  tl: "Isang garahe ng kotse bawat yunit at kasama sa presyo ng pagbebenta.",
-  zh: "每個單元一個車庫，包含在銷售價格中。",
+  es: "En el precio de venta de cada unidad se incluye una plaza de aparcamiento.",
+  tl: "Isang parking space ang kasama sa presyo ng pagbebenta ng bawat unit.",
+  zh: "每個單元的銷售價格中包含一個停車位",
 }
 
 describe("Listing Details Machine Translations", () => {

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -25,7 +25,7 @@ const INFORMATION_SESSION_RENTAL_TEXT = {
 }
 
 const INFORMATION_SESSION_SALE_TEXT = {
-  es: "La asistencia a una sesión informativa.",
+  es: "La asistencia a una sesión informativa",
   tl: "Ang pagdalo sa isang sesyon ng impormasyon",
   zh: "必須由一名申請人參加信息發布會。",
 }


### PR DESCRIPTION
DAH-1301

Since the Sale listing that was tested against isn't a protected test listing, we needed to update the sale listing the machine translations were using! This required updating the text that was being tested.

