### PR TITLE
fix: DAH-2164 check if listing is null

### DIFF
--- a/app/javascript/pages/listings/listing-detail.tsx
+++ b/app/javascript/pages/listings/listing-detail.tsx
@@ -75,9 +75,12 @@ const ListingDetail = () => {
   useEffect(() => {
     const path = getPathWithoutLanguagePrefix(router.pathname)
     void getListing(path.split("/")[2]).then((listing: RailsListing) => {
+      if (!listing) {
+        router.push("/")
+      }
       setListing(listing)
     })
-  }, [router.pathname])
+  }, [router, router.pathname])
 
   return (
     <LoadingOverlay isLoading={!listing}>


### PR DESCRIPTION
https://sfgovdt.jira.com/browse/DAH-2164

Review:

- Go to a listing that exists, ensure it loads properly
- Go to a listing that does not exist (/123), it should redirect to the homepage.