### PR TITLE
DAH-1720 provide contrast for filter dropdown text label

### DIFF
--- a/app/javascript/pages/getAssistance/counselor-filter.scss
+++ b/app/javascript/pages/getAssistance/counselor-filter.scss
@@ -19,7 +19,7 @@ select {
     }
     select {
         border-color: var(--bloom-color-gray-500);
-        @apply text-gray-700;
+        @apply text-gray-750;
     }
     input::placeholder {
         @apply overflow-visible;


### PR DESCRIPTION
[DAH-1720](https://sfgovdt.jira.com/browse/DAH-1720)

Provides contrast for the filter selection text in the language `Select` component of the react housing counselors view:

![Screenshot 2023-11-30 at 11 08 26 AM](https://github.com/SFDigitalServices/sf-dahlia-web/assets/43218114/f867948b-feb2-4e30-99d2-18958b278ee5)

[DAH-1720]: https://sfgovdt.jira.com/browse/DAH-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ