### PR TITLE
fix: DAH-2595 Add unleash env to base config

### DIFF
--- a/config/webpack/base.js
+++ b/config/webpack/base.js
@@ -38,6 +38,7 @@ generatedWebpackConfig.plugins.unshift(
       GOOGLE_TAG_MANAGER_KEY: JSON.stringify(process.env.GOOGLE_TAG_MANAGER_KEY),
       UNLEASH_URL: JSON.stringify(process.env.UNLEASH_URL),
       UNLEASH_TOKEN: JSON.stringify(process.env.UNLEASH_TOKEN),
+      UNLEASH_ENV: JSON.stringify(process.env.UNLEASH_ENV),
     },
   })
 )


### PR DESCRIPTION
## Description

This PR fixes an issue where the Unleash Environment variable was not being properly included in the webpack build.

## Jira ticket
[DAH-2595](https://sfgovdt.jira.com/browse/DAH-2595)


## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [x] code meets test coverage thresholds
- [x] code is properly formatted
- [x] code is linted
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] automated tests pass
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions have already been performed at least once
- [x] instructions can be followed by PA testers
- [x] instructions specify if it can only be followed by an engineer

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

[DAH-2595]: https://sfgovdt.jira.com/browse/DAH-2595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ