### PR TITLE
fix: DAH-2506 Fix listing directory interactivity

### DIFF
--- a/app/javascript/modules/listings/ListingDirectory.scss
+++ b/app/javascript/modules/listings/ListingDirectory.scss
@@ -22,6 +22,10 @@
   margin-bottom: 0.4rem;
 }
 
+.is-card-link::after {
+  content: none !important;
+}
+
 .match-container {
   width: 64rem;
 }

--- a/cypress/e2e/rentalListings.e2e.ts
+++ b/cypress/e2e/rentalListings.e2e.ts
@@ -5,6 +5,32 @@ describe("Rental listings directory page", () => {
     cy.wait("@listings")
   })
 
+  it("renders a listing with the correct interactivity", () => {
+    cy.intercept("/api/v1/listings/a0W8H00000140LvUAI.json", {
+      fixture: "openRentalListing.json",
+    }).as("listingDetails")
+
+    cy.get('[data-testid="listing-card-component"]')
+      .first()
+      .within(() => {
+        cy.get("table").click()
+        cy.url().should("include", "/listings/for-rent?react=true")
+        cy.get("@listingDetails.all").should("have.length", 0)
+        cy.contains("a", "See Details").click()
+        cy.wait("@listingDetails").its("response.statusCode").should("eq", 200)
+      })
+    cy.url().should("include", "/listings/a0W8H00000140LvUAI")
+    cy.go("back")
+
+    cy.get('[data-testid="listing-card-component"]')
+      .first()
+      .within(() => {
+        cy.get("h2").click()
+        cy.wait("@listingDetails").its("response.statusCode").should("eq", 200)
+      })
+    cy.url().should("include", "/listings/a0W8H00000140LvUAI")
+  })
+
   it("renders upcoming and results", () => {
     cy.contains("Upcoming Lotteries")
     cy.contains("Lottery Results")


### PR DESCRIPTION
## Description

This bug fix fixes an issue where the listing directory "See Details" button did not have a hover state and the entire card was interactive. Now, just the button, image, and header are interactive.

## Jira ticket

[DAH-2506](https://sfgovdt.jira.com/browse/DAH-2506)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

[DAH-2506]: https://sfgovdt.jira.com/browse/DAH-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ