### PR TITLE
[DO NOT MERGE] DAH-1494: research current state of DAHLIA banners

### DIFF
--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -747,7 +747,7 @@
   "listings.allUnitsReservedFor": "All units reserved for %{type}",
   "listings.allUnitsReservedFor.Accessible Units Only": "All units reserved for people who need accessibility features",
   "listings.allUnitsReservedFor.Artist Live/Work": "All units reserved for artists to live and work in",
-  "listings.allUnitsReservedFor.Senior": "All units reserved for ages %{age}+",
+  "listings.allUnitsReservedFor.Senior": "<div style={{textTransform: \"none\"}}><p>All Unit Reserved For:</p><br /><ul style={{listStyleType: \"disc\", paddingLeft: \"1em\"}}><li>Seniors</li><li>Ages <b>%{age}+</b></li></ul></div>",
   "listings.allUnitsReservedFor.Veteran": "All units reserved for veterans",
   "listings.applicationDeadline": "Application Deadline",
   "listings.applicationsClosed": "Applications Closed",

--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -747,7 +747,7 @@
   "listings.allUnitsReservedFor": "All units reserved for %{type}",
   "listings.allUnitsReservedFor.Accessible Units Only": "All units reserved for people who need accessibility features",
   "listings.allUnitsReservedFor.Artist Live/Work": "All units reserved for artists to live and work in",
-  "listings.allUnitsReservedFor.Senior": "<div style={{textTransform: \"none\"}}><p>All Unit Reserved For:</p><br /><ul style={{listStyleType: \"disc\", paddingLeft: \"1em\"}}><li>Seniors</li><li>Ages <b>%{age}+</b></li></ul></div>",
+  "listings.allUnitsReservedFor.Senior": "<div><p>All Unit Reserved For:</p><br /><ul><li>Seniors</li><li>Ages <b>%{age}+</b></li></ul></div>",
   "listings.allUnitsReservedFor.Veteran": "All units reserved for veterans",
   "listings.applicationDeadline": "Application Deadline",
   "listings.applicationsClosed": "Applications Closed",

--- a/app/javascript/modules/listingDetails/ListingDetailsReservedBanner.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsReservedBanner.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Message, t } from "@bloom-housing/ui-components"
 import { RESERVED_COMMUNITY_TYPES } from "../constants"
+import { renderInlineMarkup, renderMarkup } from "../../util/languageUtil"
 
 export interface ListingDetailsReservedBannerProps {
   reservedCommunityMinimumAge?: number
@@ -25,9 +26,32 @@ export const ListingDetailsReservedBanner = ({
         })
       : t(`listings.allUnitsReservedFor.${reservedCommunityType}`)
 
+  const content = () => (
+    <div style={{textTransform: "none"}}>
+      <p>This is my list</p>
+      <br />
+      <ul style={{listStyleType: "disc", paddingLeft: "1em"}}>
+        <li>hello <b>world</b></li>
+        <li>Good Bye</li>
+      </ul>
+    </div>
+  )
+
+  const contentString = () => (
+     // "<div style={{textTransform: \"none\"}}><p>This is my list</p><br /><ul style={{listStyleType: \"disc\", paddingLeft: \"1em\"}}><li>hello <b>world</b></li><li>Good Bye</li></ul></div>"
+    `
+    This is my list
+
+    - item one
+    - item two
+    `
+  )
+
+  const renderString = () => renderMarkup(contentString(), "<div><p><br><ul><li><b>")
+
   return (
     <div className="md:pr-8 md:w-2/3 mt-4 w-full">
-      <Message warning={true}>{message}</Message>
+      <Message warning={true}>{content()}</Message>
     </div>
   )
 }

--- a/app/javascript/modules/listingDetails/ListingDetailsReservedBanner.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsReservedBanner.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Message, t } from "@bloom-housing/ui-components"
 import { RESERVED_COMMUNITY_TYPES } from "../constants"
-import { renderInlineMarkup, renderMarkup } from "../../util/languageUtil"
+import { renderMarkup } from "../../util/languageUtil"
 
 export interface ListingDetailsReservedBannerProps {
   reservedCommunityMinimumAge?: number
@@ -26,32 +26,11 @@ export const ListingDetailsReservedBanner = ({
         })
       : t(`listings.allUnitsReservedFor.${reservedCommunityType}`)
 
-  const content = () => (
-    <div style={{textTransform: "none"}}>
-      <p>This is my list</p>
-      <br />
-      <ul style={{listStyleType: "disc", paddingLeft: "1em"}}>
-        <li>hello <b>world</b></li>
-        <li>Good Bye</li>
-      </ul>
-    </div>
-  )
-
-  const contentString = () => (
-     // "<div style={{textTransform: \"none\"}}><p>This is my list</p><br /><ul style={{listStyleType: \"disc\", paddingLeft: \"1em\"}}><li>hello <b>world</b></li><li>Good Bye</li></ul></div>"
-    `
-    This is my list
-
-    - item one
-    - item two
-    `
-  )
-
-  const renderString = () => renderMarkup(contentString(), "<div><p><br><ul><li><b>")
+  const renderString = () => renderMarkup(message, "<div><p><br><ul><li><b>")
 
   return (
     <div className="md:pr-8 md:w-2/3 mt-4 w-full">
-      <Message warning={true}>{content()}</Message>
+      <Message warning={true}>{renderString()}</Message>
     </div>
   )
 }

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -145,7 +145,23 @@ export const getCurrentLanguage = (path?: string | undefined): LanguagePrefix =>
  */
 export function renderMarkup(translatedString: string, allowedTags?: string) {
   return (
-    <Markdown options={{ forceBlock: true }}>
+    <Markdown
+      options={{
+        forceBlock: true,
+        overrides: {
+          ul: {
+            props: {
+              style: { listStyleType: "disc", paddingLeft: "1em" },
+            },
+          },
+          div: {
+            props: {
+              style: { textTransform: "none" },
+            },
+          },
+        },
+      }}
+    >
       {stripMostTags(translatedString, allowedTags)}
     </Markdown>
   )


### PR DESCRIPTION
This is a POC branch for [DAH-1494](https://sfgovdt.jira.com/browse/DAH-1494) testing how to expand ListingDetailsReservedBanner including
- expanding the content to include things like bullet points, bold text, and text that is not always capitalized
- expanding this banner to be used by listings that are not for reserved communities 

<img width="677" alt="Screenshot 2023-07-24 at 8 37 01 AM" src="https://github.com/SFDigitalServices/sf-dahlia-web/assets/135058064/96a7219e-c982-454c-b849-110d47497590">


[DAH-1494]: https://sfgovdt.jira.com/browse/DAH-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ