### PR TITLE
fix: DAH-2570 fix veterans display for non-tiered applicants

### DIFF
--- a/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
@@ -105,6 +105,8 @@ export const ListingDetailsPreferences = ({ listingID }: ListingDetailsPreferenc
                     ),
             })
           }
+          console.log("hello")
+          console.log(preference)
 
           return {
             ...determineDescription(

--- a/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsPreferences.tsx
@@ -105,8 +105,6 @@ export const ListingDetailsPreferences = ({ listingID }: ListingDetailsPreferenc
                     ),
             })
           }
-          console.log("hello")
-          console.log(preference)
 
           return {
             ...determineDescription(

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferencesEducator.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferencesEducator.tsx
@@ -24,34 +24,36 @@ const LotteryPreferences = ({
   preferenceName,
   numVeteranApps,
   lastPref,
-}: PreferencesProps) => (
-  <div>
-    <div className="px-8">
-      <Heading className="font-sans font-semibold text-xs tracking-wide uppercase" priority={3}>
-        {defaultIfNotTranslated(
-          `listings.lotteryPreference.${preferenceName}.title`,
-          preferenceName
+}: PreferencesProps) => {
+  return (
+    <div>
+      <div className="px-8">
+        <Heading className="font-sans font-semibold text-xs tracking-wide uppercase" priority={3}>
+          {defaultIfNotTranslated(
+            `listings.lotteryPreference.${preferenceName}.title`,
+            preferenceName
+          )}
+        </Heading>
+        <p className="text-sm">{t("lottery.upToXUnitsAvailable", unitsAvailable)}</p>
+        {numVeteranApps > 0 ? (
+          <>
+            <p className="text-gray-700 text-sm">
+              {t("lottery.numberApplicantsQualifiedForPreference.veteran", numVeteranApps)}
+            </p>
+            <p className="text-gray-700 text-sm">
+              {t("lottery.numberApplicantsQualifiedForPreference.nonVeteran", totalSubmittedApps)}
+            </p>
+          </>
+        ) : (
+          <p className="text-gray-700 text-sm">
+            {t("lottery.numberApplicantsQualifiedForPreference", totalSubmittedApps)}
+          </p>
         )}
-      </Heading>
-      <p className="text-sm">{t("lottery.upToXUnitsAvailable", unitsAvailable)}</p>
-      {numVeteranApps > 0 ? (
-        <>
-          <p className="text-gray-700 text-sm">
-            {t("lottery.numberApplicantsQualifiedForPreference.veteran", numVeteranApps)}
-          </p>
-          <p className="text-gray-700 text-sm">
-            {t("lottery.numberApplicantsQualifiedForPreference.nonVeteran", totalSubmittedApps)}
-          </p>
-        </>
-      ) : (
-        <p className="text-gray-700 text-sm">
-          {t("lottery.numberApplicantsQualifiedForPreference", totalSubmittedApps)}
-        </p>
-      )}
+      </div>
+      <hr className={lastPref ? "mt-4" : "my-4"} />
     </div>
-    <hr className={lastPref ? "mt-4" : "my-4"} />
-  </div>
-)
+  )
+}
 
 const LotteryBucketHeader = ({ headerKey }: { headerKey: string }) => {
   return (
@@ -84,9 +86,10 @@ const LotteryBucketsContent = ({
     // from the preference short code by adding in the 'V-'
     // e.g. The number of veteran applications for 'T1-COP' are stored in veteranAppsByBucketMap
     // under the key 'T1-V-COP', so we insert 'V-' using replace to get the veteran preference short code
-    const veteransPreferenceShortCode = bucket.preferenceShortCode
-    const numVeteranApps =
-      veteranAppsByBucketMap[veteransPreferenceShortCode.replace("-", "-V-")] ?? 0
+    const veteransPreferenceShortCode = bucket.preferenceShortCode.startsWith("T")
+      ? bucket.preferenceShortCode.replace("-", "-V-")
+      : `V-${bucket.preferenceShortCode}`
+    const numVeteranApps = veteranAppsByBucketMap[veteransPreferenceShortCode] ?? 0
 
     return (
       <LotteryPreferences


### PR DESCRIPTION
## Description

Make sure the number of veterans displays for non-tiered applicants.

## Jira ticket

DAH-2570

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [x] code meets test coverage thresholds
- [x] code is properly formatted
- [x] code is linted
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] automated tests pass
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions have already been performed at least once
- [x] instructions can be followed by PA testers
- [x] instructions specify if it can only be followed by an engineer

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack