### PR TITLE
fix: DAH-2672 fix information that shows when see the unit is disabled

### DIFF
--- a/app/javascript/modules/listingDetailsAside/ListingDetailsProcess.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsProcess.tsx
@@ -11,7 +11,7 @@ import {
 } from "@bloom-housing/ui-components"
 import { getTranslatedString, localizedFormat, renderInlineMarkup } from "../../util/languageUtil"
 import { ListingDetailsLotteryPreferenceLists } from "./ListingDetailsLotteryPreferenceLists"
-
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
 export interface ListingDetailsProcessProps {
   listing: RailsListing
   isApplicationOpen: boolean
@@ -23,6 +23,7 @@ export const ListingDetailsProcess = ({
 }: ListingDetailsProcessProps) => {
   const isListingSale = isSale(listing)
   const isListingRental = isRental(listing)
+  const { unleashFlag: seeTheUnitEnabled } = useFeatureFlag("see_the_unit", false)
 
   return (
     <>
@@ -78,7 +79,7 @@ export const ListingDetailsProcess = ({
         listing.Leasing_Agent_Phone ||
         listing.Office_Hours ||
         listing.Leasing_Agent_Title) &&
-        isListingRental && (
+        (isListingRental || !seeTheUnitEnabled) && (
           <div className="border-b border-gray-400 md:border-b-0 last:border-b-0">
             <Contact
               sectionTitle={t("contactAgent.contact")}


### PR DESCRIPTION
## Description

We were missing information because the component it is moved to is not enabled yet.

## Jira ticket

DAH-2672

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [ ] code meets test coverage thresholds
- [ ] code is properly formatted
- [ ] code is linted
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] automated tests pass
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions have already been performed at least once
- [ ] instructions can be followed by PA testers
- [ ] instructions specify if it can only be followed by an engineer

### Request review

- [x] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack