### PR TITLE
fix: DAH-2295 allow all flag overrides in development

### DIFF
--- a/app/javascript/hooks/useFeatureFlag.tsx
+++ b/app/javascript/hooks/useFeatureFlag.tsx
@@ -15,10 +15,8 @@ export const useFeatureFlag = (flagName: string, defaultValue: boolean) => {
 
   const unleashFlag = useFlagUnleash(flagName)
 
-  if (
-    doesURLHaveFlag &&
-    (urlWhiteList.has(flagName) || process.env.UNLEASH_ENV === "development")
-  ) {
+  const useUrlOverride = urlWhiteList.has(flagName) || process.env.UNLEASH_ENV === "development"
+  if (doesURLHaveFlag && useUrlOverride) {
     if (flagFromUrl === "true") {
       return { flagsReady: true, unleashFlag: true }
     } else if (flagFromUrl === "false") {

--- a/app/javascript/hooks/useFeatureFlag.tsx
+++ b/app/javascript/hooks/useFeatureFlag.tsx
@@ -15,7 +15,10 @@ export const useFeatureFlag = (flagName: string, defaultValue: boolean) => {
 
   const unleashFlag = useFlagUnleash(flagName)
 
-  if (doesURLHaveFlag && urlWhiteList.has(flagName)) {
+  if (
+    doesURLHaveFlag &&
+    (urlWhiteList.has(flagName) || process.env.UNLEASH_ENV === "development")
+  ) {
     if (flagFromUrl === "true") {
       return { flagsReady: true, unleashFlag: true }
     } else if (flagFromUrl === "false") {


### PR DESCRIPTION
## Description

I realized we should allow all flag overrides in development. 

## Jira ticket

DAH-2295

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack