### PR TITLE
fix: change sidebar headers to meet accessibility requirements

### DIFF
--- a/app/javascript/layouts/Sidebar/ContactSidebarBlock.tsx
+++ b/app/javascript/layouts/Sidebar/ContactSidebarBlock.tsx
@@ -62,6 +62,7 @@ const ContactSideBarBlock = () => (
   <SidebarBlock
     className="w-full md:w-1/3 md:max-w-xs text-gray-950 md:border-l border-t md:border-t-0 border-gray-450 border-b-0 p-6 mx-0"
     title={t("footer.contact")}
+    priority={2}
   >
     <span className="text-gray-950">
       <SidebarListingQuestion />

--- a/app/javascript/layouts/Sidebar/GetHelpSidebarBlock.tsx
+++ b/app/javascript/layouts/Sidebar/GetHelpSidebarBlock.tsx
@@ -10,6 +10,7 @@ const GetHelpSidebarBlock = () => (
   <SidebarBlock
     className="w-full md:w-1/3 md:max-w-xs text-gray-950 md:border-l border-t md:border-t-0 border-gray-450 border-b-0 p-6 mx-0"
     title={t("listings.apply.needHelp")}
+    priority={2}
   >
     <HousingCounselorHelp />
     <LinkButton

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
@@ -31,7 +31,11 @@ export interface ListingDetailsApplyProps {
 }
 
 const FcfsBmrSalesHowToApply = ({ listingId }: { listingId: string }) => (
-  <SidebarBlock className="fcfs-bmr-how-to-apply" title={t("listings.apply.howToApply")}>
+  <SidebarBlock
+    className="fcfs-bmr-how-to-apply"
+    title={t("listings.apply.howToApply")}
+    priority={2}
+  >
     <div className="fcfs-bmr-how-to-apply__list">
       <ol className="numbered-list text-black text-base">
         <li>{t("listings.fcfs.bmrSales.howToApply.step1")}</li>
@@ -52,7 +56,7 @@ const FcfsBmrSalesHowToApply = ({ listingId }: { listingId: string }) => (
 
 const ordinalHeader = (ordinal: number, title: string) => {
   return (
-    <Heading priority={4} className={"text-gray-950 text-xl -mt-2 mb-3"}>
+    <Heading priority={2} className={"text-gray-950 text-xl -mt-2 mb-3"}>
       <span className={"text-blue-500 mr-2"}>{ordinal}</span>
       {title}
     </Heading>
@@ -73,7 +77,7 @@ const StandardHowToApply = ({
   const [paperApplicationsOpen, setPaperApplicationsOpen] = useState(false)
 
   return (
-    <SidebarBlock title={t("listings.apply.howToApply")}>
+    <SidebarBlock title={t("listings.apply.howToApply")} priority={2}>
       {!isListingRental && (
         <>
           <p className={"mb-4"}>
@@ -176,7 +180,7 @@ export const ListingDetailsApply = ({ listing }: ListingDetailsApplyProps) => {
 
   const submitPaperApplicationBlocks = (
     <>
-      <SidebarBlock className={"bg-blue-100"}>
+      <SidebarBlock className={"bg-blue-100"} priority={2}>
         {ordinalHeader(2, t("listings.apply.submitAPaperApplication"))}
         {t("listings.apply.includeAnEnvelope")}
       </SidebarBlock>
@@ -184,6 +188,7 @@ export const ListingDetailsApply = ({ listing }: ListingDetailsApplyProps) => {
         className={"bg-blue-100"}
         styleType={"capsWeighted"}
         title={t("listings.apply.sendByUsMail")}
+        priority={2}
       >
         <div className={"mb-2 text-gray-950 text-base"}>
           <MultiLineAddress
@@ -198,7 +203,7 @@ export const ListingDetailsApply = ({ listing }: ListingDetailsApplyProps) => {
         </div>
         {t("listings.apply.applicationsMustBeReceivedByDeadline")}
       </SidebarBlock>
-      <SidebarBlock className={"bg-blue-100"}>
+      <SidebarBlock className={"bg-blue-100"} priority={2}>
         {t("listings.doNotApplyOneAndPaperOrMultiple")}
       </SidebarBlock>
     </>

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsAside.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsAside.tsx
@@ -29,13 +29,13 @@ export const ListingDetailsAside = ({ listing, imageSrc }: ListingDetailsSidebar
   const { unleashFlag: isSalesFcfsEnabled } = useFeatureFlag("FCFS", false)
 
   const expectedMoveInDateBlock = (
-    <SidebarBlock title={t("listings.expectedMoveinDate")}>
+    <SidebarBlock title={t("listings.expectedMoveinDate")} priority={2}>
       {localizedFormat(listing.Expected_Move_in_Date, "MMMM YYYY")}
     </SidebarBlock>
   )
 
   const needHelpBlock = (
-    <SidebarBlock title={t("listings.apply.needHelp")}>
+    <SidebarBlock title={t("listings.apply.needHelp")} priority={2}>
       {isListingRental && (
         <div className={"mb-4"}>{t("listings.apply.visitAHousingCounselor")}</div>
       )}

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsLotteryPreferenceLists.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsLotteryPreferenceLists.tsx
@@ -33,6 +33,7 @@ export const ListingDetailsLotteryPreferenceLists = ({
                   `listings.lotteryPreference.${preference.Lottery_Preference.Name}.title`
                 ),
               })}
+              priority={2}
             >
               <LinkButton
                 styleType={AppearanceStyleType.primary}

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsProcess.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsProcess.tsx
@@ -37,6 +37,7 @@ const WhatToExpect = ({
             <p className={"mt-2 mb-2"}>{t("label.whatToExpectApplicationChosen")}</p>
           </>
         }
+        // TODO: relies on uic fix priority={2}
         strings={{
           title: t("label.whatToExpect"),
           readMore: t("label.showMore"),
@@ -98,6 +99,7 @@ export const ListingDetailsProcess = ({
           <div className="border-b border-gray-400 md:border-b-0 last:border-b-0">
             <Contact
               sectionTitle={t("contactAgent.contact")}
+              // TODO: relies on uic fix priority={2}
               contactAddress={{
                 street: listing.Leasing_Agent_Street,
                 city: listing.Leasing_Agent_City,
@@ -147,7 +149,7 @@ export const ListingDetailsProcess = ({
         )}
       {isListingSale && (
         <div className="border-b border-gray-400 md:border-b-0 last:border-b-0">
-          <SidebarBlock title={t("listings.housingProgram")}>
+          <SidebarBlock title={t("listings.housingProgram")} priority={2}>
             <a href={`https://sfmohcd.org/for-buyers`} target="_blank" className="text-base">
               {t("listings.belowMarketRate")}
             </a>
@@ -156,7 +158,7 @@ export const ListingDetailsProcess = ({
       )}
       {isApplicationOpen && (
         <div className="border-b border-gray-400 md:border-b-0 last:border-b-0">
-          <SidebarBlock>
+          <SidebarBlock priority={2}>
             <p>{`${t("t.listingUpdated")}: ${localizedFormat(listing.LastModifiedDate, "LL")}`}</p>
             {!isSalesFcfsEnabled && listing.Multiple_Listing_Service_URL && (
               <p className="mt-1">

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsSeeTheUnit.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsSeeTheUnit.tsx
@@ -22,7 +22,7 @@ export interface SubsectionProps {
 const SeeTheUnitSubsection = ({ title, children, headingClass }: SubsectionProps) => {
   return (
     <div className="see-the-unit__subsection">
-      <HeadingSeeds size="md" className={headingClass ?? "pb-3"}>
+      <HeadingSeeds size="md" className={headingClass ?? "pb-3"} priority={3}>
         {title}
       </HeadingSeeds>
       <div>{children}</div>
@@ -68,7 +68,7 @@ export const ListingDetailsSeeTheUnit = ({ listing }: SeeTheUnitProps) => {
   return (
     <section className="aside-block see-the-unit translate">
       <div className="see-the-unit__heading">
-        <Heading priority={4} styleType="underlineWeighted">
+        <Heading priority={2} styleType="underlineWeighted">
           {t("label.seeTheUnit")}
         </Heading>
       </div>
@@ -113,7 +113,7 @@ export const ListingDetailsSeeTheUnit = ({ listing }: SeeTheUnitProps) => {
             </a>
           </p>
         </div>
-        <HeadingSeeds size="sm" className="pb-1">
+        <HeadingSeeds size="sm" className="pb-1" priority={3}>
           {t("contactAgent.officeHours.seeTheUnit")}
         </HeadingSeeds>
         <p className="text-sm">

--- a/app/javascript/modules/listingDetailsLottery/LotteryDetailsLotteryInfo.tsx
+++ b/app/javascript/modules/listingDetailsLottery/LotteryDetailsLotteryInfo.tsx
@@ -16,7 +16,7 @@ export const ListingDetailsLotteryInfo = ({ listing }: ListingDetailsLotteryInfo
   return (
     <>
       <div className="border-b border-gray-400 md:border-b-0">
-        <SidebarBlock title={t("label.lottery")}>
+        <SidebarBlock title={t("label.lottery")} priority={2}>
           <p className="flex justify-between mb-4">
             <span>{localizedFormat(listing.Lottery_Date, "LL")}</span>
             <span className="font-bold">{localizedFormat(listing.Lottery_Date, "h:mm a")}</span>
@@ -34,7 +34,7 @@ export const ListingDetailsLotteryInfo = ({ listing }: ListingDetailsLotteryInfo
       </div>
 
       <div className="border-b border-gray-400 md:border-b-0">
-        <SidebarBlock title={t("lottery.lotteryResults")}>
+        <SidebarBlock title={t("lottery.lotteryResults")} priority={2}>
           <p className="mb-4">{localizedFormat(listing.Lottery_Results_Date, "LL")}</p>
           <p className="text-gray-700">{t("lottery.completeResultsWillBePosted")}</p>
         </SidebarBlock>

--- a/app/javascript/pages/howToApply/how-to-apply.tsx
+++ b/app/javascript/pages/howToApply/how-to-apply.tsx
@@ -47,11 +47,11 @@ const applicationsOpen = (listing: RailsSaleListing) =>
   listing && getFcfsSalesListingState(listing) === ListingState.Open
 
 const Header = ({ headerText }: { headerText: string }) => {
-  return <h3 className="text-2xl font-alt-serif">{headerText}</h3>
+  return <h2 className="text-2xl font-alt-serif">{headerText}</h2>
 }
 
 const SubHeader = ({ subHeaderText }: { subHeaderText: string }) => {
-  return <h4 className="font-semibold font-alt-sans pt-6 pb-4">{subHeaderText}</h4>
+  return <h3 className="font-semibold font-alt-sans pt-6 pb-4">{subHeaderText}</h3>
 }
 
 const InfoBox = ({ title, children }: { title: string; children: ReactNode }) => {
@@ -164,7 +164,9 @@ export const LeasingAgentBox = ({ listing }: { listing: RailsSaleListing }) => {
           {t("label.emailAddress")}
         </a>
       </div>
-      <Heading size="sm">{t("contactAgent.officeHours.seeTheUnit")}</Heading>
+      <Heading size="sm" priority={3}>
+        {t("contactAgent.officeHours.seeTheUnit")}
+      </Heading>
       <p className="text-sm">
         {getTranslatedString(listing.Office_Hours, "Office_Hours__c", listing.translations)}
       </p>
@@ -223,7 +225,7 @@ const HowToApplyListItem = ({
 }) => {
   return (
     <li>
-      <h4 className="font-semibold font-alt-sans pb-4">{headerText}</h4>
+      <h2 className="font-semibold font-alt-sans pb-4">{headerText}</h2>
       <div className="text-base">{children}</div>
     </li>
   )


### PR DESCRIPTION
## Description

Change level 4 Sidebar headings to level 2
Change level 1 Sidebar subheadings to level 3

There are at least 3 components that require UIC Changes.

It is much easier to implement and test all of the heading level changes in one PR

## Jira ticket


https://sfgovdt.jira.com/browse/DAH-2963
https://sfgovdt.jira.com/browse/DAH-2962

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly
- [ ] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Review Instructions
- Listing Details page
- Easiest way to test is to install and use the WAVE extension
- Run on page and ensure there are no heading level warnings
- Try this for a combination of listing types: FCFS, Rental, Sales, Closed, etc

- How To Apply Page
- Use WAVE
- Ensure there are no heading level warnings

Try mobile responsive views too