### PR TITLE
fix: DAH-2976 Do not translate FCFS Listing Agent Name

### DIFF
--- a/app/javascript/modules/listingDetailsAside/ListingDetailsSeeTheUnit.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsSeeTheUnit.tsx
@@ -81,7 +81,7 @@ export const ListingDetailsSeeTheUnit = ({ listing }: SeeTheUnitProps) => {
         SeeDetailsOnline(listing)}
       <SeeTheUnitSubsection title={t("seeTheUnit.makeAnAppointment")}>
         <p className="text-sm pb-3">{t("seeTheUnit.requestATour")}</p>
-        <p>{listing.Leasing_Agent_Name}</p>
+        <p className="notranslate">{listing.Leasing_Agent_Name}</p>
         <p className="text-gray-700 text-sm">
           {getTranslatedString(
             listing.Leasing_Agent_Title,


### PR DESCRIPTION
## Description

Adds the notranslate className to the listing agent name under the "Make an appointment" section of the FCFS listing details sidebar. 

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2976

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly
- [x] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack