### PR TITLE
updating e2e translation tests

### DIFF
--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -38,7 +38,7 @@ const INFORMATION_SESSION_SALE_TEXT = {
   en: "Attendance at an information session by one applicant is mandatory",
   es: "La asistencia a una sesión informativa",
   tl: "Ang pagdalo sa isang sesyon ng impormasyon",
-  zh: "一名申請人必須參加信息發布會。",
+  zh: "一名申請人必須參加資訊發布會。",
 }
 
 describe("Listing Detail Machine Translations", () => {


### PR DESCRIPTION
Observations found by @jimlin-sfgov:

```
machine translation e2e tests are failing because Google translate has changed how they translate a chinese phrase:
一名申請人必須參加信息發布會。(old)
一名申請人必須參加資訊發布會。(new)
It is okay to update the test to expect the new chinese translation.
```

Solution:
- Updating the e2e tests w/ the new translations work. We as clients of google translate do not have as much control of the translated content. If we need more control we move from machine translations to human translations.