### PR TITLE
fix: DAH-3148 Send Listing Type in GTM

### DIFF
--- a/app/javascript/pages/listings/listing-detail.tsx
+++ b/app/javascript/pages/listings/listing-detail.tsx
@@ -91,6 +91,7 @@ const ListingDetail = () => {
         listing_record_type: listing?.RecordType?.Name,
         listing_num_preferences: listing?.Listing_Lottery_Preferences?.length,
         listing_custom_type: listing?.Custom_Listing_Type,
+        listingType: listing?.Listing_Type,
         listing_id: listing.Id,
       }
       pushToDataLayer("view_listing", tagManagerArgs)


### PR DESCRIPTION
## Description

This adds in the listing_type parameter to the view_listing datalayer event.

## Jira ticket

[DAH-3148](https://sfgovdt.jira.com/browse/DAH-3148)

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly
- [ ] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack


[DAH-3148]: https://sfgovdt.jira.com/browse/DAH-3148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ