### PR TITLE
Hotfix prod remove listing image log

### DIFF
--- a/app/services/listing_image_service.rb
+++ b/app/services/listing_image_service.rb
@@ -18,7 +18,7 @@ class ListingImageService
 
   def process_image
     unless raw_image_url
-      add_error("No image provided for listing #{listing_id}")
+      Rails.logger.info("No Photo_URL image provided for listing #{@listing_id}")
       return self
     end
 

--- a/spec/services/listing_image_service_spec.rb
+++ b/spec/services/listing_image_service_spec.rb
@@ -18,17 +18,6 @@ describe ListingImageService do
   end
 
   describe '.process_image' do
-    it 'should return an error if no building url is provided' do
-      listing_missing_image_url = listing.dup
-      listing_missing_image_url['Building_URL'] = nil
-
-      image_processor = ListingImageService.new(listing_missing_image_url).process_image
-
-      error_message =
-        "ListingImageService error: No image provided for listing #{listing_id}"
-      expect(image_processor.errors).to include(error_message)
-    end
-
     it 'should return an error if the image is unreadable' do
       stub_request(:get, /(\.jpg|\.png|\.jpeg)/)
         .to_return(body: File.new("#{Rails.root}/README.md"), status: 200)


### PR DESCRIPTION
My guess is if a listing doesn't have any value for the Photo URL field, the ListingImageService throws this error. So if a new listing only uses Listing Images, then this will happen.

Logs: https://my.papertrailapp.com/groups/4549952/events?q=%22ListingImageService+error%22

For example, this listing https://housing.sfgov.org/listings/a0W4U00000NlS7DUAV does not seen to have the Building_URL field.