### PR TITLE
DAH-1070 fix: fix switch case for priority type

### DIFF
--- a/app/javascript/__tests__/pages/DirectoryHelpers.test.tsx
+++ b/app/javascript/__tests__/pages/DirectoryHelpers.test.tsx
@@ -364,7 +364,7 @@ describe("DirectoryHelpers", () => {
       const testListing = {
         prioritiesDescriptor: [
           {
-            name: "Mobility/hearing/vision impairments",
+            name: "Mobility/Hearing/Vision impairments",
           },
         ],
       }

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -446,7 +446,7 @@ describe("getPriorityTypeText", () => {
     ${"Vision impairments"}                  | ${"Vision Impairments"}
     ${"Hearing impairments"}                 | ${"Hearing Impairments"}
     ${"Hearing/Vision impairments"}          | ${"Vision and/or Hearing Impairments"}
-    ${"Mobility/hearing/vision impairments"} | ${"Mobility, Hearing and/or Vision Impairments"}
+    ${"Mobility/Hearing/Vision impairments"} | ${"Mobility, Hearing and/or Vision Impairments"}
     ${"Mobility impairments"}                | ${"Mobility Impairments"}
   `("returns text $text when priority type is $priorityType", ({ priorityType, text }) => {
     expect(getPriorityTypeText(priorityType)).toBe(text)

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -527,7 +527,7 @@ export const getPriorityTypeText = (priortyType: string): string => {
     case "Hearing/Vision impairments":
       text = t("listings.prioritiesDescriptor.hearingVision")
       break
-    case "Mobility/hearing/vision impairments":
+    case "Mobility/Hearing/Vision impairments":
       text = t("listings.prioritiesDescriptor.mobilityHearingVision")
       break
     case "Mobility impairments":


### PR DESCRIPTION
[Jira](https://sfgovdt.jira.com/browse/DAH-1070
)

Pushing up a fix for a typo found in release testing

Changes
- Fixed a typo in the switch case for priority types. Now we correctly map the priority type to the correct string.

