### PR TITLE
DAH-1627 Fix 'beforeunload' and Rails routing compatibility in Angular

### DIFF
--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -63,6 +63,12 @@
 
         $window.location.href = SharedService.buildUrl(toState, toParams)
 
+        # if user chooses 'cancel' on the 'beforeunload' dialog, they stay on the page,
+        #   so we need to remove the laoding overlay on the current page
+        # if user chooses 'leave' on the 'beforeunload' dialog, a new page will load,
+        #   so we're okay to remove the loading overlay on the current page
+        bsLoadingOverlayService.stop()
+
         return
 
       isFirstLoad = false


### PR DESCRIPTION
https://sfgovdt.jira.com/browse/DAH-1627

## Testing

note: if you are testing locally, make sure your `.env` file has this line: `HOME_PAGE_REACT='true'`

1. navigate to a listing detail page, and click 'Apply Online'
2. move past the welcome page(s)
    - depending on the listing, there may be more than one welcome page
    - these pages are identified by the fact that the url contains `/apply-welcome/`
3. click on the DAHLIA homepage icon
![Screenshot 2023-08-22 at 3 42 46 PM](https://github.com/SFDigitalServices/sf-dahlia-web/assets/133722877/e683c348-1555-4570-b10e-7f195abf2565)
4. The 'Leave site?' dialog should appear, click 'Cancel'
![Screenshot 2023-08-22 at 3 43 40 PM](https://github.com/SFDigitalServices/sf-dahlia-web/assets/133722877/ff963f92-2b50-4b6e-ad1b-51d62919319e)
5. Confirm that you stay on the current page, that there is _no_ loading overlay, and that you can interact with the page

