### PR TITLE
fix: DAH-3176 hide directory 1.5 change

### DIFF
--- a/app/javascript/modules/listings/DirectoryHelpers.tsx
+++ b/app/javascript/modules/listings/DirectoryHelpers.tsx
@@ -326,9 +326,12 @@ export const getListingGroup = (
   hasFiltersSet?: boolean,
   subtitle?: string,
   icon?: IconTypes,
-  isOpen?: boolean
+  isOpen?: boolean,
+  newDirectoryEnabled?: boolean
 ) => {
-  const showListingsGroup = section !== DIRECTORY_SECTION_ADDITIONAL_LISTINGS || listings.length > 0
+  const showListingsGroup =
+    (newDirectoryEnabled && section !== DIRECTORY_SECTION_ADDITIONAL_LISTINGS) ||
+    listings.length > 0
   return (
     showListingsGroup && (
       <ListingsGroup
@@ -357,7 +360,8 @@ export const upcomingLotteriesView = (
   directoryType,
   stackedDataFxn: StackedDataFxnType,
   observerRef: React.MutableRefObject<null | IntersectionObserver>,
-  isOpen: boolean
+  isOpen: boolean,
+  newDirectoryEnabled?: boolean
 ) => {
   return getListingGroup(
     listings,
@@ -372,7 +376,8 @@ export const upcomingLotteriesView = (
     undefined,
     t("listings.upcomingLotteries.subtitle"),
     null,
-    isOpen
+    isOpen,
+    newDirectoryEnabled
   )
 }
 
@@ -381,7 +386,8 @@ export const lotteryResultsView = (
   directoryType,
   stackedDataFxn: StackedDataFxnType,
   observerRef: React.MutableRefObject<null | IntersectionObserver>,
-  isOpen?: boolean
+  isOpen?: boolean,
+  newDirectoryEnabled?: boolean
 ) => {
   return getListingGroup(
     listings,
@@ -396,7 +402,8 @@ export const lotteryResultsView = (
     undefined,
     t("listings.lotteryResults.subtitle"),
     "result",
-    isOpen
+    isOpen,
+    newDirectoryEnabled
   )
 }
 
@@ -406,7 +413,8 @@ export const additionalView = (
   stackedDataFxn: StackedDataFxnType,
   observerRef: React.MutableRefObject<null | IntersectionObserver>,
   filtersSet?: boolean,
-  isOpen?: boolean
+  isOpen?: boolean,
+  newDirectoryEnabled?: boolean
 ) => {
   return getListingGroup(
     listings,
@@ -421,7 +429,8 @@ export const additionalView = (
     filtersSet,
     t("listings.additional.subtitle"),
     "doubleHouse",
-    isOpen
+    isOpen,
+    newDirectoryEnabled
   )
 }
 

--- a/app/javascript/modules/listings/GenericDirectory.tsx
+++ b/app/javascript/modules/listings/GenericDirectory.tsx
@@ -193,21 +193,24 @@ export const GenericDirectory = (props: RentalDirectoryProps) => {
                   props.getSummaryTable,
                   observerRef,
                   hasFiltersSet,
-                  additionalIsOpen
+                  additionalIsOpen,
+                  newDirectoryEnabled
                 )}
               {upcomingLotteriesView(
                 listings.upcoming,
                 props.directoryType,
                 props.getSummaryTable,
                 observerRef,
-                upcomingIsOpen
+                upcomingIsOpen,
+                newDirectoryEnabled
               )}
               {lotteryResultsView(
                 listings.results,
                 props.directoryType,
                 props.getSummaryTable,
                 observerRef,
-                resultsIsOpen
+                resultsIsOpen,
+                newDirectoryEnabled
               )}
             </div>
           </>


### PR DESCRIPTION
## Description

Makes sure sections are hidden unless there are listings, until directory 1.5.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3176

## Checklist before requesting review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly
- [ ] if the changes include human translations, follow the [human translations process](https://sfgovdt.jira.com/l/cp/XS1KpvE4)

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack
