### PR TITLE
Dah 1773 fix missing priority type

### DIFF
--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -590,6 +590,9 @@ export const getPriorityTypeText = (priortyType: string): string => {
     case "Mobility impairments":
       text = t("listings.prioritiesDescriptor.mobility")
       break
+    case "Hearing/Vision (Communication)":
+      text = t("listings.Hearing/Vision (Communication).title")
+      break
     default:
       text = ""
   }


### PR DESCRIPTION
Jira: https://sfgovdt.jira.com/browse/DAH-1773

Go to listing directory page. Scroll until you see a listing with priorityTypes. Ensure all priorityTypes (excluding educator listing) get translated correctly.