### PR TITLE
feat: DAH-2945 Use env var for formassembly url

### DIFF
--- a/app/javascript/__tests__/pages/how-to-apply/how-to-apply.test.tsx
+++ b/app/javascript/__tests__/pages/how-to-apply/how-to-apply.test.tsx
@@ -4,6 +4,7 @@ import { renderAndLoadAsync } from "../../__util__/renderUtils"
 import HowToApply, { LeasingAgentBox } from "../../../pages/howToApply/how-to-apply"
 import { notYetOpenSaleFcfsListing } from "../../data/RailsSaleListing/listing-sale-fcfs-not-yet-open"
 import { fcfsSaleListing } from "../../data/RailsSaleListing/listing-sale-fcfs"
+import { openFcfsSaleListing } from "../../data/RailsSaleListing/listing-sale-fcfs-open"
 import { localizedFormat, formatTimeOfDay } from "../../../util/languageUtil"
 
 const axios = require("axios")
@@ -28,6 +29,20 @@ describe("<HowToApply />", () => {
     axios.get.mockResolvedValue({ data: { listing: fcfsSaleListing } })
     const { asFragment } = await renderAndLoadAsync(<HowToApply assetPaths={{}} />)
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it("shows 'SUBMIT APPLICATION' button if URL is present", async () => {
+    process.env.FCFS_FORMASSEMBLY_URL = "https://www.test.com"
+    axios.get.mockResolvedValue({ data: { listing: openFcfsSaleListing } })
+    const { queryByText } = await renderAndLoadAsync(<HowToApply assetPaths={{}} />)
+    expect(queryByText("Submit application")).not.toBeNull()
+  })
+
+  it("does not show 'SUBMIT APPLICATION' button if URL is missing", async () => {
+    process.env.FCFS_FORMASSEMBLY_URL = undefined
+    axios.get.mockResolvedValue({ data: { listing: openFcfsSaleListing } })
+    const { queryByText } = await renderAndLoadAsync(<HowToApply assetPaths={{}} />)
+    expect(queryByText("Submit application")).toBeNull()
   })
 
   it("shows the correct header text", async () => {

--- a/app/javascript/pages/howToApply/how-to-apply.tsx
+++ b/app/javascript/pages/howToApply/how-to-apply.tsx
@@ -8,6 +8,7 @@ import {
   getPathWithoutLanguagePrefix,
   getTranslatedString,
 } from "../../util/languageUtil"
+import { isValidUrl } from "../../util/urlUtil"
 import {
   Icon,
   t,
@@ -38,7 +39,7 @@ interface HowToApplyProps {
 
 const generateSubmissionUrl = (listingId: string) => {
   const formAssemblyUrl = process.env.FCFS_FORMASSEMBLY_URL
-  if (!formAssemblyUrl) return null
+  if (!isValidUrl(formAssemblyUrl)) return null
 
   return `${formAssemblyUrl}?ListingID=${listingId}`
 }

--- a/app/javascript/pages/howToApply/how-to-apply.tsx
+++ b/app/javascript/pages/howToApply/how-to-apply.tsx
@@ -36,8 +36,10 @@ interface HowToApplyProps {
   assetPaths: unknown
 }
 
-const submissionUrl = (listingId: string) => {
-  const formAssemblyUrl = process.env.FCFS_FORMASSEMBLY_URL || "https://sfmoh.tfaforms.net/20"
+const generateSubmissionUrl = (listingId: string) => {
+  const formAssemblyUrl = process.env.FCFS_FORMASSEMBLY_URL
+  if (!formAssemblyUrl) return null
+
   return `${formAssemblyUrl}?ListingID=${listingId}`
 }
 
@@ -309,6 +311,7 @@ const CreateBoxAccountStep = () => {
 
 const SubmitApplicationStep = ({ listing }: { listing: RailsSaleListing }) => {
   const datetime = listing.Application_Start_Date_Time
+  const submissionUrl = generateSubmissionUrl(listing.listingID)
 
   return (
     <HowToApplyListItem headerText={t("howToApplyPage.howToApplySection.step5.title")}>
@@ -335,12 +338,12 @@ const SubmitApplicationStep = ({ listing }: { listing: RailsSaleListing }) => {
           })}
         </div>
       )}
-      {applicationsOpen(listing) && (
+      {applicationsOpen(listing) && submissionUrl && (
         <Button
           className="mt-6"
           styleType={AppearanceStyleType.primary}
           onClick={() => {
-            window.open(submissionUrl(listing.listingID), "_blank")
+            window.open(submissionUrl, "_blank")
           }}
         >
           {t("howToApplyPage.howToApplySection.step5.button")}

--- a/app/javascript/pages/howToApply/how-to-apply.tsx
+++ b/app/javascript/pages/howToApply/how-to-apply.tsx
@@ -37,7 +37,8 @@ interface HowToApplyProps {
 }
 
 const submissionUrl = (listingId: string) => {
-  return `https://sfmoh.tfaforms.net/20?ListingID=${listingId}`
+  const formAssemblyUrl = process.env.FCFS_FORMASSEMBLY_URL || "https://sfmoh.tfaforms.net/20"
+  return `${formAssemblyUrl}?ListingID=${listingId}`
 }
 
 const applicationsNotYetOpen = (listing: RailsSaleListing) =>

--- a/config/webpack/base.js
+++ b/config/webpack/base.js
@@ -39,6 +39,7 @@ generatedWebpackConfig.plugins.unshift(
       UNLEASH_URL: JSON.stringify(process.env.UNLEASH_URL),
       UNLEASH_TOKEN: JSON.stringify(process.env.UNLEASH_TOKEN),
       UNLEASH_ENV: JSON.stringify(process.env.UNLEASH_ENV),
+      FCFS_FORMASSEMBLY_URL: JSON.stringify(process.env.FCFS_FORMASSEMBLY_URL),
     },
   })
 )


### PR DESCRIPTION
## Description

The 'How To Apply' page for FCFS Sales listings uses a FormAssembly url, change url from being hardcoded to using env vars.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2945

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly
- [x] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack