### PR TITLE
fix: DAH-2275: Remove SFHDC from Housing Counselor Page

### DIFF
--- a/app/assets/json/housing_counselors_react.json
+++ b/app/assets/json/housing_counselors_react.json
@@ -52,22 +52,6 @@
             "phone": "(415) 209-5143"
         },
         {
-            "fullName": "San Francisco Housing Development Corporation (SFHDC)",
-            "shortName": "SFHDC",
-            "services": [
-                "rental",
-                "ownership"
-            ],
-            "languages": [
-                "english"
-            ],
-            "address": "4439 3rd Street",
-            "cityState": "San Francisco, CA 94124",
-            "website": "https://sfhdc.org/financial-empowerment/",
-            "email": "fecstaff@sfhdc.org",
-            "phone": "(415) 822-1022"
-        },
-        {
             "fullName": "SF LGBT Center",
             "services": [
                 "rental",


### PR DESCRIPTION
[DAH-2275](https://sfgovdt.jira.com/browse/DAH-2275)

[DAH-2275]: https://sfgovdt.jira.com/browse/DAH-2275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ