### PR TITLE
fix: DAH-2754 Add missing text for RTR Hunters View application question

### DIFF
--- a/app/assets/javascripts/short-form/components/preference-proof-uploader.html.slim
+++ b/app/assets/javascripts/short-form/components/preference-proof-uploader.html.slim
@@ -12,6 +12,8 @@
     | {{'preferences.alice_griffith.proof_desc' | translate}}
   p.form-note.margin-bottom ng-if="$ctrl.preference == 'rightToReturnSunnydale'"
     | {{'preferences.rtr_sunnydale.proof_desc' | translate}}
+  p.form-note.margin-bottom ng-if="$ctrl.preference == 'rightToReturnHuntersView'"
+    | {{'preferences.rtr_huntersview.proof_desc' | translate}}
   p.form-note.margin-bottom ng-if="$ctrl.proofType == 'Copy of Lease'"
     | {{'label.upload_lease_description' | translate}}
 

--- a/app/assets/json/translations/locale-en.json
+++ b/app/assets/json/translations/locale-en.json
@@ -1272,6 +1272,7 @@
                 "address": "Hunters View Address",
                 "address_desc": "Your current or former address at the Hunters View public housing development",
                 "desc": "For households in which at least one person is a former or current resident of Hunters View public housing. Please note, these units are not subsidized, the rent will not change if your income changes. ",
+                "proof_desc": "You'll need one of the following documents showing your address at Hunters View Housing Development.",
                 "title": "Right to Return - Hunters View Preference"
             },
             "rtr_sunnydale": {

--- a/app/assets/json/translations/locale-es.json
+++ b/app/assets/json/translations/locale-es.json
@@ -1271,6 +1271,7 @@
                 "address": "Dirección en Hunters View",
                 "address_desc": "Su dirección actual o anterior en el desarrollo de vivienda pública Hunters View",
                 "desc": "Para hogares en donde por lo menos una persona es o era residente de la vivienda pública de Hunters View. Por favor tome nota de que estas unidades no son subsidiadas, la renta no cambiará si su su ingreso cambia. ",
+                "proof_desc": "Necesitará uno de los siguientes documentos que incluyan su dirección en el desarrollo de vivienda pública de Hunters View.",
                 "title": "Derecho a regresar - preferencia de vivienda en Hunters View"
             },
             "rtr_sunnydale": {

--- a/app/assets/json/translations/locale-tl.json
+++ b/app/assets/json/translations/locale-tl.json
@@ -1271,6 +1271,7 @@
                 "address": "Address sa Hunters View",
                 "address_desc": "Ang iyong kasalukuyan o dating address sa pampublikong pabahay ng Hunters View",
                 "desc": "Para sa mga kabahayan kung saan may kahit isang tao na dati o kasalukuyang residente ng pampublikong pabahay ng Hunters View. Pakitandaang hindi naka-subsidize ang mga yunit na ito, hindi magbabago ang renta kung magbabago ang iyong kita. ",
+                "proof_desc": "Kakailanganin mo ng isa sa mga sumusunod na dokumentong nagpapakita ng iyong address sa Hunters View Housing Development.",
                 "title": "Karapatang Bumalik - Kagustuhan sa Hunters View"
             },
             "rtr_sunnydale": {

--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -1272,6 +1272,7 @@
                 "address": "Hunters View 住址",
                 "address_desc": "您目前或從前在Hunters View公共住宅建築的住址。",
                 "desc": "適用於家庭中至少有一位是曾經或現在居住在Hunters View公共住宅的民眾。請注意，這些單位沒有提供補助。房租不會因您的收入改變而調整。",
+                "proof_desc": "您需要準備以下其中一項的文件來證明您在Hunters View住宅建築的地址。",
                 "title": "回歸權 - Hunters View 優先權"
             },
             "rtr_sunnydale": {


### PR DESCRIPTION
## Description

Fixes a mistake [uncovered during PA testing](https://sfgovdt.jira.com/browse/DAH-2754?focusedCommentId=81509), adds missing text below the "WHICH ONE OF THE FOLLOW DOCUMENTS..." text. To review, just check for this missing text.

This will be the second PR attached to the Jira ticket.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2754

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack