### PR TITLE
fix: DAH-2927 Display 'Removed' Applications as 'Submitted' in My Applications page

### DIFF
--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -262,10 +262,6 @@ class Api::V1::ShortFormController < ApiController
     Force::ShortFormService.can_claim?(uid, application)
   end
 
-  def submitted?(application)
-    Force::ShortFormService.submitted?(application)
-  end
-
   def draft?(application)
     Force::ShortFormService.draft?(application)
   end

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -94,7 +94,8 @@ class Api::V1::ShortFormController < ApiController
     return if params['autosave'] == 'true' && autosave_disabled
     @application = Force::ShortFormService.get(application_params[:id])
     return render_unauthorized_error unless user_can_access?(@application)
-    return render_unauthorized_error if submitted?(@application)
+    return render_unauthorized_error unless draft?(@application)
+
     # calls same underlying method for submit
     submit_application
   end
@@ -109,7 +110,8 @@ class Api::V1::ShortFormController < ApiController
   def delete_application
     @application = Force::ShortFormService.get(params[:id])
     return render_unauthorized_error unless user_can_access?(@application)
-    return render_unauthorized_error if submitted?(@application)
+    return render_unauthorized_error unless draft?(@application)
+
     result = Force::ShortFormService.delete(params[:id])
     render json: result
   end
@@ -262,6 +264,10 @@ class Api::V1::ShortFormController < ApiController
 
   def submitted?(application)
     Force::ShortFormService.submitted?(application)
+  end
+
+  def draft?(application)
+    Force::ShortFormService.draft?(application)
   end
 
   def render_unauthorized_error

--- a/app/javascript/api/types/rails/application/RailsApplication.d.ts
+++ b/app/javascript/api/types/rails/application/RailsApplication.d.ts
@@ -27,7 +27,7 @@ export type Application = {
   monthlyIncome: number
   totalMonthlyRent: number
   externalSessionId: string // "#{uuid.v4()}-#{uuid.v4()}"
-  status: "Draft" | "Submitted" | "Removed"
+  status: "Draft" | "Submitted" | "Removed" | "Submitted - Needs Review"
   applicationSubmissionType: "Electronic" | "Paper"
   applicationSubmittedDate: string // "YYYY-MM-DD"
   formMetadata: string // JSON.stringify(_.pick(app,'completedSections', 'session_uid','lastPage','groupedHouseholdAddresses','aliceGriffith_address_verified')

--- a/app/javascript/pages/account/my-applications.tsx
+++ b/app/javascript/pages/account/my-applications.tsx
@@ -75,7 +75,7 @@ const generateApplicationList = (
         applicationUpdatedAt={app.applicationSubmittedDate}
         confirmationNumber={app.lotteryNumber.toString()}
         editedDate={app.applicationSubmittedDate}
-        submitted={app.status === "Submitted"}
+        submitted={app.status !== "Draft"} // possible status values: 'Draft', 'Removed', 'Submitted', 'Submitted - Needs Review'
         listing={app.listing}
         key={app.id}
         handleDeleteApp={handleDeleteApp}

--- a/app/javascript/pages/account/my-applications.tsx
+++ b/app/javascript/pages/account/my-applications.tsx
@@ -75,7 +75,7 @@ const generateApplicationList = (
         applicationUpdatedAt={app.applicationSubmittedDate}
         confirmationNumber={app.lotteryNumber.toString()}
         editedDate={app.applicationSubmittedDate}
-        submitted={app.status !== "Draft"} // possible status values: 'Draft', 'Removed', 'Submitted', 'Submitted - Needs Review'
+        submitted={app.status !== "Draft"}
         listing={app.listing}
         key={app.id}
         handleDeleteApp={handleDeleteApp}

--- a/app/services/force/short_form_service.rb
+++ b/app/services/force/short_form_service.rb
@@ -117,10 +117,6 @@ module Force
       false
     end
 
-    def self.submitted?(application)
-      application['status'] == 'Submitted'
-    end
-
     def self.draft?(application)
       application['status'] == 'Draft'
     end

--- a/app/services/force/short_form_service.rb
+++ b/app/services/force/short_form_service.rb
@@ -121,6 +121,10 @@ module Force
       application['status'] == 'Submitted'
     end
 
+    def self.draft?(application)
+      application['status'] == 'Draft'
+    end
+
     def self.lending_institutions
       return @institutions if @institutions
 

--- a/spec/requests/api/v1/short_form_spec.rb
+++ b/spec/requests/api/v1/short_form_spec.rb
@@ -140,7 +140,7 @@ describe 'ShortForm API' do
       allow_any_instance_of(Api::V1::ShortFormController)
         .to receive(:user_can_access?).and_return(true)
       allow_any_instance_of(Api::V1::ShortFormController)
-        .to receive(:submitted?).and_return(false)
+        .to receive(:draft?).and_return(true)
     end
     it 'returns success response' do
       VCR.use_cassette('shortform/delete_application') do


### PR DESCRIPTION
## Description

Fix React My Applications page, which was treating 'Removed' applications like drafts. Add additional protection against deletion and updates in Rails as well.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2927

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack