### PR TITLE
DAH-1866 apply translate className to directory

### DIFF
--- a/app/javascript/layouts/Layout.tsx
+++ b/app/javascript/layouts/Layout.tsx
@@ -154,7 +154,7 @@ const Layout = (props: LayoutProps) => {
 
   return (
     <HelmetProvider>
-      <div className="notranslate site-wrapper">
+      <div className="site-wrapper">
         <div className="site-content">
           <MetaTags title={props.title} description={props.description} image={props.image} />
           {topAlert}

--- a/app/javascript/modules/listings/GenericDirectory.tsx
+++ b/app/javascript/modules/listings/GenericDirectory.tsx
@@ -15,6 +15,7 @@ import {
 import { RailsListing } from "./SharedHelpers"
 import "./ListingDirectory.scss"
 import { MailingListSignup } from "../../components/MailingListSignup"
+import useTranslate from "../../hooks/useTranslate"
 
 interface RentalDirectoryProps {
   listingsAPI: (filters?: EligibilityFilters) => Promise<RailsListing[]>
@@ -30,6 +31,8 @@ interface RentalDirectoryProps {
 }
 
 export const GenericDirectory = (props: RentalDirectoryProps) => {
+  useTranslate()
+
   const [rawListings, setRawListings] = useState([])
   const [listings, setListings] = useState<ListingsGroups>({
     open: [],

--- a/app/javascript/modules/listings/SharedHelpers.tsx
+++ b/app/javascript/modules/listings/SharedHelpers.tsx
@@ -80,6 +80,7 @@ export const getImageCardProps = (listing: RailsListing, hasFiltersSet?: boolean
     tags: getTagContent(listing),
     statuses: getListingImageCardStatuses(listing, hasFiltersSet),
     description: imageDescription,
+    innerClassName: "translate",
   }
 }
 


### PR DESCRIPTION
WIP: DAH-1866

These changes enable translation of alt text on the directory page BUT also translates other content such as listing name, etc.

Any suggestions welcome.

We could use `translate="yes" | "no"`, but that isn't supported in latest firefox.

If we do not want to upgrade to Google Cloud translate api, there are some other paths to explore here (another Bloom UIC change, etc) but I believe the best long term solution at this point is to change how we machine translate. 

Review:

Go to listings directory, open inspector -> network tab.
Change page language: you should see the google translate network response
If you inspect the image card on one of the listing cards, you should see alt text be translated. 