### PR TITLE
fix: DAH-3190 Use translations on confirmation modals

### DIFF
--- a/app/javascript/pages/account/create-account.tsx
+++ b/app/javascript/pages/account/create-account.tsx
@@ -38,6 +38,7 @@ import {
 import { ExpandedAccountAxiosError, getErrorMessage } from "./components/util"
 
 import "./create-account.scss"
+import { getSignInPath } from "../../util/routeUtil"
 
 interface CreateAccountProps {
   assetPaths: unknown
@@ -164,7 +165,7 @@ const onSubmit = (setError: (name: string, error: ErrorOption) => void) => (data
   createAccount(userData, contactData)
     .then(() => {
       window.sessionStorage.setItem("newAccount", userData.email)
-      window.location.replace("/sign-in")
+      window.location.replace(getSignInPath())
     })
     .catch(handleCreateAccountErrors(setError))
 }


### PR DESCRIPTION
## Description

This ticket fixes an issue where clicking to create an account on a non-english page did not redirect the user to the same language page. This ticket also incorporates all the latest translations changes.

## Jira ticket
https://sfgovdt.jira.com/browse/DAH-3190

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [x] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)