### PR TITLE
fix: DAH-2673 Prevent duplicate emails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   validate :password_complexity
 
+  validates :email, presence: true, uniqueness: { case_sensitive: false }
+
   include DeviseTokenAuth::Concerns::User
 
   def error_details(field)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,4 +4,32 @@ describe User, type: :model do
   it 'should create a new instance of User given valid attributes' do
     create(:user)
   end
+
+  describe 'validations' do
+    subject { build(:user) } # Using FactoryBot to build a user instance
+
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'is not valid without an email' do
+      subject.email = nil
+      expect(subject).to_not be_valid
+      expect(subject.errors[:email]).to include("can't be blank")
+    end
+
+    it 'is not valid with a duplicate email' do
+      create(:user, email: "test@example.com")
+      duplicate_user = build(:user, email: "test@example.com")
+      expect(duplicate_user).to_not be_valid
+      expect(duplicate_user.errors[:email]).to include("has already been taken")
+    end
+
+    it 'is not valid with a duplicate email case insensitive' do
+      create(:user, email: "test@example.com")
+      duplicate_user = build(:user, email: "TEST@EXAMPLE.COM")
+      expect(duplicate_user).to_not be_valid
+      expect(duplicate_user.errors[:email]).to include("has already been taken")
+    end
+  end
 end


### PR DESCRIPTION
## Description

This PR adds in a validation to the User model that enforces email uniqueness in the User table. Note that this PR does not address users who may have already changed their email to a duplicate email, that will be addressed in a future task. 

## Jira ticket

[DAH-2673](https://sfgovdt.jira.com/browse/DAH-2673)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

[DAH-2673]: https://sfgovdt.jira.com/browse/DAH-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ