### PR TITLE
DAH-1536: Disable Flaky Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,19 @@ To run Angular unit tests:
 To run React unit tests:
 - `yarn test`
 
-To run E2E tests:
+To run Legacy E2E (Angular) tests:
 
 - Installation (needs to be run once): `./node_modules/protractor/bin/webdriver-manager update --versions.chrome 2.41 --versions.standalone 3.141.59` to get the selenium webdriver installed
 - On one tab have your Rails server running: `rails s`
 - On another tab, run `yarn protractor` to run the selenium webdriver and protractor tests. A Chrome browser will pop up and you will see it step through each of the tests.
 - If you get errors starting selenium, make sure you have [java](https://java.com/en/download/) installed
+
+To run E2E (React) tests:
+
+- In one terminal start the application by running `yarn start`
+- In another terminal
+   - To run the full suite of tests run `yarn test:e2e`
+   - To run a specific file run `cypress run --spec 'path/to/folder/<name-of-file>.e2e.ts'`
 
 Note: These tests will run on [CircleCi](https://app.circleci.com/pipelines/github/SFDigitalServices/sf-dahlia-web) as well for every review app and QA deploy.
 

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -35,6 +35,9 @@ const CREDIT_HISTORY_TEXT = {
   zh: "非最新或貶損的賬戶將對整體評分產生負面影響",
 }
 
+// TODO: Removing flaky tests to unblock CircleCI pipeline
+// DAH-1539 will be used to investigate root cause
+//
 // const PARKING_TEXT = {
 //   es: "Fumar puede causar problemas",
 //   tl: "Deadline ng Aplikasyon",

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -35,11 +35,11 @@ const CREDIT_HISTORY_TEXT = {
   zh: "非最新或貶損的賬戶將對整體評分產生負面影響",
 }
 
-const PARKING_TEXT = {
-  es: "En el precio de venta de cada unidad se incluye una plaza de aparcamiento.",
-  tl: "Isang parking space ang kasama sa presyo ng pagbebenta ng bawat unit.",
-  zh: "每個單元的銷售價格中包含一個停車位",
-}
+// const PARKING_TEXT = {
+//   es: "SESIONES INFORMATIVAS",
+//   tl: "MGA SESYON PARA",
+//   zh: "說明會",
+// }
 
 describe("Listing Details Machine Translations", () => {
   afterEach(() => {
@@ -98,21 +98,21 @@ describe("Listing Details Machine Translations", () => {
     it("machine translations works in Filipino", () => {
       verifyMachineTranslations("tl", listings.OPEN_SALE.id, [
         INFORMATION_SESSION_SALE_TEXT.tl,
-        PARKING_TEXT.tl,
+        // PARKING_TEXT.tl,
       ])
     })
 
     it("machine translations works in Chinese", () => {
       verifyMachineTranslations("zh", listings.OPEN_SALE.id, [
         INFORMATION_SESSION_SALE_TEXT.zh,
-        PARKING_TEXT.zh,
+        // PARKING_TEXT.zh,
       ])
     })
 
     it("machine translations work in Spanish", () => {
       verifyMachineTranslations("es", listings.OPEN_SALE.id, [
         INFORMATION_SESSION_SALE_TEXT.es,
-        PARKING_TEXT.es,
+        // PARKING_TEXT.es,
       ])
     })
   })

--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -36,8 +36,8 @@ const CREDIT_HISTORY_TEXT = {
 }
 
 // const PARKING_TEXT = {
-//   es: "SESIONES INFORMATIVAS",
-//   tl: "MGA SESYON PARA",
+//   es: "Fumar puede causar problemas",
+//   tl: "Deadline ng Aplikasyon",
 //   zh: "說明會",
 // }
 
@@ -96,24 +96,15 @@ describe("Listing Details Machine Translations", () => {
      */
 
     it("machine translations works in Filipino", () => {
-      verifyMachineTranslations("tl", listings.OPEN_SALE.id, [
-        INFORMATION_SESSION_SALE_TEXT.tl,
-        // PARKING_TEXT.tl,
-      ])
+      verifyMachineTranslations("tl", listings.OPEN_SALE.id, [INFORMATION_SESSION_SALE_TEXT.tl])
     })
 
     it("machine translations works in Chinese", () => {
-      verifyMachineTranslations("zh", listings.OPEN_SALE.id, [
-        INFORMATION_SESSION_SALE_TEXT.zh,
-        // PARKING_TEXT.zh,
-      ])
+      verifyMachineTranslations("zh", listings.OPEN_SALE.id, [INFORMATION_SESSION_SALE_TEXT.zh])
     })
 
     it("machine translations work in Spanish", () => {
-      verifyMachineTranslations("es", listings.OPEN_SALE.id, [
-        INFORMATION_SESSION_SALE_TEXT.es,
-        // PARKING_TEXT.es,
-      ])
+      verifyMachineTranslations("es", listings.OPEN_SALE.id, [INFORMATION_SESSION_SALE_TEXT.es])
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "protractor": "protractor ./spec/e2e/conf.js",
     "test": "jest",
     "test:e2e": "cypress run",
-    "test:e2espec": "cypress run --spec 'cypress/e2e/listingDetails/machineTranslations.e2e.ts'",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx app/javascript cypress",
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx app/javascript cypress",
     "webpack:analyze": "yarn webpack:build_json && yarn webpack:analyze_json",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "protractor": "protractor ./spec/e2e/conf.js",
     "test": "jest",
     "test:e2e": "cypress run",
+    "test:e2espec": "cypress run --spec 'cypress/e2e/listingDetails/machineTranslations.e2e.ts'",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx app/javascript cypress",
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx app/javascript cypress",
     "webpack:analyze": "yarn webpack:build_json && yarn webpack:analyze_json",


### PR DESCRIPTION
A couple of flaky tests asserting the translations of google translate are causing instability in our CircleCI pipeline. Because the same test is asserting multiple translations on different parts of the page, for now we will disable the assertion that is causing the flakiness. [DAH-1539](https://sfgovdt.jira.com/browse/DAH-1539) will investigate further the root cause of the flaky test.