### PR TITLE
DAH-2643 handle diff response

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -38,4 +38,8 @@ module ServiceHelper
   def self.convert_to_salesforce_field_name(field_name)
     "#{field_name}__c"
   end
+
+  def self.convert_to_domain_field_name(field_name)
+    field_name[0..-4]
+  end
 end

--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -113,15 +113,18 @@ module Force
     def process_event_values(listing_id, values)
       return [] unless values&.values
 
-      listing = Request.new(parse_response: true).get(
-        "/ListingDetails/#{CGI.escape(listing_id)}",
-      ).first
+      listing = nil
 
       text_to_translate = []
       values.each do |key, value|
         if value.is_a?(String)
           text_to_translate.push(value)
         else
+          if listing.nil?
+            listing = Request.new(parse_response: true).get(
+              "/ListingDetails/#{CGI.escape(listing_id)}",
+            ).first
+          end
           domain_key = ServiceHelper.convert_to_domain_field_name(key)
           text_to_translate.push(listing[domain_key])
         end

--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -113,8 +113,8 @@ module Force
     def process_event_values(listing_id, values)
       return [] unless values&.values
 
-      listing = Request.new(parse_response: true).cached_get(
-        "/ListingDetails/#{CGI.escape(listing_id)}", nil, true
+      listing = Request.new(parse_response: true).get(
+        "/ListingDetails/#{CGI.escape(listing_id)}",
       ).first
 
       text_to_translate = []

--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -89,7 +89,7 @@ module Force
     end
 
     def translate_and_cache(event)
-      translations = translate_event_values(event.updated_values)
+      translations = translate_event_values(event.listing_id, event.updated_values)
       logger(
         "Event Translations: #{translations.inspect}",
       )
@@ -110,12 +110,30 @@ module Force
       )
     end
 
-    def translate_event_values(values)
-      logger("Translating values: #{values.inspect}")
+    def process_event_values(listing_id, values)
       return [] unless values&.values
 
+      listing = Request.new(parse_response: true).cached_get(
+        "/ListingDetails/#{CGI.escape(listing_id)}", nil, true
+      ).first
+
+      text_to_translate = []
+      values.each do |key, value|
+        if value.is_a?(String)
+          text_to_translate.push(value)
+        else
+          domain_key = ServiceHelper.convert_to_domain_field_name(key)
+          text_to_translate.push(listing[domain_key])
+        end
+      end
+      text_to_translate
+    end
+
+    def translate_event_values(listing_id, values)
+      logger("Translating values: #{values.inspect}")
       languages = %w[ES ZH TL]
-      @translation_service.translate(values.values, languages)
+      text_to_translate = process_event_values(listing_id, values)
+      @translation_service.translate(text_to_translate, languages)
     end
 
     def parse_event(platform_event)

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -46,6 +46,7 @@ describe Force::EventSubscriberTranslateService do
     end
   end
   before do
+    listing_id = 'a0W4U00000KnjQuUAJ'
     allow(Restforce).to receive(:new).and_return(salesforce_client)
     allow(salesforce_client).to receive(:authenticate!).and_return(salesforce_auth_obj)
     allow(salesforce_client).to receive(:options).and_return({})
@@ -62,7 +63,10 @@ describe Force::EventSubscriberTranslateService do
       .with(Force::EventSubscriberTranslateService::UNSUBSCRIBE_CACHE_KEY)
       .and_return(true)
     allow(cache).to receive(:fetch)
-      .with('salesforce_oauth_token', { force: false })
+      .with('salesforce_oauth_token', any_args).and_yield
+    allow(cache).to receive(:fetch)
+      .with("/ListingDetails/#{CGI.escape(listing_id)}", { expires_in: 1.day,
+                                                           force: true })
       .and_return([:single_listing])
     allow(cache).to receive(:delete)
   end

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -29,22 +29,6 @@ describe Force::EventSubscriberTranslateService do
       'event' => { 'replayId' => 9_730_266 },
     }
   end
-  let(:event_obj) do
-    OpenStruct.new(
-      listing_id: 'a0W4U00000KnjQuUAJ',
-      last_modified_date: '2024-06-29T19:09:24Z',
-      entity_name: 'Listing__c',
-      changed_fields: %w[Name Credit_Rating__c LastModifiedDate],
-      replay_id: 9_730_266,
-      updated_values: {},
-    )
-    listing_id = 'a0W0P00000F8YG4UAN'
-    let(:single_listing) do
-      VCR.use_cassette('listings/single_listing') do
-        Force::ListingService.send :listing, listing_id
-      end
-    end
-  end
   before do
     listing_id = 'a0W4U00000KnjQuUAJ'
     allow(Restforce).to receive(:new).and_return(salesforce_client)

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -24,11 +24,7 @@ describe Force::EventSubscriberTranslateService do
         },
         'LastModifiedDate' => '2024-06-29T19:09:24Z',
         'Name' => '1075 Market St Unit 206 Update 3',
-        'Credit_Rating__c' => {
-          Eviction_History__c: {
-            diff: "--- \n+++ 62fad941bf896e7ac7c8381acc271fa2cb32671af45fe9a6c01c1b805b399c2d\n@@ -1,1 +1,1 @@\n-Hello, world 4\n+Hello, world",
-          },
-        },
+        'Credit_Rating__c' => 'Test update again, again',
       },
       'event' => { 'replayId' => 9_730_266 },
     }

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -38,10 +38,17 @@ describe Force::EventSubscriberTranslateService do
       replay_id: 9_730_266,
       updated_values: {},
     )
+    listing_id = 'a0W0P00000F8YG4UAN'
+    let(:single_listing) do
+      VCR.use_cassette('listings/single_listing') do
+        Force::ListingService.send :listing, listing_id
+      end
+    end
   end
   before do
     allow(Restforce).to receive(:new).and_return(salesforce_client)
     allow(salesforce_client).to receive(:authenticate!).and_return(salesforce_auth_obj)
+    allow(salesforce_client).to receive(:options).and_return({})
     allow(Faye::Client).to receive(:new).and_return(faye_client)
     allow(faye_client).to receive(:set_header)
     allow(faye_client).to receive(:subscribe).and_return(faye_subscription)
@@ -54,6 +61,9 @@ describe Force::EventSubscriberTranslateService do
     allow(cache).to receive(:fetch)
       .with(Force::EventSubscriberTranslateService::UNSUBSCRIBE_CACHE_KEY)
       .and_return(true)
+    allow(cache).to receive(:fetch)
+      .with('salesforce_oauth_token', { force: false })
+      .and_return([:single_listing])
     allow(cache).to receive(:delete)
   end
 

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -24,7 +24,11 @@ describe Force::EventSubscriberTranslateService do
         },
         'LastModifiedDate' => '2024-06-29T19:09:24Z',
         'Name' => '1075 Market St Unit 206 Update 3',
-        'Credit_Rating__c' => 'Test update again, again',
+        'Credit_Rating__c' => {
+          Eviction_History__c: {
+            diff: "--- \n+++ 62fad941bf896e7ac7c8381acc271fa2cb32671af45fe9a6c01c1b805b399c2d\n@@ -1,1 +1,1 @@\n-Hello, world 4\n+Hello, world",
+          },
+        },
       },
       'event' => { 'replayId' => 9_730_266 },
     }
@@ -86,7 +90,8 @@ describe Force::EventSubscriberTranslateService do
       end
       it 'detects incoming events from Salesforce and calls translations service' do
         EM.run do
-          expect(faye_client).to receive(:subscribe).with('/data/Listing__ChangeEvent').and_yield(event)
+          expect(faye_client).to receive(:subscribe)
+            .with('/data/Listing__ChangeEvent').and_yield(event)
           expect(translation_service).to receive(:translate).and_return(['Hello World'])
           expect(translation_service).to receive(:cache_listing_translations)
 


### PR DESCRIPTION
## Description

When the change to a salesforce field is large, the event from Salesforce sends a diff instead of the whole content. This PR gets the content from the listing when a diff is received and uses the content from the listing to get the translation.

## Jira ticket

DAH-2643

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [x] code meets test coverage thresholds
- [x] code is properly formatted
- [x] code is linted
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] automated tests pass
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions have already been performed at least once
- [x] instructions can be followed by PA testers
- [ ] instructions specify if it can only be followed by an engineer

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack