### PR TITLE
fix: DAH-3122 Prevent translation rake tasks from triggering page_view logs

### DIFF
--- a/app/services/force/listing_service.rb
+++ b/app/services/force/listing_service.rb
@@ -50,7 +50,9 @@ module Force
 
     def self.translation_usage_by_trigger(listing, rake_task = nil)
       # only one of these feature flags should be turned on at a time
-      if Rails.configuration.unleash.is_enabled? 'LogGoogleCloudTranslateUsageForPageView'
+      if Rails.configuration.unleash.is_enabled?(
+        'LogGoogleCloudTranslateUsageForPageView'
+      ) && rake_task.blank?
         listing['translations'] = log_listing_translations(listing, 'page_view')
       elsif Rails.configuration.unleash.is_enabled?(
         'LogGoogleCloudTranslateUsageForPrefetch10Min',


### PR DESCRIPTION
## Description

This is a fix for the original PR, a bug was discovered after it got merged. We need an additional conditional check, so that the prefetch rake tasks do not trigger the page_view translation logs.

Review instructions:
- view the review app logs: https://addons-sso.heroku.com/apps/dec3e3d9-3bc6-4d97-bf3a-61a540a7a280/addons/0ba15c26-07dc-47e0-bc72-41f8384bfc95
- check that the prefetch tasks that runs every 10 minutes does not trigger translation usage logs, e.g. [here](https://my.papertrailapp.com/events?focus=1816651311778619402&selected=1816651299745116160)
- verify that `log_google_translate_usage, page_view...` logs are triggered by the web dyno only (called `app/web.1` in papertrail, e.g. [here](https://my.papertrailapp.com/groups/39381605/events?focus=1816651638598717455&selected=1816651638598717456)
  - for the review app, they'll get triggered when you modify a listing in Salesforce, and then view the listing details page

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3122

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly
- [x] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack
