### PR TITLE
DAH-2950 revert workaround for Islais Place

### DIFF
--- a/app/assets/javascripts/listings/ListingLotteryService.js.coffee
+++ b/app/assets/javascripts/listings/ListingLotteryService.js.coffee
@@ -27,8 +27,6 @@ ListingLotteryService = ($http, ListingIdentityService, ModalService) ->
   Service.listingHasLotteryBuckets = (listing) ->
     return false unless listing
 
-    # Temporary workaround for `lottery_buckets` API issues, revert once fixed
-    return true if listing.Id == 'a0W4U00000IXRHWUA5'
 
     listingLotteryBucketInfo = Service.lotteryBucketInfo[listing.Id]
     if listingLotteryBucketInfo

--- a/app/services/force/listing_service.rb
+++ b/app/services/force/listing_service.rb
@@ -153,9 +153,6 @@ module Force
 
     # get Lottery Buckets with rankings
     def self.lottery_buckets(listing_id, opts = {})
-      # Temporary workaround for `lottery_buckets` API issues, revert once fixed
-      return nil if listing_id == 'a0W4U00000IXRHWUA5'
-
       esc_listing_id = CGI.escape(listing_id)
       force = opts[:force] || false
       data = Request.new


### PR DESCRIPTION
## Description
The Lottery Modal does not show because this listing is returning a value of null for the `lottery_buckets` endpoint due to a previous workaround. This reverts that workaround. 

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2950

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Review
- The actual listing that is impacted is in production
- We can deploy this PR to prod-test to point at prod data
- Otherwise, ensure that lottery results are loading properly for rental listings with completed lotteries.