### PR TITLE
return list instead of string for tableSubHeader

### DIFF
--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -844,7 +844,7 @@
   "listings.householdMaximumIncome": "Household Maximum Income",
   "listings.housingProgram": "Housing Program",
   "listings.importantProgramRules": "Important Program Rules",
-  "listings.includesPriorityUnits": "Includes Priority Units for %{priorities}",
+  "listings.includesPriorityUnits": "Includes Priority Units for:",
   "listings.includingChildren": "(including <span class='eligibility-subtext'>%{number} %{children}</span> under 6)",
   "listings.incomeExceptions.intro": "People in your household may need <a href='%{url}' target='_blank'>special income calculations</a> if they:",
   "listings.incomeExceptions.nontaxable": "Receive non-taxable income (non-taxable income might include SSI, SSDI, child support payments, and worker’s compensation benefits).",

--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -807,7 +807,7 @@
   "listings.householdMaximumIncome": "Ingresos anuales del grupo familiar",
   "listings.housingProgram": "Programa de vivienda",
   "listings.importantProgramRules": "Reglas Importantes del Programa",
-  "listings.includesPriorityUnits": "Incluye unidades con prioridad para %{priorities}",
+  "listings.includesPriorityUnits": "Incluye unidades con prioridad para:",
   "listings.includingChildren": "(incluidos <span class='eligibility-subtext'>%{number} %{children}</span> menores de 6 años)",
   "listings.incomeExceptions.intro": "Las personas en su hogar pueden necesitar <a href='%{url}' target='_blank'> cálculos de ingresos especiales</a> en el caso que ellos",
   "listings.incomeExceptions.students": "Sean estudiantes de tiempo completo (no se aplica al solicitante principal)",

--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -807,7 +807,6 @@
   "listings.householdMaximumIncome": "Ingresos anuales del grupo familiar",
   "listings.housingProgram": "Programa de vivienda",
   "listings.importantProgramRules": "Reglas Importantes del Programa",
-  "listings.includesPriorityUnits": "Incluye unidades con prioridad para:",
   "listings.includingChildren": "(incluidos <span class='eligibility-subtext'>%{number} %{children}</span> menores de 6 años)",
   "listings.incomeExceptions.intro": "Las personas en su hogar pueden necesitar <a href='%{url}' target='_blank'> cálculos de ingresos especiales</a> en el caso que ellos",
   "listings.incomeExceptions.students": "Sean estudiantes de tiempo completo (no se aplica al solicitante principal)",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -807,7 +807,7 @@
   "listings.householdMaximumIncome": "Maximum o Pinakamalaki nang Kita Dapat ng Kabahayan",
   "listings.housingProgram": "Programa sa Pabahay (Housing Program)",
   "listings.importantProgramRules": "Mahahalagang Patakaran ng Programa ",
-  "listings.includesPriorityUnits": "Kasama ang mga Unit na Nagbibigay Prayoridad para sa %{priorities}",
+  "listings.includesPriorityUnits": "Kasama ang mga Unit na Nagbibigay Prayoridad para sa:",
   "listings.includingChildren": "(kasama ang <span class='eligibility-subtext'>%{number} %{children}</span> mas bata sa edad na 6)",
   "listings.incomeExceptions.intro": "Posibleng kailangan ng mga tao sa inyong kabahayan ng  <a href='%{url}' target='_blank'>espesyal na pagkakalkula ng kita </a> kung sila ay:",
   "listings.incomeExceptions.students": "Mga buong oras na estudyante (pero hindi ang pangunahing aplikante)",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -807,7 +807,6 @@
   "listings.householdMaximumIncome": "Maximum o Pinakamalaki nang Kita Dapat ng Kabahayan",
   "listings.housingProgram": "Programa sa Pabahay (Housing Program)",
   "listings.importantProgramRules": "Mahahalagang Patakaran ng Programa ",
-  "listings.includesPriorityUnits": "Kasama ang mga Unit na Nagbibigay Prayoridad para sa:",
   "listings.includingChildren": "(kasama ang <span class='eligibility-subtext'>%{number} %{children}</span> mas bata sa edad na 6)",
   "listings.incomeExceptions.intro": "Posibleng kailangan ng mga tao sa inyong kabahayan ng  <a href='%{url}' target='_blank'>espesyal na pagkakalkula ng kita </a> kung sila ay:",
   "listings.incomeExceptions.students": "Mga buong oras na estudyante (pero hindi ang pangunahing aplikante)",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -808,7 +808,7 @@
   "listings.householdMaximumIncome": "家庭最高收入",
   "listings.housingProgram": "住房計劃",
   "listings.importantProgramRules": "重要計畫規定",
-  "listings.includesPriorityUnits": "包括 %{priorities} 的優先單位",
+  "listings.includesPriorityUnits": "包括 的優先單位",
   "listings.includingChildren": "(包括<span class='eligibility-subtext'>%{number} %{children}</span>6歲以下兒童)",
   "listings.incomeExceptions.intro": "如果您家中的成員符合以下情況，可能需要<a href='%{url}' target='_blank'>特別收入計算方式</a>：",
   "listings.incomeExceptions.students": "是全日制學生（但不是主申請人）",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -808,7 +808,6 @@
   "listings.householdMaximumIncome": "家庭最高收入",
   "listings.housingProgram": "住房計劃",
   "listings.importantProgramRules": "重要計畫規定",
-  "listings.includesPriorityUnits": "包括 的優先單位",
   "listings.includingChildren": "(包括<span class='eligibility-subtext'>%{number} %{children}</span>6歲以下兒童)",
   "listings.incomeExceptions.intro": "如果您家中的成員符合以下情況，可能需要<a href='%{url}' target='_blank'>特別收入計算方式</a>：",
   "listings.incomeExceptions.students": "是全日制學生（但不是主申請人）",

--- a/app/javascript/__tests__/modules/listings/TableSubHeader.test.tsx
+++ b/app/javascript/__tests__/modules/listings/TableSubHeader.test.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import renderer from "react-test-renderer"
+import TableSubHeader from "../../../modules/listings/TableSubHeader"
+
+describe("TableSubHeader", () => {
+  it("renders TableSubHeader component", () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }
+    })
+    const tree = renderer.create(<TableSubHeader priorityTypes={["test"]} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app/javascript/__tests__/modules/listings/TableSubHeader.test.tsx
+++ b/app/javascript/__tests__/modules/listings/TableSubHeader.test.tsx
@@ -4,18 +4,6 @@ import TableSubHeader from "../../../modules/listings/TableSubHeader"
 
 describe("TableSubHeader", () => {
   it("renders TableSubHeader component", () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => {
-      return {
-        matches: true,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      }
-    })
     const tree = renderer.create(<TableSubHeader priorityTypes={["test"]} />).toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/app/javascript/__tests__/modules/listings/__snapshots__/TableSubHeader.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listings/__snapshots__/TableSubHeader.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableSubHeader renders TableSubHeader component 1`] = `
+<div>
+  Includes Priority Units for:
+  <ul
+    className="list-disc ml-4"
+  >
+    <li>
+      test
+    </li>
+  </ul>
+</div>
+`;

--- a/app/javascript/__tests__/pages/DirectoryHelpers.test.tsx
+++ b/app/javascript/__tests__/pages/DirectoryHelpers.test.tsx
@@ -6,7 +6,7 @@ import {
   getRentSubText,
   getTableHeader,
   showWaitlist,
-  getTableSubHeader,
+  getPriorityTypes,
 } from "../../modules/listings/DirectoryHelpers"
 import { getListingImageCardStatuses } from "../../modules/listings/SharedHelpers"
 import RailsRentalListing from "../../api/types/rails/listings/RailsRentalListing"
@@ -316,12 +316,12 @@ describe("DirectoryHelpers", () => {
   describe("getTableSubHeader", () => {
     it("returns null with listing lacking prioritiesDescriptor", () => {
       const testListing = {}
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBeNull()
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toBeNull()
     })
 
     it("returns null with listing lacking priorities length", () => {
       const testListing = { prioritiesDescriptor: [] }
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBeNull()
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toBeNull()
     })
 
     it("correctly parses Vision impairments", () => {
@@ -333,9 +333,7 @@ describe("DirectoryHelpers", () => {
         ],
       }
 
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBe(
-        "Includes Priority Units for Vision Impairments"
-      )
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toEqual(["Vision Impairments"])
     })
 
     it("correctly parses Hearing impairments", () => {
@@ -347,9 +345,7 @@ describe("DirectoryHelpers", () => {
         ],
       }
 
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBe(
-        "Includes Priority Units for Hearing Impairments"
-      )
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toEqual(["Hearing Impairments"])
     })
 
     it("correctly parses Hearing/Vision impairments", () => {
@@ -361,9 +357,9 @@ describe("DirectoryHelpers", () => {
         ],
       }
 
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBe(
-        "Includes Priority Units for Vision and/or Hearing Impairments"
-      )
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toEqual([
+        "Vision and/or Hearing Impairments",
+      ])
     })
 
     it("correctly parses Mobility/hearing/vision impairments", () => {
@@ -375,9 +371,9 @@ describe("DirectoryHelpers", () => {
         ],
       }
 
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBe(
-        "Includes Priority Units for Mobility, Hearing and/or Vision Impairments"
-      )
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toEqual([
+        "Mobility, Hearing and/or Vision Impairments",
+      ])
     })
 
     it("correctly parses Mobility impairments", () => {
@@ -389,9 +385,7 @@ describe("DirectoryHelpers", () => {
         ],
       }
 
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBe(
-        "Includes Priority Units for Mobility Impairments"
-      )
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toEqual(["Mobility Impairments"])
     })
 
     it("correctly parses no matches", () => {
@@ -403,9 +397,7 @@ describe("DirectoryHelpers", () => {
         ],
       }
 
-      expect(getTableSubHeader(testListing as RailsRentalListing)).toBe(
-        "Includes Priority Units for test"
-      )
+      expect(getPriorityTypes(testListing as RailsRentalListing)).toEqual(["test"])
     })
   })
 })

--- a/app/javascript/modules/listings/DirectoryHelpers.tsx
+++ b/app/javascript/modules/listings/DirectoryHelpers.tsx
@@ -172,7 +172,16 @@ export const getTableSubHeader = (listing: RailsRentalListing) => {
       }
     })
 
-    return t("listings.includesPriorityUnits", { priorities: priorityNames.join(", ") })
+    return (
+      <div>
+        {t("listings.includesPriorityUnits")}
+        <ul className="list-disc ml-4">
+          {priorityNames.map((name) => (
+            <li key={name}>{name}</li>
+          ))}
+        </ul>
+      </div>
+    )
   }
   return null
 }

--- a/app/javascript/modules/listings/DirectoryHelpers.tsx
+++ b/app/javascript/modules/listings/DirectoryHelpers.tsx
@@ -25,6 +25,7 @@ import { ListingAddress } from "../../components/ListingAddress"
 import TextBanner from "../../components/TextBanner"
 import { getHabitatContent } from "./HabitatForHumanity"
 import { getImageCardProps, RailsListing } from "./SharedHelpers"
+import TableSubHeader from "./TableSubHeader"
 
 export type RailsUnitSummary = RailsSaleUnitSummary | RailsRentalUnitSummary
 
@@ -147,7 +148,7 @@ export const getTableHeader = (listing: RailsRentalListing) => {
 }
 
 // Get the summary table subheader
-export const getTableSubHeader = (listing: RailsRentalListing) => {
+export const getPriorityTypes = (listing: RailsRentalListing): string[] | null => {
   if (listing.prioritiesDescriptor && listing.prioritiesDescriptor.length > 0) {
     const priorityNames = []
     listing.prioritiesDescriptor.forEach((priority) => {
@@ -171,17 +172,7 @@ export const getTableSubHeader = (listing: RailsRentalListing) => {
           priorityNames.push(priority.name)
       }
     })
-
-    return (
-      <div>
-        {t("listings.includesPriorityUnits")}
-        <ul className="list-disc ml-4">
-          {priorityNames.map((name) => (
-            <li key={name}>{name}</li>
-          ))}
-        </ul>
-      </div>
-    )
+    return priorityNames
   }
   return null
 }
@@ -200,7 +191,9 @@ export const getListingCards = (listings, directoryType, stackedDataFxn, hasFilt
             ? null
             : {
                 tableHeader: { content: getTableHeader(listing) },
-                tableSubheader: { content: getTableSubHeader(listing) },
+                tableSubheader: {
+                  content: <TableSubHeader priorityTypes={getPriorityTypes(listing)} />,
+                },
                 contentHeader: { content: listing.Name },
                 contentSubheader: { content: <ListingAddress listing={listing} /> },
               }

--- a/app/javascript/modules/listings/TableSubHeader.tsx
+++ b/app/javascript/modules/listings/TableSubHeader.tsx
@@ -1,0 +1,23 @@
+import { t } from "@bloom-housing/ui-components"
+import React from "react"
+
+type TableSubHeaderProps = {
+  priorityTypes: string[] | null
+}
+
+const TableSubHeader = ({ priorityTypes }: TableSubHeaderProps) => {
+  return (
+    priorityTypes && (
+      <div>
+        {t("listings.includesPriorityUnits")}
+        <ul className="list-disc ml-4">
+          {priorityTypes.map((name) => (
+            <li key={name}>{name}</li>
+          ))}
+        </ul>
+      </div>
+    )
+  )
+}
+
+export default TableSubHeader


### PR DESCRIPTION
JIRA Ticket: https://sfgovdt.jira.com/browse/DAH-1070

## Changes:

- Instead of generating a string with commas separating priorityTypes, we are now generating a list with each priorityType as a list item.
- **Changed the translation to remove the %priorities% field** - I think I edited all the language json files correctly, but I will put the updated text in the translation doc to ensure.
- Refactored the getTableSubheader function to be getPriorityTypes. I just returns a list of priority types now
- Created TableSubHeader component to render a list based on passed priority types. **Curious for feedback here**
- In progress: Tests are fixed, looking at some potential refactors still

## Review Instructions

- Go to /listings/for-rent?react=true
- Look for a listing with Priority Types
- It should be displayed as a bulleted list
- Check other languages and ensure everything looks consistent
- You may notice some priority types are not translated correctly. I am looking into a fix. That bug exists on full as well. https://dahlia-full.herokuapp.com/zh/listings/for-rent?react=true


