### PR TITLE
fix: add redis ssl configs

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end


### PR DESCRIPTION
Attempt to fix an SSL issue related to how Heroku utilizes Redis.

References:
- https://ogirginc.github.io/en/heroku-redis-ssl-error
- https://www.sandipmane.dev/openssl-connection-error-with-redis6-on-heroku

This may not be the correct way to configure things with our particular app set up, but due to the urgency of this issue, we should attempt to deploy this change on staging, and then production today.