### PR TITLE
fix: remove specified engine versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,11 +124,6 @@
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-dev-server": "^4.15.1"
   },
-  "engines": {
-    "npm": "5.3.0",
-    "yarn": "1.x.x",
-    "node": "18.x.x"
-  },
   "scripts": {
     "postinstall": "bower install",
     "protractor": "protractor ./spec/e2e/conf.js",


### PR DESCRIPTION
## Description

Remove the requirements for engine versions in the package.json to resolve a Heroku build error that `Multiple package managers declared in package.json`, so that the default Heroku settings for versions are used instead.

To review, confirm that the PR branch builds successfully for [Heroku](https://dahlia-webapp-pr-2298.herokuapp.com) and [CircleCI](https://app.circleci.com/pipelines/github/SFDigitalServices/sf-dahlia-web/5858/workflows/02c7c097-de1d-4455-82ea-30268996b833). Note: the branch name includes `angular` to confirm that angular tests pass. 

## Jira ticket

This PR comes from a [Slack bug thread](https://exygy.slack.com/archives/C030EGQAKK2/p1726073362684259) instead of a Jira ticket.

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [x] code meets test coverage thresholds
- [x] code is properly formatted
- [x] code is linted
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] automated tests pass
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions have already been performed at least once
- [x] instructions can be followed by PA testers
- [x] instructions specify if it can only be followed by an engineer

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack