### PR TITLE
fix: DAH-2955 fix redirect for how to apply page

### DIFF
--- a/app/constraints/how_to_apply_constraint.rb
+++ b/app/constraints/how_to_apply_constraint.rb
@@ -21,11 +21,7 @@ class HowToApplyConstraint
   end
 
   def listing_active(listing)
-    # Status has to be Active
-    # TODO: DAH-2846 Status will be added to the listing object
-    # Until then, that field will be nil
-    (!listing['Status'].nil? && listing['Status'] == 'Active') ||
-      # Accepting Online Applications has to be true
-      listing['Accepting_Online_Applications'] == true
+    # Status has to be Active && Accepting Online Applications has to be true
+    listing['Status'] == 'Active' && listing['Accepting_Online_Applications'] == true
   end
 end

--- a/spec/constraints/how_to_apply_constraint_spec.rb
+++ b/spec/constraints/how_to_apply_constraint_spec.rb
@@ -32,13 +32,6 @@ describe HowToApplyConstraint do
       expect(response).to render_template 'layouts/application-react'
     end
 
-    it 'navigates to how to apply for a fcfs sales listing without a status' do
-      single_listing['Status'] = nil
-      get '/listings/test-listing-id/how-to-apply'
-
-      expect(response).to render_template 'layouts/application-react'
-    end
-
     it 'redirects a rental listing' do
       single_listing['RecordType']['Name'] = 'Rental'
       get '/listings/test-listing-id/how-to-apply'


### PR DESCRIPTION
## Description

Fixes redirect so that a the how to apply page is not accessible when the listing is not active or if the listing is not accepting applications.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2955

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly
- [ ] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack