### PR TITLE
feat: DAH-2575 include original text when translating

### DIFF
--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -256,7 +256,7 @@ export const getTranslatedString = (
   translations: RailsTranslations
 ) => {
   const languageCode = getPageLanguageCode()
-  if (!languageCode || languageCode === "EN") {
+  if (!languageCode) {
     return originalValue
   }
   const isTranslationsEmpty = !translations || Object.keys(translations).length === 0

--- a/app/services/google_translation_service.rb
+++ b/app/services/google_translation_service.rb
@@ -18,13 +18,16 @@ class GoogleTranslationService
     return [] if text.empty?
 
     google_translation_logger("Translating text: #{text} to: #{to}")
-    to.map do |target|
+    translations = to.map do |target|
       translation = @translate.translate(text, to: target)
       { to: target, translation: parse_translations(translation) }
     rescue StandardError => e
       google_translation_logger("An error occured: #{e.inspect}", error: true)
       return []
     end
+    # include original values on the response
+    translations.push({ to: 'EN', translation: text })
+    translations
   end
 
   def cache_listing_translations(listing_id, keys, translations, last_modified)

--- a/spec/services/google_translation_service_spec.rb
+++ b/spec/services/google_translation_service_spec.rb
@@ -5,7 +5,10 @@ describe GoogleTranslationService do
     fields = %w[Hello World]
     languages = %w[ES]
     mock_response = [OpenStruct.new(text: 'Hello'), OpenStruct.new(text: 'World')]
-    expected_result = [{ to: 'ES', translation: %w[Hello World] }]
+    expected_result = [
+      { to: 'ES', translation: %w[Hello World] },
+      { to: 'EN', translation: %w[Hello World] },
+    ]
     listing_id = 'a0W0P00000F8YG4UAN'
     let(:mock_translate) { instance_double(Google::Cloud::Translate::V2::Api) }
     let(:mock_request) { instance_double(Force::Request) }
@@ -39,7 +42,7 @@ describe GoogleTranslationService do
       )
 
       expect(result).to eq({ LastModifiedDate: '2021-07-01T00:00:00Z',
-                             Hello: { ES: 'Hello' }, World: { ES: 'World' } })
+                             Hello: { EN: 'Hello', ES: 'Hello' }, World: { EN: 'World', ES: 'World' } })
     end
 
     it 'updates translation object for a listing' do


### PR DESCRIPTION
## Description

Adds original text as the English translation when translating. 

Note: We have the option in the future to pass english as a language for google translate to process, but I don't want to risk the response having a different value from the original text. But it would open up the option in the option in the future to allow any language submitted in Salesforce. (Don't think we need that for our purposes)

## Jira ticket

DAH-2575

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack