### PR TITLE
feat: DAH-2809 Start Salesforce event listener in a dedicated dyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -C config/sidekiq.yml
+listener: bundle exec rake translate:subscribe
 release: bundle exec rake db:migrate

--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -32,9 +32,6 @@ module Force
       end
 
       EM.run do
-        # available methods for the subscription instance:
-        #   https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Deferrable
-        #   https://www.rubydoc.info/gems/faye/Faye/Subscription
         if Rails.configuration.unleash.is_enabled? 'GoogleCloudTranslate'
           subscription = subscribe_to_listing_updates
           subscription.callback do

--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -38,7 +38,7 @@ module Force
         if Rails.configuration.unleash.is_enabled? 'GoogleCloudTranslate'
           subscription = subscribe_to_listing_updates
           subscription.callback do
-            Rails.logger.info('Subscribed to Salesforce Platform Events')
+            logger.info('Subscribed to Salesforce Platform Events')
           end
           subscription.errback do |error|
             logger(
@@ -49,7 +49,7 @@ module Force
         else
           logger('GoogleCloudTranslate is disabled')
         end
-        EM.add_periodic_timer(10, proc { check_for_unsubscribe(subscription) })
+        EM.add_periodic_timer(60, proc { check_for_unsubscribe(subscription) })
       end
     end
 
@@ -166,6 +166,14 @@ module Force
     end
 
     def check_for_unsubscribe(subscription)
+      logger(
+        'Checking for unsubscribe conditions... ' \
+        'GoogleCloudTranslate flag is enabled: ' \
+        "#{Rails.configuration.unleash.is_enabled?('GoogleCloudTranslate')} - " \
+        'Unsubcribe request from cache: ' \
+        "#{Rails.cache.fetch(UNSUBSCRIBE_CACHE_KEY).inspect}",
+      )
+
       if Rails.configuration.unleash.is_enabled?('GoogleCloudTranslate') &&
          !Rails.cache.fetch(UNSUBSCRIBE_CACHE_KEY)
         return
@@ -173,7 +181,7 @@ module Force
 
       subscription&.unsubscribe
       Rails.cache.delete(UNSUBSCRIBE_CACHE_KEY)
-      logger('Unsubscribed to Salesforce Platform Events')
+      logger('Unsubscribed from Salesforce Platform Events')
       EM.stop_event_loop
     end
 

--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -14,8 +14,6 @@ module Force
       keyword_init: true,
     )
 
-    UNSUBSCRIBE_CACHE_KEY = 'unsubscribe_from_listing_updates'.freeze
-
     def initialize
       setup_salesforce_client
       setup_faye_client

--- a/lib/tasks/translate.rake
+++ b/lib/tasks/translate.rake
@@ -48,7 +48,4 @@ namespace :translate do # rubocop:disable Metrics/BlockLength
     subscriber = Force::EventSubscriberTranslateService.new
     subscriber.listen_and_process_events
   end
-  task unsubscribe: :environment do
-    Rails.cache.write(Force::EventSubscriberTranslateService::UNSUBSCRIBE_CACHE_KEY, true)
-  end
 end

--- a/spec/services/event_subscriber_translate_service_spec.rb
+++ b/spec/services/event_subscriber_translate_service_spec.rb
@@ -81,7 +81,9 @@ describe Force::EventSubscriberTranslateService do
       it 'subscribes to and unsubscribes from Salesforce platform event channel' do
         EM.run do
           expect(faye_client).to receive(:subscribe).with('/data/Listing__ChangeEvent')
+          expect(faye_subscription).to receive(:callback).and_yield
           expect(faye_subscription).to receive(:unsubscribe)
+          expect(Rails.logger).to receive(:info).twice
 
           EM.add_timer(0.1) { EM.stop }
 


### PR DESCRIPTION
## Description

Add an entry to the Procfile, which will configure Heroku to create a dedicated dyno to listen for Salesforce events and translate them.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2809

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack