### PR TITLE
fix: DAH-2758 Add required indicators to required account settings fields

### DIFF
--- a/app/javascript/__tests__/pages/account/__snapshots__/account-settings.test.tsx.snap
+++ b/app/javascript/__tests__/pages/account/__snapshots__/account-settings.test.tsx.snap
@@ -275,6 +275,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               class="input"
                               id="firstName"
                               name="firstName"
+                              required=""
                               type="text"
                               value="FirstName"
                             />
@@ -327,6 +328,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               class="input"
                               id="lastName"
                               name="lastName"
+                              required=""
                               type="text"
                               value="LastName"
                             />
@@ -387,6 +389,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                                 id="dobObject.birthMonth"
                                 maxlength="2"
                                 name="dobObject.birthMonth"
+                                required=""
                                 type="number"
                                 value="01"
                               />
@@ -414,6 +417,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                                 id="dobObject.birthDay"
                                 maxlength="2"
                                 name="dobObject.birthDay"
+                                required=""
                                 type="number"
                                 value="01"
                               />
@@ -441,6 +445,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                                 id="dobObject.birthYear"
                                 maxlength="4"
                                 name="dobObject.birthYear"
+                                required=""
                                 type="number"
                                 value="1999"
                               />
@@ -497,6 +502,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               id="email"
                               name="email"
                               placeholder="example@web.com"
+                              required=""
                               type="email"
                               value="email@email.com"
                             />
@@ -558,6 +564,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               class="input pr-10"
                               id="currentPassword"
                               name="currentPassword"
+                              required=""
                               type="password"
                               value=""
                             />
@@ -652,6 +659,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               class="input pr-10"
                               id="password"
                               name="password"
+                              required=""
                               type="text"
                               value=""
                             />
@@ -1104,6 +1112,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             class="input"
                             id="firstName"
                             name="firstName"
+                            required=""
                             type="text"
                             value="FirstName"
                           />
@@ -1156,6 +1165,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             class="input"
                             id="lastName"
                             name="lastName"
+                            required=""
                             type="text"
                             value="LastName"
                           />
@@ -1216,6 +1226,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               id="dobObject.birthMonth"
                               maxlength="2"
                               name="dobObject.birthMonth"
+                              required=""
                               type="number"
                               value="01"
                             />
@@ -1243,6 +1254,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               id="dobObject.birthDay"
                               maxlength="2"
                               name="dobObject.birthDay"
+                              required=""
                               type="number"
                               value="01"
                             />
@@ -1270,6 +1282,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                               id="dobObject.birthYear"
                               maxlength="4"
                               name="dobObject.birthYear"
+                              required=""
                               type="number"
                               value="1999"
                             />
@@ -1326,6 +1339,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             id="email"
                             name="email"
                             placeholder="example@web.com"
+                            required=""
                             type="email"
                             value="email@email.com"
                           />
@@ -1387,6 +1401,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             class="input pr-10"
                             id="currentPassword"
                             name="currentPassword"
+                            required=""
                             type="password"
                             value=""
                           />
@@ -1481,6 +1496,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             class="input pr-10"
                             id="password"
                             name="password"
+                            required=""
                             type="text"
                             value=""
                           />
@@ -1990,6 +2006,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               class="input"
                               id="firstName"
                               name="firstName"
+                              required=""
                               type="text"
                               value="FirstName"
                             />
@@ -2042,6 +2059,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               class="input"
                               id="lastName"
                               name="lastName"
+                              required=""
                               type="text"
                               value="LastName"
                             />
@@ -2102,6 +2120,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                                 id="dobObject.birthMonth"
                                 maxlength="2"
                                 name="dobObject.birthMonth"
+                                required=""
                                 type="number"
                                 value="01"
                               />
@@ -2129,6 +2148,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                                 id="dobObject.birthDay"
                                 maxlength="2"
                                 name="dobObject.birthDay"
+                                required=""
                                 type="number"
                                 value="01"
                               />
@@ -2156,6 +2176,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                                 id="dobObject.birthYear"
                                 maxlength="4"
                                 name="dobObject.birthYear"
+                                required=""
                                 type="number"
                                 value="1999"
                               />
@@ -2212,6 +2233,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               id="email"
                               name="email"
                               placeholder="example@web.com"
+                              required=""
                               type="email"
                               value="email@email.com"
                             />
@@ -2273,6 +2295,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               class="input pr-10"
                               id="currentPassword"
                               name="currentPassword"
+                              required=""
                               type="password"
                               value=""
                             />
@@ -2367,6 +2390,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               class="input pr-10"
                               id="password"
                               name="password"
+                              required=""
                               type="text"
                               value=""
                             />
@@ -2819,6 +2843,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             class="input"
                             id="firstName"
                             name="firstName"
+                            required=""
                             type="text"
                             value="FirstName"
                           />
@@ -2871,6 +2896,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             class="input"
                             id="lastName"
                             name="lastName"
+                            required=""
                             type="text"
                             value="LastName"
                           />
@@ -2931,6 +2957,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               id="dobObject.birthMonth"
                               maxlength="2"
                               name="dobObject.birthMonth"
+                              required=""
                               type="number"
                               value="01"
                             />
@@ -2958,6 +2985,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               id="dobObject.birthDay"
                               maxlength="2"
                               name="dobObject.birthDay"
+                              required=""
                               type="number"
                               value="01"
                             />
@@ -2985,6 +3013,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                               id="dobObject.birthYear"
                               maxlength="4"
                               name="dobObject.birthYear"
+                              required=""
                               type="number"
                               value="1999"
                             />
@@ -3041,6 +3070,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             id="email"
                             name="email"
                             placeholder="example@web.com"
+                            required=""
                             type="email"
                             value="email@email.com"
                           />
@@ -3102,6 +3132,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             class="input pr-10"
                             id="currentPassword"
                             name="currentPassword"
+                            required=""
                             type="password"
                             value=""
                           />
@@ -3196,6 +3227,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             class="input pr-10"
                             id="password"
                             name="password"
+                            required=""
                             type="text"
                             value=""
                           />

--- a/app/javascript/pages/account/components/DOBFieldset.tsx
+++ b/app/javascript/pages/account/components/DOBFieldset.tsx
@@ -165,7 +165,7 @@ const DateField = ({
           range: fieldInfo[fieldKey].validation,
         },
       }}
-      inputProps={{ maxLength: fieldInfo[fieldKey].maxLength }}
+      inputProps={{ maxLength: fieldInfo[fieldKey].maxLength, required: true }}
       type="number"
       register={register}
       onChange={onChange}

--- a/app/javascript/pages/account/components/EmailFieldset.tsx
+++ b/app/javascript/pages/account/components/EmailFieldset.tsx
@@ -100,6 +100,7 @@ const EmailFieldset = ({ register, errors, defaultEmail, onChange, note }: Email
         register={register}
         defaultValue={defaultEmail ?? null}
         onChange={onChange}
+        inputProps={{ required: true }}
       />
     </Fieldset>
   )

--- a/app/javascript/pages/account/components/NameFieldset.tsx
+++ b/app/javascript/pages/account/components/NameFieldset.tsx
@@ -70,6 +70,7 @@ const NameFieldset = ({
           required: "name:firstName",
           validate: (data: string) => data.trim() !== "" || "name:firstName",
         }}
+        inputProps={{ required: true }}
         onChange={onChange}
       />
       <Field
@@ -97,6 +98,7 @@ const NameFieldset = ({
           validate: (data: string) => data.trim() !== "" || "name:firstName",
         }}
         onChange={onChange}
+        inputProps={{ required: true }}
       />
     </Fieldset>
   )

--- a/app/javascript/pages/account/components/PasswordFieldset.tsx
+++ b/app/javascript/pages/account/components/PasswordFieldset.tsx
@@ -128,7 +128,7 @@ const PasswordField = ({ passwordVisibilityDefault = false, ...props }: Password
     <Field
       {...props}
       type={showPassword ? "text" : "password"}
-      inputProps={{ className: "input pr-10" }}
+      inputProps={{ className: "input pr-10", required: true }}
       postInputContent={
         <button
           className="absolute right-2 h-full"


### PR DESCRIPTION
## Description

This A11Y ticket adds the required flag to required account setting fields.

## Jira ticket

[DAH-2758](https://sfgovdt.jira.com/browse/DAH-2758)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

[DAH-2758]: https://sfgovdt.jira.com/browse/DAH-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ