### PR TITLE
DAH-2722 fix: check for nil before parsing LastModifiedDate

### DIFF
--- a/app/services/force/listing_service.rb
+++ b/app/services/force/listing_service.rb
@@ -85,7 +85,7 @@ module Force
     def self.listing_is_outdated?(cache_last_modified, listing_last_modified)
       parse_time(cache_last_modified) > parse_time(listing_last_modified)
     rescue InvalidLastModifiedDateError => e
-      Rails.logger.error("Error checking if translations are outdated: #{e.message}")
+      Rails.logger.error("Error checking if listing is outdated: #{e.message}")
       true
     end
 

--- a/app/services/force/listing_service.rb
+++ b/app/services/force/listing_service.rb
@@ -74,10 +74,14 @@ module Force
     end
 
     def self.translations_are_outdated?(cache_last_modified, listing_last_modified)
+      return true if cache_last_modified.nil? || listing_last_modified.nil?
+
       parse_time(cache_last_modified) < parse_time(listing_last_modified)
     end
 
     def self.listing_is_outdated?(cache_last_modified, listing_last_modified)
+      return true if cache_last_modified.nil? || listing_last_modified.nil?
+
       parse_time(cache_last_modified) > parse_time(listing_last_modified)
     end
 
@@ -94,7 +98,12 @@ module Force
     end
 
     def self.parse_time(time_str)
+      return nil if time_str.nil?
+
       Time.parse(time_str)
+    rescue ArgumentError => e
+      Rails.logger.error("Error parsing time: #{e.message}")
+      nil
     end
 
     # get all units for a given listing

--- a/spec/services/listing_service_spec.rb
+++ b/spec/services/listing_service_spec.rb
@@ -164,6 +164,39 @@ describe Force::ListingService do
       translations_invalid = Force::ListingService.translations_invalid?(translations)
       expect(translations_invalid).to be_falsey
     end
+    it 'listing_outdated returns true when listing LastModifiedDate is old' do
+      listing_is_outdated = Force::ListingService.listing_is_outdated?(
+        '2024-03-08T16:51:35.000+0000', '2024-02-08T16:51:35.000+0000'
+      )
+      expect(listing_is_outdated).to be_truthy
+    end
+    it 'listing_outdated returns false when listing LastModifiedDate is fresh' do
+      listing_is_outdated = Force::ListingService.listing_is_outdated?(
+        '2024-03-08T16:51:35.000+0000', '2024-03-08T16:51:35.000+0000'
+      )
+      expect(listing_is_outdated).to be_falsey
+    end
+    it 'listing_outdated returns true when listing LastModifiedDate is Nil' do
+      listing_is_outdated = Force::ListingService.listing_is_outdated?(nil, nil)
+      expect(listing_is_outdated).to be_truthy
+    end
+    it 'translations_are_outdated returns true when translation LastModifiedDate is old' do
+      translations_are_outdated = Force::ListingService.translations_are_outdated?(
+        '2024-02-08T16:51:35.000+0000', '2024-03-08T16:51:35.000+0000'
+      )
+      expect(translations_are_outdated).to be_truthy
+    end
+    it 'translations_are_outdated returns false when translation LastModifiedDate is fresh' do
+      translations_are_outdated = Force::ListingService.translations_are_outdated?(
+        '2024-03-08T16:51:35.000+0000', '2024-03-08T16:51:35.000+0000'
+      )
+      expect(translations_are_outdated).to be_falsey
+    end
+    it 'translations_are_outdated returns true when translation LastModifiedDate is nil' do
+      translations_are_outdated = Force::ListingService.translations_are_outdated?(nil,
+                                                                                   nil)
+      expect(translations_are_outdated).to be_truthy
+    end
   end
 
   describe '.eligible_listings' do


### PR DESCRIPTION
## Description

If `Time.parse` receives `nil`, it throws an `ArgumentError`
Check for `nil` before comparing `LastModifiedDate`

## DAH-2722

https://sfgovdt.jira.com/

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Review

Run `memcached`
Run `yarn start`

Once loaded, visit several listing detail pages. Ensure that the page loads.
Check logs to see if the outdated checks are working properly
