### PR TITLE
DAH-1820 fix: latest uic for mobile modal cutoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.5",
-    "@bloom-housing/ui-components": "^12.1.0",
+    "@bloom-housing/ui-components": "^12.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "ag-grid-community": "^29.0.0",
     "autoprefixer": "^10.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,10 +1093,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-12.1.0.tgz#c6066ed097887820bf2195c748ac2862fb171eef"
-  integrity sha512-xFW4IlPw9v9OJCkEQiKdIiN4csJyHuuaz1GmZGD33+m2phU79f5he2zBw0/qZogqpmP8aYsuzzKHAigHKXNhdQ==
+"@bloom-housing/ui-components@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-12.1.1.tgz#e69a79619353beed7cf97c519eb2da90c2f11895"
+  integrity sha512-sK1YqaFl31pvvuUed9dhIkglVLw+1+ds7tD7pN/KjHYWTD16uVAViaanAlJGBNOjxp5iDH8tTouPWqkGIjrjpg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"


### PR DESCRIPTION
Jira: DAH-1820
Bloom UIC PR: https://github.com/bloom-housing/ui-components/pull/138/files

# Review
- On a physical mobile device or browserstack:
  - Go to a rental listing with multiple listing images: https://dahlia-webapp-pr-2022.herokuapp.com/listings/a0W8H0000014LS9UAM?react=true
  - Open the modal and ensure the close button is visible and clickable
  - Go to sales listing with completed lottery. https://dahlia-webapp-pr-2022.herokuapp.com/listings/a0W4U00000KnlR9UAJ?react=true
  - Open the lottery results modal and ensure no info is cut off
  - A known issue with this Bloom UIC fix is that the content overflow on scrolling modals causes the background color to persist a bit when scrolling up from the bottom. 