### PR TITLE
Remove chromedriver from build circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,6 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
             chmod +x ./tmp/cc-test-reporter
             ./tmp/cc-test-reporter before-build
-      - setup-webdriver
       - persist_to_workspace:
           root: .
           paths:

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -30,10 +30,8 @@ const INFORMATION_SESSION_SALE_TEXT = {
 }
 
 const CREDIT_HISTORY_TEXT = {
-  es:
-    "Proporcione un informe de crédito",
-  tl:
-    "Magbigay ng credit report",
+  es: "Proporcione un informe de crédito",
+  tl: "Magbigay ng credit report",
   zh: "非最新或貶損的賬戶將對整體評分產生負面影響",
 }
 

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -31,9 +31,9 @@ const INFORMATION_SESSION_SALE_TEXT = {
 
 const CREDIT_HISTORY_TEXT = {
   es:
-    "Proporcione un informe de crédito con puntaje de Equifax, Experian o TransUnion fechado dentro de los treinta (30) días posteriores a la solicitud.",
+    "Proporcione un informe de crédito",
   tl:
-    "Magbigay ng credit report na may marka mula sa Equifax, Experian, o TransUnion na may petsa sa loob ng tatlumpung (30) araw ng aplikasyon.",
+    "Magbigay ng credit report",
   zh: "非最新或貶損的賬戶將對整體評分產生負面影響",
 }
 


### PR DESCRIPTION
This (for some reason...) fixes a breakage in the e2e test jobs in circleci. https://app.circleci.com/pipelines/github/SFDigitalServices/sf-dahlia-web/2560/workflows/48b50096-a3e5-4c14-88c5-fe78f6d791b3/jobs/16304

<img width="1095" alt="Screenshot 2023-01-12 at 3 54 32 PM" src="https://user-images.githubusercontent.com/5691923/212198708-2951c019-b5b3-4aad-8620-a756467891d5.png">

I don't necessarily feel like this is a long term solution, but it will at least unblock people's work and still has all the test suites and checks running in circleci.

I also simplified some machine translation strings to test with, to make them more resilient to different translations.