### PR TITLE
DAH-2933 feat: Translate Lottery Bucket Preference Names

### DIFF
--- a/app/javascript/__tests__/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.test.tsx
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.test.tsx
@@ -7,7 +7,10 @@ import { lotteryResultSaleTwo } from "../../data/RailsLotteryResult/lottery-resu
 describe("ListingDetailsLotteryPreferences", () => {
   it("displays 3 default preferences - COP, DTHP, L/W", () => {
     const { asFragment } = render(
-      <ListingDetailsLotteryPreferences lotteryBucketsDetails={lotteryResultRentalThree} />
+      <ListingDetailsLotteryPreferences
+        lotteryBucketsDetails={lotteryResultRentalThree}
+        machineTranslations={{}}
+      />
     )
 
     expect(asFragment()).toMatchSnapshot()
@@ -15,7 +18,10 @@ describe("ListingDetailsLotteryPreferences", () => {
 
   it("displays 2 preferences - NRHP, L/W", () => {
     const { asFragment } = render(
-      <ListingDetailsLotteryPreferences lotteryBucketsDetails={lotteryResultSaleTwo} />
+      <ListingDetailsLotteryPreferences
+        lotteryBucketsDetails={lotteryResultSaleTwo}
+        machineTranslations={{}}
+      />
     )
 
     expect(asFragment()).toMatchSnapshot()

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotteryPreferences.tsx
@@ -1,15 +1,18 @@
 import React from "react"
 import { Heading, t } from "@bloom-housing/ui-components"
 import type { RailsLotteryResult } from "../../api/types/rails/listings/RailsLotteryResult"
-import { defaultIfNotTranslated, renderMarkup } from "../../util/languageUtil"
+import { defaultOrMachineTranslationIfNotTranslated, renderMarkup } from "../../util/languageUtil"
 import { LOTTERY_RANKING_VIDEO_URL } from "../constants"
+import { RailsTranslations } from "../../api/types/rails/listings/RailsTranslation"
 
 export interface ListingDetailsLotteryPreferencesProps {
   lotteryBucketsDetails: RailsLotteryResult
+  machineTranslations: RailsTranslations
 }
 
 export const ListingDetailsLotteryPreferences = ({
   lotteryBucketsDetails,
+  machineTranslations,
 }: ListingDetailsLotteryPreferencesProps) => {
   return (
     <div className="text-sm">
@@ -39,7 +42,8 @@ export const ListingDetailsLotteryPreferences = ({
                 className="font-sans font-semibold text-xs tracking-wide uppercase"
                 priority={3}
               >
-                {defaultIfNotTranslated(
+                {defaultOrMachineTranslationIfNotTranslated(
+                  machineTranslations,
                   `listings.lotteryPreference.${bucket.preferenceName}.title`,
                   bucket.preferenceName
                 )}

--- a/app/javascript/modules/listingDetailsLottery/ListingDetailsLotterySearchForm.tsx
+++ b/app/javascript/modules/listingDetailsLottery/ListingDetailsLotterySearchForm.tsx
@@ -90,7 +90,10 @@ export const ListingDetailsLotterySearchForm = ({
           isEducatorOne={isEducatorOne(listing)}
         />
       ) : (
-        <ListingDetailsLotteryPreferences lotteryBucketsDetails={lotteryBucketDetails} />
+        <ListingDetailsLotteryPreferences
+          lotteryBucketsDetails={lotteryBucketDetails}
+          machineTranslations={listing.translations}
+        />
       )
       break
     }

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -274,3 +274,22 @@ export const getTranslatedString = (
   const translatedValue = translations[fieldName]?.[languageCode] as string
   return translatedValue || originalValue
 }
+
+/**
+ * Lottery bucket preference names *may* be missing
+ *   human translations, and *may* need to be machine translated
+ * This is a workaround to address that, ahead of a future project
+ *   to better integrate human and machine translations
+ */
+export function defaultOrMachineTranslationIfNotTranslated(
+  translations: RailsTranslations,
+  key: string,
+  value: string,
+  translationInterpolations?: TranslationInterpolations
+): string {
+  const translation = defaultIfNotTranslated(key, value, translationInterpolations)
+  if (value !== translation) return translation
+
+  // all keys are appended with '__c' because the current translation system expects for Salesforce field names as keys
+  return getTranslatedString(value, `${key}__c`, translations)
+}

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -71,11 +71,7 @@ class CacheService
       listing,
       strings_to_translate,
     )
-    strings_to_translate = translate_lottery_bucket_preference_names(
-      listing,
-      strings_to_translate,
-    )
-    translate_listing_preference_descriptions(
+    translate_lottery_bucket_preference_names(
       listing,
       strings_to_translate,
     )

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -106,6 +106,8 @@ class CacheService
   # This is a workaround to address that, ahead of a future project
   #   to better integrate human and machine translations
   def translate_lottery_bucket_preference_names(listing, strings_to_translate)
+    return strings_to_translate unless listing['Lottery_Status'] == 'Lottery Complete'
+
     lottery_buckets = Force::ListingService.lottery_buckets(listing['listingID'])
     return strings_to_translate unless lottery_buckets.try(:[], 'lotteryBuckets')
 

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -58,29 +58,27 @@ class CacheService
     ServiceHelper.listing_field_names.each do |field|
       strings_to_translate[field] = listing[field].present? ? listing[field] : ''
     end
-    strings_to_translate = process_nested_translations(listing, strings_to_translate,
-                                                       'Open_Houses',
-                                                       'Venue')
-    strings_to_translate = process_nested_translations(listing, strings_to_translate,
-                                                       'Information_Sessions',
-                                                       'Venue')
-    strings_to_translate = process_nested_translations(listing, strings_to_translate,
-                                                       'Listing_Images',
-                                                       'Image_Description')
-    strings_to_translate = process_nested_translations(listing, strings_to_translate,
-                                                       'Listing_Online_Details',
-                                                       'Listing_Online_Detail_Name')
+    [
+      %w[Open_Houses Venue],
+      %w[Information_Sessions Venue],
+      %w[Listing_Images Image_Description],
+      %w[Listing_Online_Details Listing_Online_Detail_Name],
+    ].each do |key, nested_key|
+      strings_to_translate =
+        process_nested_translations(listing, strings_to_translate, key, nested_key)
+    end
+    strings_to_translate = translate_listing_preference_descriptions(
+      listing,
+      strings_to_translate,
+    )
     strings_to_translate = translate_lottery_bucket_preference_names(
       listing,
       strings_to_translate,
     )
-
-    listing_preferences = Force::ListingService.preferences(listing['listingID'])
-    listing_preferences&.each do |preference|
-      strings_to_translate["#{preference['listingPreferenceID']}.Description"] ||=
-        preference['description']
-    end
-    strings_to_translate
+    translate_listing_preference_descriptions(
+      listing,
+      strings_to_translate,
+    )
   end
 
   def process_nested_translations(listing, strings_to_translate, object_key, value)
@@ -88,6 +86,17 @@ class CacheService
       unless object[value].nil?
         strings_to_translate["#{object['Id']}.#{object_key}.#{value}"] ||= object[value]
       end
+    end
+    strings_to_translate
+  end
+
+  def translate_listing_preference_descriptions(listing, strings_to_translate)
+    listing_preferences = Force::ListingService.preferences(listing['listingID'])
+    return strings_to_translate if listing_preferences.blank?
+
+    listing_preferences&.each do |preference|
+      strings_to_translate["#{preference['listingPreferenceID']}.Description"] ||=
+        preference['description']
     end
     strings_to_translate
   end

--- a/app/services/google_translation_service.rb
+++ b/app/services/google_translation_service.rb
@@ -4,8 +4,6 @@ require 'google/cloud/translate/v2'
 class GoogleTranslationService
   class TranslationError < StandardError; end
 
-  MAX_TRANSLATION_LOG_LENGTH = 128
-
   def initialize
     google_translation_logger('Connecting to Google Cloud Translate...')
     @translate = Google::Cloud::Translate::V2.new(

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -143,6 +143,7 @@ describe CacheService do
       # mock cached listing
       listing['Listing_Other_Notes'] = 'Test Notes'
       listing['Realtor_Commission_Info'] = 'Test Commission Info'
+      listing['Lottery_Status'] = 'Lottery Complete'
 
       allow(Force::ListingService).to receive(:listing)
         .and_return(:listing)

--- a/spec/services/cache_service_spec.rb
+++ b/spec/services/cache_service_spec.rb
@@ -27,6 +27,15 @@ describe CacheService do
 
   let(:multiple_listing_image_service) { instance_double(MultipleListingImageService) }
 
+  let(:lottery_buckets) do
+    {
+      'lotteryBuckets' => [
+        { 'preferenceName' => 'Veteran with Certificate of Preference' },
+        { 'preferenceName' => 'Certificate of Preference (COP)' },
+      ],
+    }
+  end
+
   before do
     allow(Force::ListingService).to receive(:listings).and_return(cached_listings)
     allow(Force::ListingService).to receive(:listings)
@@ -34,7 +43,7 @@ describe CacheService do
     allow(Force::ListingService).to receive(:listing)
     allow(Force::ListingService).to receive(:units)
     allow(Force::ListingService).to receive(:preferences)
-    allow(Force::ListingService).to receive(:lottery_buckets)
+    allow(Force::ListingService).to receive(:lottery_buckets).and_return(lottery_buckets)
     allow(multiple_listing_image_service).to receive(:process_images)
       .and_return(OpenStruct.new(errors: nil))
     allow(MultipleListingImageService).to receive(:new).and_return(multiple_listing_image_service)


### PR DESCRIPTION
## Description

Update the new machine translation system to handle an edge case: lottery bucket preference names *may* be missing human translations, and *may* need to be machine translated.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2933

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack