### PR TITLE
feat: remove force update flag

### DIFF
--- a/app/services/multiple_listing_image_service.rb
+++ b/app/services/multiple_listing_image_service.rb
@@ -43,8 +43,7 @@ class MultipleListingImageService
         create_or_update_listing_image(@listing_id, image_url, li_raw_image_url)
       end
     # Else, if the image has been uploaded, check if we need to create the record in Postgres
-    elsif !listing_image_current?(@listing_id, image_url) ||
-          ENV['FORCE_MULTIPLE_LISTING_IMAGE_UPDATE'].to_s.casecmp('true').zero?
+    elsif !listing_image_current?(@listing_id, image_url)
       # if the listing_image record containing the image_url does not exist, create it
       create_or_update_listing_image(@listing_id, image_url, li_raw_image_url)
     end


### PR DESCRIPTION
https://sfgovdt.jira.com/browse/DAH-1997?atlOrigin=eyJpIjoiODM1MTMxODBjZjNhNDhmN2I1ZGQ5YTllZjJkYmI1M2YiLCJwIjoiaiJ9

Removed the FORCE_MULTIPLE_LISTING_IMAGE_UPDATE flag which overrides the check determining if we write to the Postgres table.

Testing steps:
Follow typical listing image flow
Ensure the rake job is set in the scheduler and the proper env variables are set in heroku
Update a listing image and wait for the job to run
Ensure that the image is cached and the database table is updated correctly.

