### PR TITLE
fix: DAH-2227 permit the recache param

### DIFF
--- a/app/controllers/api/v1/listings_controller.rb
+++ b/app/controllers/api/v1/listings_controller.rb
@@ -79,6 +79,6 @@ class Api::V1::ListingsController < ApiController
   private
 
   def listings_params
-    params.permit(:ids, :type, :subset).to_h
+    params.permit(:ids, :type, :subset, :force).to_h
   end
 end


### PR DESCRIPTION
https://sfgovdt.jira.com/browse/DAH-2227?focusedCommentId=79464

This addresses a mistake in the code found during PA testing. To the future release facilitator: you can safely exclude this PR from the release notes.