### PR TITLE
fix: DAH-2792 remove popup warning for 'save and finish later' redirect

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -888,6 +888,10 @@ ShortFormApplicationController = (
     ShortFormNavigationService.isLoading(true)
     if AccountService.loggedIn()
       ShortFormApplicationService.submitApplication().then((response) ->
+        # if redirecting to the React my-applications page, disable the "Leave site?" popup
+        if $window.ACCOUNT_INFORMATION_PAGES_REACT is "true"
+          $window.removeEventListener('beforeunload', ShortFormApplicationService.onExit)
+
         # ShortFormNavigationService.isLoading(false) will happen after My Apps are loaded
         # go to my applications without tracking Form Success
         $scope.go('dahlia.my-applications', {skipConfirm: true})


### PR DESCRIPTION
## Description

Remove the "Leave Site?" pop up warning that happens when clicking "Save and finish later". This happens now because the redirect to the My Applications page now goes to a React page.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2792

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack