### PR TITLE
fix: DAH-2759 Associate new password instructions with field

### DIFF
--- a/app/javascript/__tests__/pages/account/__snapshots__/account-settings.test.tsx.snap
+++ b/app/javascript/__tests__/pages/account/__snapshots__/account-settings.test.tsx.snap
@@ -617,6 +617,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                         </div>
                         <div
                           class="field-note"
+                          id="newPasswordInstructions"
                         >
                           <span>
                             Must include at least:
@@ -654,7 +655,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             class="control"
                           >
                             <input
-                              aria-describedby="password-error"
+                              aria-describedby="newPasswordInstructions"
                               aria-invalid="false"
                               class="input pr-10"
                               id="password"
@@ -1454,6 +1455,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                       </div>
                       <div
                         class="field-note"
+                        id="newPasswordInstructions"
                       >
                         <span>
                           Must include at least:
@@ -1491,7 +1493,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                           class="control"
                         >
                           <input
-                            aria-describedby="password-error"
+                            aria-describedby="newPasswordInstructions"
                             aria-invalid="false"
                             class="input pr-10"
                             id="password"
@@ -2348,6 +2350,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                         </div>
                         <div
                           class="field-note"
+                          id="newPasswordInstructions"
                         >
                           <span>
                             Must include at least:
@@ -2385,7 +2388,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             class="control"
                           >
                             <input
-                              aria-describedby="password-error"
+                              aria-describedby="newPasswordInstructions"
                               aria-invalid="false"
                               class="input pr-10"
                               id="password"
@@ -3185,6 +3188,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                       </div>
                       <div
                         class="field-note"
+                        id="newPasswordInstructions"
                       >
                         <span>
                           Must include at least:
@@ -3222,7 +3226,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                           class="control"
                         >
                           <input
-                            aria-describedby="password-error"
+                            aria-describedby="newPasswordInstructions"
                             aria-invalid="false"
                             class="input pr-10"
                             id="password"

--- a/app/javascript/pages/account/components/PasswordFieldset.tsx
+++ b/app/javascript/pages/account/components/PasswordFieldset.tsx
@@ -102,7 +102,7 @@ const NewPasswordInstructions = ({
 }) => {
   const showValidationInfo = passwordValidationContent.length > 0
   return (
-    <div className="field-note">
+    <div className="field-note" id="newPasswordInstructions">
       <span>{t("createAccount.passwordInstructions.mustInclude")}</span>
       <ul className={`${showValidationInfo ? "" : "list-disc list-inside pl-2"}`}>
         {instructionListItem(
@@ -211,6 +211,7 @@ const PasswordFieldset = ({
         <NewPasswordInstructions passwordValidationContent={passwordValidationContent} />
       )}
       <PasswordField
+        describedBy={errors.password?.message ? undefined : "newPasswordInstructions"} // undefined will force the input to be described by the error message
         name="password"
         label="password"
         labelClassName="hidden"


### PR DESCRIPTION
## Description

This PR makes it so that the new password instructions are correctly associated with the new password field.

## Jira ticket

[DAH-2759](https://sfgovdt.jira.com/browse/DAH-2759)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

[DAH-2759]: https://sfgovdt.jira.com/browse/DAH-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ