### PR TITLE
fix: DAH-2845 Error summary banner sort order

### DIFF
--- a/app/javascript/__tests__/components/ErrorSummaryBanner.test.tsx
+++ b/app/javascript/__tests__/components/ErrorSummaryBanner.test.tsx
@@ -36,6 +36,30 @@ describe("ErrorSummaryBanner", () => {
     expect(errorItems).toHaveLength(2)
   })
 
+  test("should display errors in alignment with the fieldOrder", () => {
+    const fieldOrder = ["firstName", "lastName", "birthMonth", "email", "password"]
+
+    const errors: DeepMap<FieldValues, FieldError> = {
+      email: { type: "required", message: "Email is required" },
+      password: { type: "minLength", message: "Password must be at least 6 characters" },
+      firstName: { type: "required", message: "First name is required" },
+      lastName: { type: "required", message: "Last name is required" },
+      birthMonth: { type: "required", message: "Date of birth is required" },
+    }
+
+    render(<ErrorSummaryBanner errors={errors} sortOrder={fieldOrder} />)
+
+    const errorMessages = screen.getAllByRole("listitem").map((button) => button.textContent)
+
+    expect(errorMessages).toEqual([
+      "First name is required",
+      "Last name is required",
+      "Date of birth is required",
+      "Email is required",
+      "Password must be at least 6 characters",
+    ])
+  })
+
   test("will call messageMap if provided", () => {
     const messageMap = jest.fn((message) => message)
     render(

--- a/app/javascript/__tests__/components/ErrorSummaryBanner.test.tsx
+++ b/app/javascript/__tests__/components/ErrorSummaryBanner.test.tsx
@@ -5,6 +5,10 @@ import {
   scrollToErrorOnSubmit,
 } from "../../pages/account/components/ErrorSummaryBanner"
 import { DeepMap, FieldValues, FieldError } from "react-hook-form"
+import { dobSortOrder } from "../../pages/account/components/DOBFieldset"
+import { emailSortOrder } from "../../pages/account/components/EmailFieldset"
+import { nameSortOrder } from "../../pages/account/components/NameFieldset"
+import { passwordSortOrder } from "../../pages/account/components/PasswordFieldset"
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn()
 
@@ -37,7 +41,7 @@ describe("ErrorSummaryBanner", () => {
   })
 
   test("should display errors in alignment with the fieldOrder", () => {
-    const fieldOrder = ["firstName", "lastName", "birthMonth", "email", "password"]
+    const fieldOrder = [...nameSortOrder, ...dobSortOrder, ...emailSortOrder, ...passwordSortOrder]
 
     const errors: DeepMap<FieldValues, FieldError> = {
       email: { type: "required", message: "Email is required" },

--- a/app/javascript/pages/account/account-settings.tsx
+++ b/app/javascript/pages/account/account-settings.tsx
@@ -11,17 +11,24 @@ import { User } from "../../authentication/user"
 import Layout from "../../layouts/Layout"
 import EmailFieldset, {
   emailFieldsetErrors,
+  emailSortOrder,
   handleEmailServerErrors,
 } from "./components/EmailFieldset"
 import FormSubmitButton from "./components/FormSubmitButton"
 import PasswordFieldset, {
   handlePasswordServerErrors,
   passwordFieldsetErrors,
+  passwordSortOrder,
 } from "./components/PasswordFieldset"
-import NameFieldset, { handleNameServerErrors, nameFieldsetErrors } from "./components/NameFieldset"
+import NameFieldset, {
+  handleNameServerErrors,
+  nameFieldsetErrors,
+  nameSortOrder,
+} from "./components/NameFieldset"
 import DOBFieldset, {
   deduplicateDOBErrors,
   dobFieldsetErrors,
+  dobSortOrder,
   handleDOBServerErrors,
 } from "./components/DOBFieldset"
 import "./styles/account.scss"
@@ -141,6 +148,7 @@ const EmailSection = ({ user, setUser }: SectionProps) => {
       />
       <ErrorSummaryBanner
         errors={errors}
+        sortOrder={emailSortOrder}
         messageMap={(messageKey) => getErrorMessage(messageKey, emailFieldsetErrors, true)}
       />
       <UpdateForm onSubmit={handleSubmit(onSubmit)} loading={loading}>
@@ -199,6 +207,7 @@ const PasswordSection = ({ user, setUser }: SectionProps) => {
       />
       <ErrorSummaryBanner
         errors={errors}
+        sortOrder={passwordSortOrder}
         messageMap={(messageKey) => getErrorMessage(messageKey, passwordFieldsetErrors, true)}
       />
       <UpdateForm onSubmit={handleSubmit(onSubmit)} loading={loading}>
@@ -275,6 +284,7 @@ const NameSection = ({ user, setUser, handleBanners }: SectionProps) => {
       {errors && (
         <ErrorSummaryBanner
           errors={errors}
+          sortOrder={nameSortOrder}
           messageMap={(messageKey) => getErrorMessage(messageKey, nameFieldsetErrors, true)}
         />
       )}
@@ -354,6 +364,7 @@ const DateOfBirthSection = ({ user, setUser }: SectionProps) => {
       />
       {errors && errors?.dobObject && (
         <ErrorSummaryBanner
+          sortOrder={dobSortOrder}
           errors={deduplicateDOBErrors(errors.dobObject as DeepMap<DOBFieldValues, FieldError>)}
           messageMap={(messageKey) => getErrorMessage(messageKey, dobFieldsetErrors, true)}
         />

--- a/app/javascript/pages/account/components/DOBFieldset.tsx
+++ b/app/javascript/pages/account/components/DOBFieldset.tsx
@@ -82,6 +82,8 @@ export const dobFieldsetErrors: ErrorMessages = {
   },
 }
 
+export const dobSortOrder = ["birthMonth", "birthDay", "birthYear"]
+
 const validateNumber = (required: boolean, value: string, maxValue: number, errorKey: string) => {
   if (!required && !value?.length) return true
 

--- a/app/javascript/pages/account/components/EmailFieldset.tsx
+++ b/app/javascript/pages/account/components/EmailFieldset.tsx
@@ -50,6 +50,8 @@ export const emailFieldsetErrors: ErrorMessages = {
   },
 }
 
+export const emailSortOrder = ["email"]
+
 const emailValidation = (data: string) => {
   const numberOfAts = (data.match(/@/g) || []).length
   if (numberOfAts === 0) {

--- a/app/javascript/pages/account/components/ErrorSummaryBanner.tsx
+++ b/app/javascript/pages/account/components/ErrorSummaryBanner.tsx
@@ -38,6 +38,18 @@ export const scrollToErrorOnSubmit =
     }
   }
 
+const sortErrors = (errors: DeepMap<FieldValues, FieldError>, fieldOrder: string[]): string[] => {
+  const errorKeys = Object.keys(errors)
+
+  const sortedKeys = errorKeys.sort((keyA, keyB) => {
+    const indexA = fieldOrder.indexOf(keyA)
+    const indexB = fieldOrder.indexOf(keyB)
+    return indexA - indexB
+  })
+
+  return sortedKeys
+}
+
 export interface ErrorMessage {
   default: string
   abbreviated: string
@@ -57,9 +69,11 @@ export const UnifiedErrorMessageMap: ErrorMessages = {
 export const ErrorSummaryBanner = ({
   errors,
   messageMap,
+  sortOrder,
 }: {
   errors: DeepMap<FieldValues, FieldError>
   messageMap?: (message: string) => string
+  sortOrder?: string[]
 }) => {
   const listRef = React.useRef<HTMLUListElement>(null)
 
@@ -67,11 +81,13 @@ export const ErrorSummaryBanner = ({
     return null
   }
 
+  const sortedErrors = sortOrder ? sortErrors(errors, sortOrder) : Object.keys(errors)
+
   return (
     <Alert fullwidth variant="alert" className="error-summary-banner">
       {t("error.accountBanner.header")}
       <ul className="list-disc list-inside pl-2 pt-1" ref={listRef}>
-        {Object.keys(errors).map((key: string) => {
+        {sortedErrors.map((key: string) => {
           let fieldError = errors[key]
 
           if (messageMap && fieldError.message && typeof fieldError.message === "string") {

--- a/app/javascript/pages/account/components/NameFieldset.tsx
+++ b/app/javascript/pages/account/components/NameFieldset.tsx
@@ -28,6 +28,8 @@ export const handleNameServerErrors = (
     : [name, { message: "name:server:generic", shouldFocus: true }]
 }
 
+export const nameSortOrder = ["firstName", "middleName", "lastName"]
+
 const nameValidation = (name: "firstName" | "lastName", value: string) => {
   // The below check is also happening on the backend, but we want to provide immediate feedback to the user
   // The backend check is happening in the account_validation_service.rb file

--- a/app/javascript/pages/account/components/PasswordFieldset.tsx
+++ b/app/javascript/pages/account/components/PasswordFieldset.tsx
@@ -72,6 +72,8 @@ export const passwordFieldsetErrors: ErrorMessages = {
   },
 }
 
+export const passwordSortOrder = ["currentPassword", "password"]
+
 const instructionListItem = (
   shouldShowValidationInformation: boolean,
   validation: boolean,

--- a/app/javascript/pages/account/create-account.tsx
+++ b/app/javascript/pages/account/create-account.tsx
@@ -6,7 +6,7 @@ import { Card } from "@bloom-housing/ui-seeds"
 
 import withAppSetup from "../../layouts/withAppSetup"
 import Layout from "../../layouts/Layout"
-import NameFieldset, { handleNameServerErrors } from "./components/NameFieldset"
+import NameFieldset, { handleNameServerErrors, nameSortOrder } from "./components/NameFieldset"
 import {
   DeepMap,
   ErrorOption,
@@ -18,10 +18,14 @@ import {
 import DOBFieldset, {
   deduplicateDOBErrors,
   DOBFieldValues,
+  dobSortOrder,
   handleDOBServerErrors,
 } from "./components/DOBFieldset"
-import EmailFieldset, { handleEmailServerErrors } from "./components/EmailFieldset"
-import PasswordFieldset, { handlePasswordServerErrors } from "./components/PasswordFieldset"
+import EmailFieldset, { emailSortOrder, handleEmailServerErrors } from "./components/EmailFieldset"
+import PasswordFieldset, {
+  handlePasswordServerErrors,
+  passwordSortOrder,
+} from "./components/PasswordFieldset"
 import { FormHeader, FormSection, getDobStringFromDobObject } from "../../util/accountUtil"
 import "./styles/account.scss"
 import { User } from "../../authentication/user"
@@ -176,6 +180,8 @@ const CreateAccountContent = ({ register, watch, errors }: SectionProps) => {
   )
 }
 
+const fieldOrder = [...nameSortOrder, ...dobSortOrder, ...emailSortOrder, ...passwordSortOrder]
+
 const modifyErrors = (errors: DeepMap<FieldValues, FieldError>) => {
   if (errors?.dobObject) {
     const dobObject: DeepMap<DOBFieldValues, FieldError> = errors.dobObject
@@ -210,6 +216,7 @@ const CreateAccount = (_props: CreateAccountProps) => {
                 messageMap={(messageKey) =>
                   getErrorMessage(messageKey, UnifiedErrorMessageMap, true)
                 }
+                sortOrder={fieldOrder}
               />
             </span>
             <Form


### PR DESCRIPTION
## Description

This ticket addresses an issue where the error banner rendered errors not in the order that the inputs appeared on the screen.

## Jira ticket

[DAH-2845](https://sfgovdt.jira.com/browse/DAH-2845)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

[DAH-2845]: https://sfgovdt.jira.com/browse/DAH-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ