### PR TITLE
hotfix: DAH-2416 add invalid character validation

### DIFF
--- a/app/controllers/overrides/registrations_controller.rb
+++ b/app/controllers/overrides/registrations_controller.rb
@@ -43,7 +43,7 @@ module Overrides
     end
 
     def includes_url_characters(value)
-      value.include?('www') || value.include?('http')
+      value.include?('www') || value.include?('http') || value.include?('.')
     end
 
     def setup_resource_for_create

--- a/app/controllers/overrides/registrations_controller.rb
+++ b/app/controllers/overrides/registrations_controller.rb
@@ -38,7 +38,7 @@ module Overrides
     end
 
     def name_fields_have_invalid_characters?
-      includes_url_characters(params[:contact][:firstName]) || includes_url_characters(params[:contact][:lastName]) || includes_url_characters(params[:contact][:middleName])
+      includes_url_characters(params[:contact][:firstName]) || includes_url_characters(params[:contact][:lastName])
     end
 
     def includes_url_characters(value)

--- a/app/controllers/overrides/registrations_controller.rb
+++ b/app/controllers/overrides/registrations_controller.rb
@@ -4,19 +4,20 @@ module Overrides
     # method copied from original gem; refactored to please Rubocop
     def create
       setup_resource_for_create
+      return render_create_error if name_fields_have_invalid_characters?
+
       if resource_class.devise_modules.include?(:confirmable) && !@redirect_url
         return render_create_error_missing_confirm_success_url
       end
 
       # if whitelist is set, validate redirect_url against whitelist
-      if DeviseTokenAuth.redirect_whitelist
-        unless DeviseTokenAuth.redirect_whitelist.include?(@redirect_url)
-          return render_create_error_redirect_url_not_allowed
-        end
+      if DeviseTokenAuth.redirect_whitelist && !DeviseTokenAuth.redirect_whitelist.include?(@redirect_url)
+        return render_create_error_redirect_url_not_allowed
       end
 
       begin
         # override email confirmation, must be sent manually from ctrl
+
         resource_class.set_callback('create',
                                     :after,
                                     :send_on_create_confirmation_instructions)
@@ -34,6 +35,14 @@ module Overrides
 
     def error_checks_for_create
       # success redirect url is required
+    end
+
+    def name_fields_have_invalid_characters?
+      includes_url_characters(params[:contact][:firstName]) || includes_url_characters(params[:contact][:lastName]) || includes_url_characters(params[:contact][:middleName])
+    end
+
+    def includes_url_characters(value)
+      value.include?('www') || value.include?('http')
     end
 
     def setup_resource_for_create
@@ -100,7 +109,7 @@ module Overrides
     def render_create_error
       render json: {
         status: 'error',
-        data:   @resource.as_json,
+        data: @resource.as_json,
         errors: resource_errors,
       }, status: 422
     end
@@ -110,17 +119,18 @@ module Overrides
       resource['confirmed_at'] = @resource.confirmed_at
       render json: {
         status: 'success',
-        data:   resource,
+        data: resource,
       }
     end
 
     def resource_errors
       full_messages = @resource.errors.full_messages
-      @resource.errors.to_hash.merge(full_messages: full_messages)
+      @resource.errors.to_hash.merge(full_messages:)
     end
 
     def sync_with_salesforce
       return false if @resource.errors.any?
+
       attrs = account_params.merge(webAppID: current_user.id)
       salesforce_contact = Force::AccountService.create_or_update(attrs)
       unless salesforce_contact && salesforce_contact['contactId'].present?

--- a/app/controllers/overrides/registrations_controller.rb
+++ b/app/controllers/overrides/registrations_controller.rb
@@ -38,7 +38,8 @@ module Overrides
     end
 
     def name_fields_have_invalid_characters?
-      includes_url_characters(params[:contact][:firstName]) || includes_url_characters(params[:contact][:lastName])
+      contact_names = [params[:contact][:firstName], params[:contact][:lastName]]
+      contact_names.any? { |name| includes_url_characters(name) }
     end
 
     def includes_url_characters(value)

--- a/spec/controllers/overrides/registrations_controller_spec.rb
+++ b/spec/controllers/overrides/registrations_controller_spec.rb
@@ -29,24 +29,6 @@ describe Overrides::RegistrationsController do
     }
   end
 
-  let(:invalid_user_params) do
-    {
-      user: {
-        id: 1,
-        email: 'jane@doe.com',
-        password: 'somepassword',
-        password_confirmation: 'somepassword',
-      },
-      contact: {
-        firstName: 'http',
-        lastName: 'Doe',
-        DOB: '1985-07-23',
-        email: 'jane@doe.com',
-      },
-      confirm_success_url: 'http://localhost/my-account',
-    }
-  end
-
   let!(:user) do
     @user ||= User.create(
       email: 'jack@doe.com',
@@ -76,7 +58,45 @@ describe Overrides::RegistrationsController do
         .to receive(:create_or_update)
         .and_return(salesforce_response)
 
-      post :create, params: invalid_user_params
+      post :create, params: {
+        user: {
+          id: 1,
+          email: 'jane@doe.com',
+          password: 'somepassword',
+          password_confirmation: 'somepassword',
+        },
+        contact: {
+          firstName: 'http',
+          lastName: 'Doe',
+          DOB: '1985-07-23',
+          email: 'jane@doe.com',
+        },
+        confirm_success_url: 'http://localhost/my-account',
+      }
+
+      expect(response.status).to eq 422
+    end
+
+    it 'throws error if lastName includes invalid characters' do
+      allow(Force::AccountService)
+        .to receive(:create_or_update)
+        .and_return(salesforce_response)
+
+      post :create, params: {
+        user: {
+          id: 1,
+          email: 'jane@doe.com',
+          password: 'somepassword',
+          password_confirmation: 'somepassword',
+        },
+        contact: {
+          firstName: 'John',
+          lastName: 'www',
+          DOB: '1985-07-23',
+          email: 'jane@doe.com',
+        },
+        confirm_success_url: 'http://localhost/my-account',
+      }
 
       expect(response.status).to eq 422
     end

--- a/spec/controllers/overrides/registrations_controller_spec.rb
+++ b/spec/controllers/overrides/registrations_controller_spec.rb
@@ -29,6 +29,24 @@ describe Overrides::RegistrationsController do
     }
   end
 
+  let(:invalid_user_params) do
+    {
+      user: {
+        id: 1,
+        email: 'jane@doe.com',
+        password: 'somepassword',
+        password_confirmation: 'somepassword',
+      },
+      contact: {
+        firstName: 'http',
+        lastName: 'Doe',
+        DOB: '1985-07-23',
+        email: 'jane@doe.com',
+      },
+      confirm_success_url: 'http://localhost/my-account',
+    }
+  end
+
   let!(:user) do
     @user ||= User.create(
       email: 'jack@doe.com',
@@ -51,6 +69,16 @@ describe Overrides::RegistrationsController do
 
       expect(assigns(:resource).salesforce_contact_id)
         .to eq('0036C000001sI5oQAE')
+    end
+
+    it 'throws error if firstName includes invalid characters' do
+      allow(Force::AccountService)
+        .to receive(:create_or_update)
+        .and_return(salesforce_response)
+
+      post :create, params: invalid_user_params
+
+      expect(response.status).to eq 422
     end
   end
 

--- a/spec/controllers/overrides/registrations_controller_spec.rb
+++ b/spec/controllers/overrides/registrations_controller_spec.rb
@@ -97,7 +97,28 @@ describe Overrides::RegistrationsController do
         },
         confirm_success_url: 'http://localhost/my-account',
       }
+      expect(response.status).to eq 422
+    end
+    it 'throws error if lastName includes "."' do
+      allow(Force::AccountService)
+        .to receive(:create_or_update)
+        .and_return(salesforce_response)
 
+      post :create, params: {
+        user: {
+          id: 1,
+          email: 'jane@doe.com',
+          password: 'somepassword',
+          password_confirmation: 'somepassword',
+        },
+        contact: {
+          firstName: 'John',
+          lastName: 'bit.ly',
+          DOB: '1985-07-23',
+          email: 'jane@doe.com',
+        },
+        confirm_success_url: 'http://localhost/my-account',
+      }
       expect(response.status).to eq 422
     end
   end


### PR DESCRIPTION
Changes related to the issues documented in this ticket: https://sfgovdt.jira.com/browse/DAH-2416

Added a check for the firstName, lastName, and middleName parameters coming from the create account flow:
If any of those fields contains 'http' or 'www', we render an error.

Review Instructions
- Go to create an account
- In First Name, Middle Name, and Last Name fields: try to add a url and see if you can create an account successfully.
- Finally, remove any invalid characters and ensure you can create an account.
- I added a quick unit test, hopefully that passes.

We will need to review our validation practices going forward. I think there are some opportunities for refactoring here. This should address part of the issue (next we need to look at API limiting), but I am curious what other validations we may want to add here.

Additionally, I think we should also add validation checks to the Salesforce code.