### PR TITLE
fix: DAH-2888 handle error arg in logs

### DIFF
--- a/app/services/force/event_subscriber_translate_service.rb
+++ b/app/services/force/event_subscriber_translate_service.rb
@@ -172,8 +172,8 @@ module Force
     def logger(message, error = nil)
       if error
         Rails.logger.error(
-          "EventSubscriberTranslateService #{message}: #{error&.message}, " \
-          "backtrace: #{error&.backtrace&.[](0..5)}",
+          "EventSubscriberTranslateService #{message}: #{error.try(:message)}, " \
+          "backtrace: #{error.try(:backtrace)&.[](0..5)}",
         )
       else
         Rails.logger.info("EventSubscriberTranslateService #{message}")

--- a/app/services/google_translation_service.rb
+++ b/app/services/google_translation_service.rb
@@ -24,7 +24,7 @@ class GoogleTranslationService
       translation = @translate.translate(text, to: target)
       { to: target, translation: parse_translations(translation) }
     rescue StandardError => e
-      google_translation_logger("An error occured: #{e.inspect}", error: true)
+      google_translation_logger('Error translating', e)
       return []
     end
     # include original values on the response
@@ -44,7 +44,7 @@ class GoogleTranslationService
       )
     else
       google_translation_logger(
-        "Error writing translations to cache with key '#{cache_key}'", error: true
+        "Error writing translations to cache with key '#{cache_key}'", true
       )
     end
     translations
@@ -92,8 +92,8 @@ class GoogleTranslationService
   def google_translation_logger(message, error = nil)
     if error
       Rails.logger.error(
-        "GoogleTranslationService #{message}: #{error&.message}, " \
-        "backtrace: #{error&.backtrace&.[](0..5)}",
+        "GoogleTranslationService #{message}: #{error.try(:message)}, " \
+        "backtrace: #{error.try(:backtrace)&.[](0..5)}",
       )
     else
       Rails.logger.info("GoogleTranslationService #{message}")


### PR DESCRIPTION
## Description

This is a follow-up to fix a bug caused by #2380 after it was already merged. This PR will be attached to the same ticket, and the release notes should ignore this PR.

I added automated tests for the error logging, you can add `raise 'test error'` in the source code if you want to do manual testing.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2888

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack