### PR TITLE
DAH-1615 Restore Angular test

### DIFF
--- a/spec/e2e/pages/short-form/demographic-survey.coffee
+++ b/spec/e2e/pages/short-form/demographic-survey.coffee
@@ -46,10 +46,10 @@ class DemographicSurvey extends AngularPage
       referral: 'Bus Ad'
 
   fill: (opts = {}) ->
-    # @userGender.sendKeys(@defaults.userGender)
-    # @genderOther.clear().sendKeys(@defaults.genderOther)
-    # @userSex.sendKeys(@defaults.userSex)
-    # @userSexOther.clear().sendKeys(@defaults.userSexOther)
+    @userGender.sendKeys(@defaults.userGender)
+    @genderOther.clear().sendKeys(@defaults.genderOther)
+    @userSex.sendKeys(@defaults.userSex)
+    @userSexOther.clear().sendKeys(@defaults.userSexOther)
 
     # Select Black - African
     @blackAccordionHeader.click()


### PR DESCRIPTION
The first PR for this ticket removed an Angular test to debug flaky tests.

However, it was merged before that test was restored to its original state: https://github.com/SFDigitalServices/sf-dahlia-web/pull/1893/files#diff-8eea343f3848586174dbddb1122ba46257d2afae76c06c60d98f2fc6f3fac493

This PR restores the Angular test to its original state.