### PR TITLE
Hotfix- Change ListingImage error to an info log

### DIFF
--- a/app/services/multiple_listing_image_service.rb
+++ b/app/services/multiple_listing_image_service.rb
@@ -16,7 +16,7 @@ class MultipleListingImageService
 
   def process_images
     unless @listing_images
-      add_error(@errors, "No listing images provided for listing #{@listing_id}")
+      Rails.logger.info("No listing images provided for listing #{@listing_id}")
       return self
     end
     Rails.logger.info("Processing Listing Images for #{@listing_id}")

--- a/spec/services/multiple_listing_image_service_spec.rb
+++ b/spec/services/multiple_listing_image_service_spec.rb
@@ -18,16 +18,6 @@ describe MultipleListingImageService do
   end
 
   describe '.process_images' do
-    it 'should return an error if listing images array is empty' do
-      listing_copy = listing.dup
-      listing_copy['Listing_Images'] = nil
-
-      image_processor = MultipleListingImageService.new(listing_copy).process_images
-
-      error_message =
-        "MultipleListingImageService error: No listing images provided for listing #{listing_id}"
-      expect(image_processor.errors).to include(error_message)
-    end
 
     it 'should return an error if the image is unreadable' do
       stub_request(:get, /(\.jpg|\.png|\.jpeg)/)


### PR DESCRIPTION
# Changes
- "No listing images provided for listing" error is now an info statement

# Review
- In Papertrail ensure that this log does not throw an error: https://my.papertrailapp.com/systems/dahlia-prod-test/events