### PR TITLE
DAH-1841 fix: use alt text from Salesforce

### DIFF
--- a/app/javascript/__tests__/pages/listings/ForRent.test.tsx
+++ b/app/javascript/__tests__/pages/listings/ForRent.test.tsx
@@ -49,7 +49,7 @@ describe("For Rent", () => {
       }
     )
 
-    const image = await findByAltText(`${sroRentalListing.Building_Name} Building`)
+    const image = await findByAltText("This is a listing image")
     expect(image.getAttribute("src")).toBe(sroRentalListing.Listing_Images[0].displayImageURL)
     done()
   })

--- a/app/javascript/__tests__/pages/listings/ForSale.test.tsx
+++ b/app/javascript/__tests__/pages/listings/ForSale.test.tsx
@@ -36,7 +36,7 @@ describe("For Sale", () => {
 
     const { findByAltText } = render(<ForSale assetPaths="/" />)
 
-    const image = await findByAltText(`${openSaleListing.Building_Name} Building`)
+    const image = await findByAltText("This is a listing image")
     expect(image.getAttribute("src")).toBe(openSaleListing.Listing_Images[0].displayImageURL)
     done()
   })

--- a/app/javascript/modules/listings/SharedHelpers.tsx
+++ b/app/javascript/modules/listings/SharedHelpers.tsx
@@ -70,12 +70,16 @@ export const getImageCardProps = (listing: RailsListing, hasFiltersSet?: boolean
       ? listing.Listing_Images[0].displayImageURL
       : listing?.imageURL ?? fallbackImg
 
+  const imageDescription =
+    listing?.Listing_Images?.length > 0
+      ? listing.Listing_Images[0].Image_Description
+      : `${listing.Building_Name} Building`
   return {
     imageUrl: imageUrl,
     href: `/listings/${listing.listingID}`,
     tags: getTagContent(listing),
     statuses: getListingImageCardStatuses(listing, hasFiltersSet),
-    description: `${listing.Building_Name} Building`,
+    description: imageDescription,
   }
 }
 


### PR DESCRIPTION
JIRA: https://sfgovdt.jira.com/browse/DAH-1841

# Changes
- For the listing directory image we now use the image description field from the Salesforce listing image object as alt text

# Review Instructions
- Go to /for-rent
- Scroll to a listing with multiple listing images (Casa Adelante)
- Inspect the cover image and ensure alt text is the same as what is set in Salesforce