### PR TITLE
Only pass force param if preview flag is present

### DIFF
--- a/app/javascript/api/listingApiService.ts
+++ b/app/javascript/api/listingApiService.ts
@@ -19,11 +19,11 @@ type ListingPreferencesResponse = { preferences: RailsListingPreference[] }
 type ListingUnitsResponse = { units: RailsUnit[] }
 type ListingAmiChartsResponse = { ami: RailsAmiChart[] }
 
-const forceRecache = (): boolean => window.location.search.includes("preview=true")
+const forceRecache = () => (window.location.search.includes("preview=true") ? { force: true } : {})
 
 export const getListing = async (listingId?: string): Promise<RailsListing> => {
   const httpConfig = { params: {} }
-  httpConfig.params = { force: forceRecache() }
+  httpConfig.params = forceRecache()
   return get<ListingsResponse>(listing(listingId), httpConfig).then(({ data }) => data.listing)
 }
 
@@ -34,7 +34,7 @@ export const getListing = async (listingId?: string): Promise<RailsListing> => {
  */
 export const getLotteryBucketDetails = async (listingId: string): Promise<RailsLotteryResult> => {
   const httpConfig = { params: {} }
-  httpConfig.params = { force: forceRecache() }
+  httpConfig.params = forceRecache
   return get<RailsLotteryResult>(lotteryBuckets(listingId), httpConfig).then(
     (response) => response.data
   )
@@ -76,7 +76,7 @@ export const getLotteryResults = async (
  */
 export const getPreferences = async (listingId: string): Promise<RailsListingPreference[]> => {
   const httpConfig = { params: {} }
-  httpConfig.params = { force: forceRecache() }
+  httpConfig.params = forceRecache()
   return get<ListingPreferencesResponse>(listingPreferences(listingId), httpConfig).then(
     ({ data }) => data.preferences
   )


### PR DESCRIPTION
# Changes
- Refactored logic for adding `force=true` to api requests

# Review 
- Go to a listing detail page in react
- Open network tab
- Add `preview=true` to url and ensure that the force param is applied
- Add `preview=false` and ensure that force param is not applied
- Update listing details in Salesforce and ensure changes are updated on React (Will only work on prod env until we merge production branch back into main)