### PR TITLE
DAH-1336 fix: change link

### DIFF
--- a/app/assets/json/additional-resources.json
+++ b/app/assets/json/additional-resources.json
@@ -20,7 +20,7 @@
                     "title": "assistance.additionalResources.sfHousingResources.rental.title",
                     "agency": "assistance.additionalResources.sfHousingResources.rental.agency",
                     "description": "assistance.additionalResources.sfHousingResources.rental.description",
-                    "externalUrl": "https://sf.gov/reports/december-2022/city-second-program-current-listings"
+                    "externalUrl": "https://sf.gov/information/san-francisco-rental-opportunities"
                 },
                 {
                     "title": "assistance.additionalResources.sfHousingResources.support.title",


### PR DESCRIPTION
Fix link for Additional Housing Opportunities page

![image](https://github.com/SFDigitalServices/sf-dahlia-web/assets/131277283/6a440302-207a-4c00-9d40-35427fb7c426)

Should point to https://sf.gov/information/san-francisco-rental-opportunities