### PR TITLE
DAH-1597 hotfix: remove markdown from translation string

### DIFF
--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -1104,7 +1104,7 @@
   "rentalDirectory.callouttitle": "透過社區夥伴查看更多物業名單。",
   "rentalDirectory.findMatchingListings": "尋找符合的物業項目",
   "rentalDirectory.ifYouTellUs": "如果您告知我們您的家庭人數以及收入，我們可以列出您可能符合資格的房源。",
-  "rentalDirectory.orGetHelpCalculating": "或者 尋求協助如何計算您的收入",
+  "rentalDirectory.orGetHelpCalculating": "或者尋求協助如何計算您的收入",
   "rentalDirectory.title": "租用可負擔房屋",
   "resetPassword.title": "重設密碼",
   "resetPassword.updatePassword": "更新密碼",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -1104,7 +1104,7 @@
   "rentalDirectory.callouttitle": "透過社區夥伴查看更多物業名單。",
   "rentalDirectory.findMatchingListings": "尋找符合的物業項目",
   "rentalDirectory.ifYouTellUs": "如果您告知我們您的家庭人數以及收入，我們可以列出您可能符合資格的房源。",
-  "rentalDirectory.orGetHelpCalculating": "或者 <a href='%{incomeLink}'>尋求協助如何計算您的收入</a>",
+  "rentalDirectory.orGetHelpCalculating": "或者 尋求協助如何計算您的收入",
   "rentalDirectory.title": "租用可負擔房屋",
   "resetPassword.title": "重設密碼",
   "resetPassword.updatePassword": "更新密碼",


### PR DESCRIPTION
Jira: https://sfgovdt.jira.com/browse/DAH-1597

Changes

on [1409](https://github.com/SFDigitalServices/sf-dahlia-web/pull/1849/files#r1237233320), I forgot to remove the markdown from the zh translation file.
Removed the a tag from the translation string