### PR TITLE
DAH-1936 fix endpoint being intercepted in machineTranslations e2e test

### DIFF
--- a/cypress/e2e/listingDetails/machineTranslations.e2e.ts
+++ b/cypress/e2e/listingDetails/machineTranslations.e2e.ts
@@ -1,5 +1,5 @@
 const verifyMachineTranslations = (language, id, translation) => {
-  cy.intercept("POST", "https://translate.googleapis.com/translate_a/t?*").as("getTranslate")
+  cy.intercept("POST", "https://translate-pa.googleapis.com/v1/translateHtml").as("getTranslate")
   cy.visit(`${language}/listings/${id}?react=true`)
   cy.wait("@getTranslate")
   return cy.contains(translation)


### PR DESCRIPTION
[DAH-1936](https://sfgovdt.jira.com/browse/DAH-1936)

Corrects `machineTranslations.e2e.ts` to the updated endpoint that google is using for translations. 

[DAH-1936]: https://sfgovdt.jira.com/browse/DAH-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ