### PR TITLE
DAH-1657 Consolidate AMI charts in React

### DIFF
--- a/app/javascript/__tests__/data/RailsAmiCharts/ami-charts.ts
+++ b/app/javascript/__tests__/data/RailsAmiCharts/ami-charts.ts
@@ -347,9 +347,6 @@ export const amiChartsWithOneAmi = [
 export const amiChartsWithDuplicatePercents = [
   {
     percent: "55",
-    year: "2021",
-    chartType: "MOHCD",
-    derivedFrom: "MinAmi",
     values: [
       {
         year: "2021",
@@ -369,9 +366,6 @@ export const amiChartsWithDuplicatePercents = [
   },
   {
     percent: "55",
-    year: "2022",
-    chartType: "MOHCD",
-    derivedFrom: "MinAmi",
     values: [
       {
         year: "2022",

--- a/app/javascript/__tests__/data/RailsAmiCharts/ami-charts.ts
+++ b/app/javascript/__tests__/data/RailsAmiCharts/ami-charts.ts
@@ -343,3 +343,50 @@ export const amiChartsWithOneAmi = [
     ],
   },
 ]
+
+export const amiChartsWithDuplicatePercents = [
+  {
+    percent: "55",
+    year: "2021",
+    chartType: "MOHCD",
+    derivedFrom: "MinAmi",
+    values: [
+      {
+        year: "2021",
+        percent: 55,
+        numOfHousehold: 1,
+        chartType: "MOHCD",
+        amount: 31000,
+      },
+      {
+        year: "2021",
+        percent: 55,
+        numOfHousehold: 2,
+        chartType: "MOHCD",
+        amount: 42001,
+      },
+    ],
+  },
+  {
+    percent: "55",
+    year: "2022",
+    chartType: "MOHCD",
+    derivedFrom: "MinAmi",
+    values: [
+      {
+        year: "2022",
+        percent: 55,
+        numOfHousehold: 1,
+        chartType: "MOHCD",
+        amount: 31001,
+      },
+      {
+        year: "2022",
+        percent: 55,
+        numOfHousehold: 2,
+        chartType: "MOHCD",
+        amount: 42000,
+      },
+    ],
+  },
+]

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -446,9 +446,6 @@ describe("consolidateAmiCharts", () => {
     const consolidatedAmiCharts = [
       {
         percent: "55",
-        year: "2021",
-        chartType: "MOHCD",
-        derivedFrom: "MinAmi",
         values: [
           {
             year: "2021",

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -443,7 +443,7 @@ describe("getAmiChartDataFromUnits", () => {
 
 describe("consolidateAmiCharts", () => {
   it("combines AMI charts with the same percent into a single chart, using the values with the larger amount", () => {
-    expect(consolidateAmiCharts(amiChartsWithDuplicatePercents)).toEqual([
+    const consolidatedAmiCharts = [
       {
         percent: "55",
         year: "2021",
@@ -466,7 +466,8 @@ describe("consolidateAmiCharts", () => {
           },
         ],
       },
-    ])
+    ]
+    expect(consolidateAmiCharts(amiChartsWithDuplicatePercents)).toEqual(consolidatedAmiCharts)
   })
 })
 

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -18,6 +18,7 @@ import {
   buildAmiArray,
   groupAndSortUnitsByOccupancy,
   getAmiChartDataFromUnits,
+  consolidateAmiCharts,
   getPriorityTypeText,
 } from "../../util/listingUtil"
 import { openSaleListing } from "../data/RailsSaleListing/listing-sale-open"
@@ -26,7 +27,7 @@ import { lotteryCompleteRentalListing } from "../data/RailsRentalListing/listing
 import { habitatListing } from "../data/RailsSaleListing/listing-sale-habitat"
 import { sroRentalListing } from "../data/RailsRentalListing/listing-rental-sro"
 import { unitsWithOccupancyAndMaxIncome, units } from "../data/RailsListingUnits/listing-units"
-import { amiCharts } from "../data/RailsAmiCharts/ami-charts"
+import { amiCharts, amiChartsWithDuplicatePercents } from "../data/RailsAmiCharts/ami-charts"
 import { groupedUnitsByOccupancy } from "../data/RailsListingUnits/grouped-units-by-occupancy"
 
 describe("listingUtil", () => {
@@ -436,6 +437,35 @@ describe("getAmiChartDataFromUnits", () => {
       },
       { derivedFrom: "MaxAmi", year: 2021, type: "MOHCD", percent: 109.8 },
       { derivedFrom: "MinAmi", year: 2021, type: "MOHCD", percent: 35 },
+    ])
+  })
+})
+
+describe("consolidateAmiCharts", () => {
+  it("combines AMI charts with the same percent into a single chart, using the values with the larger amount", () => {
+    expect(consolidateAmiCharts(amiChartsWithDuplicatePercents)).toEqual([
+      {
+        percent: "55",
+        year: "2021",
+        chartType: "MOHCD",
+        derivedFrom: "MinAmi",
+        values: [
+          {
+            year: "2021",
+            percent: 55,
+            numOfHousehold: 1,
+            chartType: "MOHCD",
+            amount: 31001,
+          },
+          {
+            year: "2021",
+            percent: 55,
+            numOfHousehold: 2,
+            chartType: "MOHCD",
+            amount: 42001,
+          },
+        ],
+      },
     ])
   })
 })

--- a/app/javascript/api/types/rails/listings/RailsAmiChart.d.ts
+++ b/app/javascript/api/types/rails/listings/RailsAmiChart.d.ts
@@ -8,9 +8,9 @@ export type RailsAmiChartValue = {
 
 export type RailsAmiChart = {
   percent: string
-  derivedFrom: string
+  derivedFrom?: string
   values: Array<RailsAmiChartValue>
-  year: string
+  year?: string
   chartType?: string
 }
 

--- a/app/javascript/contexts/listingDetails/listingDetailsReducer.ts
+++ b/app/javascript/contexts/listingDetails/listingDetailsReducer.ts
@@ -2,6 +2,7 @@ import { createReducer } from "typesafe-actions"
 import { ListingDetailsActions } from "./listingDetailsActions"
 import RailsUnit from "../../api/types/rails/listings/RailsUnit"
 import { RailsAmiChart, RailsAmiChartMetaData } from "../../api/types/rails/listings/RailsAmiChart"
+import { consolidateAmiCharts } from "../../util/listingUtil"
 
 type ListingDetailsState = {
   fetchingUnits: boolean
@@ -33,11 +34,12 @@ const ListingDetailsReducer = createReducer({ units: [] } as ListingDetailsState
     state,
     { payload: { amiCharts, chartsToFetch } }
   ) => {
+    const consolidatedAmiCharts = consolidateAmiCharts(amiCharts)
     return {
       ...state,
       fetchingAmiCharts: false,
       fetchedAmiCharts: true,
-      amiCharts: amiCharts?.map((amiChart: RailsAmiChart) => {
+      amiCharts: consolidatedAmiCharts?.map((amiChart: RailsAmiChart) => {
         return {
           ...amiChart,
           /*

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -462,6 +462,31 @@ export const getAmiChartDataFromUnits = (units: RailsUnit[]): RailsAmiChartMetaD
   return uniqueCharts
 }
 
+// based on ListingUnitService's _consolidatedAMICharts
+export const consolidateAmiCharts = (amiCharts: RailsAmiChart[]): RailsAmiChart[] => {
+  if (!amiCharts) return amiCharts
+
+  const consolidatedCharts = []
+  amiCharts.forEach((chart: RailsAmiChart) => {
+    const existingChartWithSamePercent = consolidatedCharts.find(
+      (consolidatedChart) => consolidatedChart.percent === chart.percent
+    )
+    if (!existingChartWithSamePercent) {
+      consolidatedCharts.push(chart)
+    } else {
+      existingChartWithSamePercent.values.forEach(
+        (existingValue: RailsAmiChartValue, idx: number) => {
+          // it is fine to use idx instead of numOfHousehold, because the values array is sorted by numOfHousehold
+          const currentAmount = chart.values[idx]?.amount
+          if (!currentAmount) return
+          existingValue.amount = Math.max(existingValue.amount, currentAmount)
+        }
+      )
+    }
+  })
+  return consolidatedCharts
+}
+
 export const getLongestAmiChartValueLength = (amiCharts: RailsAmiChart[]): number => {
   let longestChartLength: number
 


### PR DESCRIPTION
https://sfgovdt.jira.com/browse/DAH-1657

# Testing

1. go to the listing details page for a listing that has exactly two AMI charts, and both charts have the same percent
    - this one should work: `/listings/a0W4U00000KnVK8UAN`
    - you can check AMI chart data in the network tab of the browser developer tools
![Screenshot 2023-08-24 at 2 07 04 PM](https://github.com/SFDigitalServices/sf-dahlia-web/assets/133722877/c6233aee-af48-4a45-8382-7b71fc9ce61d)
2. append `?react=true` and `?react=false` to compare the tables in the "Eligibility: Household Maximum Income" section
3. the tables should have identical headers and rows in React and Angular versions of the page
    | angular          | react               |
    | ------------- | ------------- |
    | ![Screenshot 2023-08-24 at 2 13 29 PM](https://github.com/SFDigitalServices/sf-dahlia-web/assets/133722877/50fd878b-b81f-4524-9ed1-2bc569c50230)  |  ![Screenshot 2023-08-24 at 2 13 39 PM](https://github.com/SFDigitalServices/sf-dahlia-web/assets/133722877/6c0a7de1-3fcc-47b7-9db9-37633169fbc5) |

