### PR TITLE
DAH-1674 fix: disable google translate on eligibility sections

### DIFF
--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
@@ -565,7 +565,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -601,7 +601,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -637,7 +637,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <span>
@@ -1230,7 +1230,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -1266,7 +1266,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -1302,7 +1302,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <span>
@@ -2570,7 +2570,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -2606,7 +2606,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -2642,7 +2642,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <span>
@@ -3244,7 +3244,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -3280,7 +3280,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 translate additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <div>
@@ -3316,7 +3316,7 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
             </h3>
           </div>
           <div
-            class="expandable-text text-xs text-gray-700 additional-rule-card"
+            class="expandable-text text-xs text-gray-700 notranslate additional-rule-card"
           >
              
             <span>

--- a/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
@@ -209,7 +209,7 @@ export const ListingDetailsEligibility = ({
             {listing.Credit_Rating && (
               <InfoCard title={t("listings.additionalEligibilityRules.creditHistory")}>
                 <ExpandableText
-                  className="text-xs text-gray-700 translate additional-rule-card"
+                  className="text-xs text-gray-700 notranslate additional-rule-card"
                   strings={{
                     readMore: t("label.showMore"),
                     readLess: t("label.showLess"),
@@ -225,7 +225,7 @@ export const ListingDetailsEligibility = ({
             {listing.Eviction_History && (
               <InfoCard title={t("listings.additionalEligibilityRules.rentalHistory")}>
                 <ExpandableText
-                  className="text-xs text-gray-700 translate additional-rule-card"
+                  className="text-xs text-gray-700 notranslate additional-rule-card"
                   strings={{
                     readMore: t("label.showMore"),
                     readLess: t("label.showLess"),
@@ -239,7 +239,7 @@ export const ListingDetailsEligibility = ({
             )}
             <InfoCard title={t("listings.additionalEligibilityRules.criminalBackground")}>
               <ExpandableText
-                className="text-xs text-gray-700 additional-rule-card"
+                className="text-xs text-gray-700 notranslate additional-rule-card"
                 strings={{
                   readMore: t("label.showMore"),
                   readLess: t("label.showLess"),


### PR DESCRIPTION
Temporary fix for [1674](https://sfgovdt.jira.com/browse/DAH-1674)

Review instructions

- Go to /listings/a0W4U00000KnfMyUAJ?react=true
- Scroll down to Eligibility sections and expand the Rental History expandable text.
- Click the toggle button a few times
- If you view page in a different language, these sections will **not** be translated

Context
https://github.com/facebook/react/issues/11538#issuecomment-390386520
