### PR TITLE
fix: DAH-2744 Uninitialized Unleash Constant in Rails

### DIFF
--- a/app/services/force/listing_service.rb
+++ b/app/services/force/listing_service.rb
@@ -40,7 +40,7 @@ module Force
       results = Request.new(parse_response: true).cached_get(endpoint, nil, force)
       listing = process_listing_images(results)
 
-      if ::UNLEASH.is_enabled? 'GoogleCloudTranslate'
+      if Rails.configuration.unleash.is_enabled? 'GoogleCloudTranslate'
         listing['translations'] = get_listing_translations(listing) || {}
       end
       listing

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,13 @@
 Sidekiq.configure_server do |config|
   config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+
+  config.on(:startup) do
+    ::UNLEASH ||= Unleash::Client.new # rubocop:disable Style/RedundantConstantBase, Lint/OrAssignmentToConstant
+  end
+
+  config.on(:shutdown) do
+    ::UNLEASH.shutdown # rubocop:disable Style/RedundantConstantBase
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,11 +2,11 @@ Sidekiq.configure_server do |config|
   config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
 
   config.on(:startup) do
-    ::UNLEASH ||= Unleash::Client.new # rubocop:disable Style/RedundantConstantBase, Lint/OrAssignmentToConstant
+    Rails.configuration.unleash = Unleash::Client.new
   end
 
   config.on(:shutdown) do
-    ::UNLEASH.shutdown # rubocop:disable Style/RedundantConstantBase
+    Rails.configuration.unleash.shutdown
   end
 end
 

--- a/config/initializers/unleash.rb
+++ b/config/initializers/unleash.rb
@@ -3,6 +3,9 @@ Unleash.configure do |config|
   config.url      = ENV.fetch('UNLEASH_URL', nil)
   config.logger   = Rails.logger
   config.custom_http_headers = { Authorization: ENV.fetch('UNLEASH_TOKEN_RAILS', nil) }
+  # this needs to be explicitly set, otherwise the toggle fetcher never re-fetches,
+  #   might be an Unleash SDK bug
+  config.refresh_interval = 15
 end
 
 ::UNLEASH = Unleash::Client.new # rubocop:disable Style/RedundantConstantBase

--- a/config/initializers/unleash.rb
+++ b/config/initializers/unleash.rb
@@ -1,8 +1,7 @@
 Unleash.configure do |config|
-  config.app_name  = 'webapp'
-  config.url       = ENV.fetch('UNLEASH_URL', nil)
-  config.logger    = Rails.logger
-  config.log_level = Logger::DEBUG
+  config.app_name = 'webapp'
+  config.url      = ENV.fetch('UNLEASH_URL', nil)
+  config.logger   = Rails.logger
   config.custom_http_headers = { Authorization: ENV.fetch('UNLEASH_TOKEN_RAILS', nil) }
 end
 

--- a/config/initializers/unleash.rb
+++ b/config/initializers/unleash.rb
@@ -4,3 +4,5 @@ Unleash.configure do |config|
   config.logger   = Rails.logger
   config.custom_http_headers = { Authorization: ENV.fetch('UNLEASH_TOKEN_RAILS', nil) }
 end
+
+::UNLEASH = Unleash::Client.new # rubocop:disable Style/RedundantConstantBase

--- a/config/initializers/unleash.rb
+++ b/config/initializers/unleash.rb
@@ -1,11 +1,9 @@
 Unleash.configure do |config|
-  config.app_name = 'webapp'
-  config.url      = ENV.fetch('UNLEASH_URL', nil)
-  config.logger   = Rails.logger
+  config.app_name  = 'webapp'
+  config.url       = ENV.fetch('UNLEASH_URL', nil)
+  config.logger    = Rails.logger
+  config.log_level = Logger::DEBUG
   config.custom_http_headers = { Authorization: ENV.fetch('UNLEASH_TOKEN_RAILS', nil) }
-  # this needs to be explicitly set, otherwise the toggle fetcher never re-fetches,
-  #   might be an Unleash SDK bug
-  config.refresh_interval = 15
 end
 
-::UNLEASH = Unleash::Client.new # rubocop:disable Style/RedundantConstantBase
+Rails.configuration.unleash = Unleash::Client.new

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,3 @@
-require 'unleash'
-
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,11 +40,11 @@ preload_app!
 # cannot share connections between processes.
 #
 on_worker_boot do
-  ::UNLEASH ||= Unleash::Client.new # rubocop:disable Style/RedundantConstantBase, Lint/OrAssignmentToConstant
+  Rails.configuration.unleash = Unleash::Client.new
 end
 
 on_worker_shutdown do
-  ::UNLEASH.shutdown # rubocop:disable Style/RedundantConstantBase
+  Rails.configuration.unleash.shutdown
 end
 
 # Allow puma to be restarted by `rails restart` command.

--- a/lib/tasks/debug_unleash_flag.rake
+++ b/lib/tasks/debug_unleash_flag.rake
@@ -1,0 +1,18 @@
+# TODO: DAH-2744 delete this debug task
+
+namespace :debug do
+  desc 'Debug Unleash flag initialization'
+  task debug_unleash_flag: :environment do
+    puts "::UNLEASH constant: #{::UNLEASH.inspect}" # rubocop:disable Style/RedundantConstantBase
+
+    puts "creating 'submission_confirmation' sidekiq job"
+    Emailer.submission_confirmation(
+      locale: 'en',
+      email: 'jim.lin+test@sfgov.org',
+      listing_id: 'a0W0P00000F8YG4UAN',
+      lottery_number: '01234567',
+      first_name: 'testfirst',
+      last_name: 'testlast',
+    ).deliver_later
+  end
+end

--- a/lib/tasks/debug_unleash_flag.rake
+++ b/lib/tasks/debug_unleash_flag.rake
@@ -1,14 +1,16 @@
-# TODO: DAH-2744 delete this debug task
-
 namespace :debug do
   desc 'Debug Unleash flag initialization'
   task debug_unleash_flag: :environment do
     puts "::UNLEASH constant: #{::UNLEASH.inspect}" # rubocop:disable Style/RedundantConstantBase
 
-    puts "creating 'submission_confirmation' sidekiq job"
+    email = ENV.fetch('email', nil)
+    raise 'Error: invalid email' if email.blank? || !/.+@.+\..+/.match(email)
+
+    puts "creating fake submission confirmation email to #{email}" \
+         'to debug sidekiq job'
     Emailer.submission_confirmation(
       locale: 'en',
-      email: 'jim.lin+test@sfgov.org',
+      email:,
       listing_id: 'a0W0P00000F8YG4UAN',
       lottery_number: '01234567',
       first_name: 'testfirst',

--- a/lib/tasks/debug_unleash_flag.rake
+++ b/lib/tasks/debug_unleash_flag.rake
@@ -1,7 +1,7 @@
 namespace :debug do
   desc 'Debug Unleash flag initialization'
   task debug_unleash_flag: :environment do
-    puts "::UNLEASH constant: #{::UNLEASH.inspect}" # rubocop:disable Style/RedundantConstantBase
+    puts "Rails.configuration.unleash: #{Rails.configuration.unleash.inspect}"
 
     email = ENV.fetch('email', nil)
     raise 'Error: invalid email' if email.blank? || !/.+@.+\..+/.match(email)

--- a/lib/tasks/debug_unleash_flag.rake
+++ b/lib/tasks/debug_unleash_flag.rake
@@ -6,7 +6,7 @@ namespace :debug do
     email = ENV.fetch('email', nil)
     raise 'Error: invalid email' if email.blank? || !/.+@.+\..+/.match(email)
 
-    puts "creating fake submission confirmation email to #{email}" \
+    puts "sending fake submission confirmation email to '#{email}' " \
          'to debug sidekiq job'
     Emailer.submission_confirmation(
       locale: 'en',

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -58,12 +58,12 @@ describe Force::EventSubscriberTranslateService do
 
   describe '#listen_and_process_events when the GoogleCloudTranslate ff is enabled' do
     before do
-      allow(::UNLEASH).to receive(:is_enabled?) # rubocop:disable Style/RedundantConstantBase
+      allow(Rails.configuration.unleash).to receive(:is_enabled?)
         .with('GoogleCloudTranslate')
         .and_return(true)
     end
     after do
-      allow(::UNLEASH).to receive(:is_enabled?) # rubocop:disable Style/RedundantConstantBase
+      allow(Rails.configuration.unleash).to receive(:is_enabled?)
         .and_return(false)
     end
     describe 'when the service is initialized' do

--- a/spec/services/listing_service_spec.rb
+++ b/spec/services/listing_service_spec.rb
@@ -83,7 +83,7 @@ describe Force::ListingService do
       allow(Force::Request).to receive(:new).and_return(request_instance)
       allow(request_instance).to receive(:cached_get).with(endpoint, nil,
                                                            false).and_return([single_listing])
-      allow(::UNLEASH).to receive(:is_enabled?) # rubocop:disable Style/RedundantConstantBase
+      allow(Rails.configuration.unleash).to receive(:is_enabled?)
         .with('GoogleCloudTranslate')
         .and_return(true)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,10 +65,8 @@ RSpec.configure do |config|
     unleash_client = instance_double(Unleash::Client)
     allow(Unleash::Client).to receive(:new).and_return(unleash_client)
     allow(unleash_client).to receive(:is_enabled?).and_return(false)
-    stub_const('UNLEASH', unleash_client)
-
-    ::UNLEASH ||= unleash_client # rubocop:disable Style/RedundantConstantBase, Lint/OrAssignmentToConstant
-    allow(::UNLEASH).to receive(:is_enabled?).and_return(false) # rubocop:disable Style/RedundantConstantBase
+    Rails.configuration.unleash = unleash_client
+    allow(Rails.configuration.unleash).to receive(:is_enabled?).and_return(false)
 
     DatabaseCleaner.clean
     Rails.cache.clear


### PR DESCRIPTION
## Description

Fix Unleash configuration in Rails, specifically for rake tasks and sidekiq jobs.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2744

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack