### PR TITLE
fix: remove specified engine versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,11 +124,6 @@
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-dev-server": "^4.15.1"
   },
-  "engines": {
-    "npm": "5.3.0",
-    "yarn": "1.x.x",
-    "node": "18.x.x"
-  },
   "scripts": {
     "postinstall": "bower install",
     "protractor": "protractor ./spec/e2e/conf.js",


### PR DESCRIPTION
## Description

Remove the requirements for engine versions in the package.json to resolve a Heroku build issue that multiple package versions are specified, so that the default Heroku settings for versions are used instead. 

## Jira ticket

[Slack bug thread](https://exygy.slack.com/archives/C030EGQAKK2/p1726073362684259)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [ ] code meets test coverage thresholds
- [ ] code is properly formatted
- [ ] code is linted
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] automated tests pass
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions have already been performed at least once
- [ ] instructions can be followed by PA testers
- [ ] instructions specify if it can only be followed by an engineer

### Request review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack