### PR TITLE
fix: DAH-2808 Use initialized unleash client

### DIFF
--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -35,7 +35,7 @@ module Force
         # available methods for the subscription instance:
         #   https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Deferrable
         #   https://www.rubydoc.info/gems/faye/Faye/Subscription
-        if Unleash::Client.new.is_enabled? 'GoogleCloudTranslate'
+        if Rails.configuration.unleash.is_enabled? 'GoogleCloudTranslate'
           subscription = subscribe_to_listing_updates
           subscription.callback do
             Rails.logger.info('Subscribed to Salesforce Platform Events')
@@ -166,7 +166,7 @@ module Force
     end
 
     def check_for_unsubscribe(subscription)
-      if Unleash::Client.new.is_enabled?('GoogleCloudTranslate') &&
+      if Rails.configuration.unleash.is_enabled?('GoogleCloudTranslate') &&
          !Rails.cache.fetch(UNSUBSCRIBE_CACHE_KEY)
         return
       end


### PR DESCRIPTION
## Description

Remove creation of new Unleash clients to avoid memory issues, we should just use the one client created during Rails initialization.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2808

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack