### PR TITLE
DAH-1427 pricing table error handling

### DIFF
--- a/app/javascript/api/listingApiService.ts
+++ b/app/javascript/api/listingApiService.ts
@@ -80,11 +80,7 @@ export const getAmiCharts = async (
     )
   }, "")
 
-  return get<ListingAmiChartsResponse>(amiCharts(queryParams))
-    .then(({ data }) => {
-      return data.ami
-    })
-    .catch(() => {
-      return null
-    })
+  return get<ListingAmiChartsResponse>(amiCharts(queryParams)).then(({ data }) => {
+    return data.ami
+  })
 }

--- a/app/javascript/contexts/listingDetails/listingDetailsReducer.ts
+++ b/app/javascript/contexts/listingDetails/listingDetailsReducer.ts
@@ -42,6 +42,18 @@ const ListingDetailsReducer = createReducer({ units: [] } as ListingDetailsState
       }),
     }
   },
+  [ListingDetailsActions.SetFetchingAmiChartsError]: (state, { payload: error }) => {
+    return {
+      ...state,
+      fetchingAmiChartsError: error,
+    }
+  },
+  [ListingDetailsActions.SetFetchingUnitsError]: (state, { payload: error }) => {
+    return {
+      ...state,
+      fetchingUnitsError: error,
+    }
+  },
 })
 
 export default ListingDetailsReducer

--- a/app/javascript/modules/listingDetails/ListingDetailsPricingTable.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsPricingTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React, { useContext, useEffect } from "react"
 import { CategoryTable, ContentAccordion, Icon, t } from "@bloom-housing/ui-components"
 import { RailsListing } from "../listings/SharedHelpers"
 import { isHabitatListing, isSale, groupAndSortUnitsByOccupancy } from "../../util/listingUtil"
@@ -247,8 +247,26 @@ const buildContent = (
 export const ListingDetailsPricingTable = ({ listing }: ListingDetailsPricingTableProps) => {
   const listingIsSale = isSale(listing)
   const listingIsHabitat = isHabitatListing(listing)
-  const { fetchedAmiCharts, fetchedUnits, amiCharts, units } = useContext(ListingDetailsContext)
+  const {
+    fetchedAmiCharts,
+    fetchedUnits,
+    amiCharts,
+    units,
+    fetchingAmiChartsError,
+    fetchingUnitsError,
+  } = useContext(ListingDetailsContext)
   const dataHasBeenFetched = fetchedAmiCharts && fetchedUnits
+
+  useEffect(() => {
+    if (fetchingAmiChartsError) {
+      // TODO: Log error properly
+      throw fetchingAmiChartsError
+    }
+    if (fetchingUnitsError) {
+      // TODO: Log error properly
+      throw fetchingUnitsError
+    }
+  }, [fetchingAmiChartsError, fetchingUnitsError])
 
   return (
     <div

--- a/app/javascript/pages/listings/listing-detail.tsx
+++ b/app/javascript/pages/listings/listing-detail.tsx
@@ -38,6 +38,7 @@ import { ListingDetailsHabitat } from "../../modules/listingDetails/ListingDetai
 import { ListingDetailsMOHCD } from "../../modules/listingDetails/ListingDetailsMOHCD"
 import { ListingDetailsApply } from "../../modules/listingDetailsAside/ListingDetailsApply"
 import ListingDetailsContext from "../../contexts/listingDetails/listingDetailsContext"
+import ErrorBoundary, { BoundaryScope } from "../../components/ErrorBoundary"
 
 const ListingDetail = () => {
   const alertClasses = "flex-grow mt-6 max-w-6xl w-full"
@@ -99,7 +100,9 @@ const ListingDetail = () => {
               reservedCommunityMinimumAge={listing.Reserved_community_minimum_age}
               reservedCommunityType={listing.Reserved_community_type}
             />
-            <ListingDetailsPricingTable listing={listing} />
+            <ErrorBoundary boundaryScope={BoundaryScope.component}>
+              <ListingDetailsPricingTable listing={listing} />
+            </ErrorBoundary>
             {listingHasSROUnits(listing) &&
               !(
                 isPluralSRO("1335 Folsom Street", listing) || isPluralSRO("750 Harrison", listing)


### PR DESCRIPTION
JIRA Ticket: https://sfgovdt.jira.com/browse/DAH-1427

### Changes:

Wrapped ListingDetailsPricingTable component with an ErrorBoundary

- This will catch any render errors thrown within the ListingDetailsPricingTable

Implemented reducers for the setFetchingAmiChartsError and setFetchingUnitsError actions

If those errors happen, throw them up to the ErrorBoundary

- This will allow for more precise logging or error handling behavior in the future

### Review Instructions

#### Render Error

- In the ListingDetailsPricingTable component, create a render error by referencing an unknown variable or manually throwing a new error
- Go to /listings/a0W4U00000KRHeEUAX and ensure that the listing page loads. There should be a 'An application error occurred. Check back later.' message in place of the pricing table

#### Fetching Units and AMI Charts error
- Open up proxyman
- Navigate to /listings/a0W4U00000KRHeEUAX
- Find the '/api/v1/listings/ami.json?year[]=2021&percent[]=55&chartType[]=MOHCD&' request
- Right click -> tools -> map local -> Change the '200' to '500' on the first line -> Save
- Refresh the listing page in your browser
- That request should return a 500 error
- Ensure that the listing page loads. There should be a 'An application error occurred. Check back later.' message in place of the pricing table
- Do the same for the '/api/v1/listings/a0W4U00000KRHeEUAX/units' request
