### PR TITLE
DAH-1451: Hotfix for Lottery Modal Translations

### DIFF
--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -1004,7 +1004,6 @@
   "lottery.numberApplicantsQualifiedForGeneralPool": "Hay %{number} solicitantes en esta lista. Tenga en cuenta que los titulares de preferencias se considerarán primero para todas las unidades.",
   "lottery.numberApplicantsQualifiedForPreference": "Hay %{number} solicitantes en esta lista.",
   "lottery.rank": "Clasificación",
-  "lottery.rankingOrderNote": "La clasificación en estas listas se considera en el orden que se muestra aquí.",
   "lottery.rankingPreferenceConsiderationNote": "Por favor tenga en cuenta que hay otras preferencias que se considerarán primero para las unidades.",
   "lottery.rankingPreferencesConsideredOverGeneralNote": "Por favor tenga en cuenta que las personas con preferencia se considerarán primero para todas las unidades.",
   "lottery.rankingTitle": "Su orden de preferencia",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -1003,7 +1003,6 @@
   "lottery.numberApplicantsQualifiedForGeneralPool": "%{number} aplikante ang nasa listahang ito. Pakitandaan, ang mga may hawak na preference ay unang mabibigyan ng konsiderasyon para sa lahat ng yunit.",
   "lottery.numberApplicantsQualifiedForPreference": "Mayroong %{number} aplikante sa listahang ito.",
   "lottery.rank": "Ranggo",
-  "lottery.rankingOrderNote": "Isasaalang-alang ang pagkakaranggo sa mga listahang ito ayon sa pagkakasunod-sunod na ipinapakita rito.",
   "lottery.rankingPreferenceConsiderationNote": "Pakitandaan na may iba pang preperensiya na isasaalang-alang muna para mga unit.",
   "lottery.rankingPreferencesConsideredOverGeneralNote": "Pakitandaan na isasaaalang-alang muna ang mga may preperensiya para sa lahat ng unit.",
   "lottery.rankingTitle": "Ang ranggo ng inyong preperensiya",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -1005,7 +1005,6 @@
   "lottery.numberApplicantsQualifiedForGeneralPool": "此列表中有 %{number} 位申請人。請注意，優先權持有人將優先納入所有住宅單位的考量。",
   "lottery.numberApplicantsQualifiedForPreference": "本名單中有 %{number} 位申請人。",
   "lottery.rank": "順位",
-  "lottery.rankingOrderNote": "在這些名單中的順位會依照此處顯示的順序。",
   "lottery.rankingPreferenceConsiderationNote": "請注意，還有其他優先權利會列入單位申請考量。",
   "lottery.rankingPreferencesConsideredOverGeneralNote": "請注意，所有單位會先考慮擁有優先權利的持有人。",
   "lottery.rankingTitle": "您的優先權利順位",

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
       Housing Preferences
     </h2>
     <p
-      className="pb-4 text-gray-700 text-xs mx-8"
+      className="pb-4 text-gray-700 text-xs mx-8 translate"
     >
       <p>
         Ranking in these lists is considered in the order shown here. 
@@ -129,7 +129,7 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
       Housing Preferences
     </h2>
     <p
-      className="pb-4 text-gray-700 text-xs mx-8"
+      className="pb-4 text-gray-700 text-xs mx-8 translate"
     >
       <p>
         Ranking in these lists is considered in the order shown here. 

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with o
       Your preference ranking
     </h2>
     <p
-      className="border-b border-gray-450 pb-4 text-gray-700"
+      className="border-b border-gray-450 pb-4 text-gray-700 translate"
     >
       <p>
         Ranking in these lists is considered in the order shown here. 
@@ -113,7 +113,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with t
       Your preference ranking
     </h2>
     <p
-      className="border-b border-gray-450 pb-4 text-gray-700"
+      className="border-b border-gray-450 pb-4 text-gray-700 translate"
     >
       <p>
         Ranking in these lists is considered in the order shown here. 
@@ -228,7 +228,7 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for sale with gen
       Your lottery ranking
     </h2>
     <p
-      className="border-b border-gray-450 pb-4 text-gray-700"
+      className="border-b border-gray-450 pb-4 text-gray-700 translate"
     >
       <p>
         Ranking in these lists is considered in the order shown here. 

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
           Housing Preferences
         </h2>
         <p
-          className="pb-4 text-gray-700 text-xs mx-8"
+          className="pb-4 text-gray-700 text-xs mx-8 translate"
         >
           <p>
             Ranking in these lists is considered in the order shown here. 

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.tsx
@@ -17,7 +17,7 @@ export const ListingDetailsLotteryPreferences = ({
         <Heading styleType="underlineWeighted" className="mx-8" priority={2}>
           {t("lottery.housingPreferences")}
         </Heading>
-        <p className="pb-4 text-gray-700 text-xs mx-8">
+        <p className="pb-4 text-gray-700 text-xs mx-8 translate">
           {renderMarkup(
             `${t("lottery.rankingOrderNote", {
               lotteryRankingVideoUrl: "https://www.youtube.com/watch?v=4ZB35gagUl8",

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryRanking.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryRanking.tsx
@@ -47,7 +47,7 @@ export const ListingDetailsLotteryRanking = ({
               ? t("lottery.rankingTitle")
               : t("lottery.rankingTitle.noPreference")}
           </Heading>
-          <p className="border-b border-gray-450 pb-4 text-gray-700">
+          <p className="border-b border-gray-450 pb-4 text-gray-700 translate">
             {renderMarkup(
               `${t("lottery.rankingOrderNote", {
                 lotteryRankingVideoUrl: "https://www.youtube.com/watch?v=4ZB35gagUl8",


### PR DESCRIPTION
[DAH-1451](https://sfgovdt.jira.com/browse/DAH-1451)

There was an issue where the non-English translations did not contain the video link. This was because we did not remove the non-english strings after changing the English string to include the link.

Our solution is to remove the non-english strings and have Google Machine Translate the string until we have human translations completed.

[DAH-1451]: https://sfgovdt.jira.com/browse/DAH-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ