### PR TITLE
feat: DAH-3055 Send user id and timestamp with every push

### DIFF
--- a/app/assets/javascripts/account/AccountService.js.coffee
+++ b/app/assets/javascripts/account/AccountService.js.coffee
@@ -95,7 +95,7 @@ AccountService = (
         AnalyticsService.trackEvent("login_failed", {
             user_id: null,
             origin: 'Application Sign In',
-            error_reason: response?.reason || undefined,
+            reason: response?.reason || undefined,
           })
         # for errors we manually stop the loading overlay
         bsLoadingOverlayService.stop()

--- a/app/javascript/__tests__/hooks/useGTMDataLayer.test.tsx
+++ b/app/javascript/__tests__/hooks/useGTMDataLayer.test.tsx
@@ -1,59 +1,127 @@
+import React from "react"
 import { renderHook } from "@testing-library/react"
-import { useGTMDataLayer } from "../../hooks/analytics/useGTMDataLayer"
+import {
+  useGTMDataLayer,
+  useGTMDataLayerWithoutUserContext,
+} from "../../hooks/analytics/useGTMDataLayer"
 import TagManager from "react-gtm-module"
+import UserContext from "../../authentication/context/UserContext"
+import { mockProfileStub } from "../__util__/accountUtils"
 
 describe("useGTMDataLayer", () => {
   let consoleSpy
+  const mockedDate = new Date()
 
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    jest.useFakeTimers()
+    jest.setSystemTime(mockedDate)
   })
 
   afterEach(() => {
     consoleSpy.mockRestore()
   })
 
-  it("pushes data to the data layer", () => {
-    const event = "testEvent"
-    const data = { test: "data" }
+  describe("User Information is available", () => {
+    let pushToDataLayer
 
-    const { result } = renderHook(() => useGTMDataLayer())
+    beforeEach(() => {
+      const wrapper = ({ children }) => (
+        <UserContext.Provider value={{ profile: mockProfileStub }}>{children}</UserContext.Provider>
+      )
 
-    result.current.pushToDataLayer(event, data)
+      const { result } = renderHook(() => useGTMDataLayer(), { wrapper })
 
-    expect(TagManager.dataLayer).toHaveBeenCalledWith({ dataLayer: { event, ...data } })
+      pushToDataLayer = result.current.pushToDataLayer
+    })
+
+    it("pushes data to the data layer", () => {
+      const event = "testEvent"
+      const data = { test: "data" }
+
+      pushToDataLayer(event, data)
+
+      expect(TagManager.dataLayer).toHaveBeenCalledWith({
+        dataLayer: {
+          event,
+          event_timestamp: mockedDate.toISOString(),
+          ...data,
+          user_id: mockProfileStub.id,
+        },
+      })
+    })
+
+    it("errors out when no event is provided", () => {
+      const event = undefined
+      const data = { test: "data" }
+
+      pushToDataLayer(event, data)
+
+      expect(consoleSpy).toHaveBeenCalled()
+    })
+
+    it("errors out when an event property is provided in the data object", () => {
+      const event = "testEvent"
+      const data = { test: "data", event: "testEvent" }
+
+      pushToDataLayer(event, data)
+
+      expect(consoleSpy).toHaveBeenCalled()
+    })
   })
 
-  it("errors out when no data is provided", () => {
-    const event = "testEvent"
-    const data = undefined
+  describe("User Information is not available", () => {
+    let pushToDataLayer
 
-    const { result } = renderHook(() => useGTMDataLayer())
+    beforeEach(() => {
+      const wrapper = ({ children }) => (
+        <UserContext.Provider value={{ profile: undefined }}>{children}</UserContext.Provider>
+      )
 
-    result.current.pushToDataLayer(event, data)
+      const { result } = renderHook(() => useGTMDataLayer(), { wrapper })
 
-    expect(consoleSpy).toHaveBeenCalled()
+      pushToDataLayer = result.current.pushToDataLayer
+    })
+
+    it("pushed data to the data layer but with an undefined user_id", () => {
+      const event = "testEvent"
+      const data = { test: "data" }
+
+      pushToDataLayer(event, data)
+
+      expect(TagManager.dataLayer).toHaveBeenCalledWith({
+        dataLayer: {
+          event,
+          event_timestamp: mockedDate.toISOString(),
+          ...data,
+          user_id: undefined, // when a value is undefined it is ignored by GTM
+        },
+      })
+    })
   })
 
-  it("errors out when no event is provided", () => {
-    const event = undefined
-    const data = { test: "data" }
+  describe("useGTMDataLayerWithoutUserContext", () => {
+    let pushToDataLayer
 
-    const { result } = renderHook(() => useGTMDataLayer())
+    beforeEach(() => {
+      const { result } = renderHook(() => useGTMDataLayerWithoutUserContext())
 
-    result.current.pushToDataLayer(event, data)
+      pushToDataLayer = result.current.pushToDataLayer
+    })
 
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+    it("pushed data to the data layer but without a user_id", () => {
+      const event = "testEvent"
+      const data = { test: "data" }
 
-  it("errors out when an event property is provided in the data object", () => {
-    const event = "testEvent"
-    const data = { test: "data", event: "testEvent" }
+      pushToDataLayer(event, data)
 
-    const { result } = renderHook(() => useGTMDataLayer())
-
-    result.current.pushToDataLayer(event, data)
-
-    expect(consoleSpy).toHaveBeenCalled()
+      expect(TagManager.dataLayer).toHaveBeenCalledWith({
+        dataLayer: {
+          event,
+          event_timestamp: mockedDate.toISOString(),
+          ...data,
+        },
+      })
+    })
   })
 })

--- a/app/javascript/__tests__/pages/listings/ListingDetail.test.tsx
+++ b/app/javascript/__tests__/pages/listings/ListingDetail.test.tsx
@@ -80,9 +80,12 @@ describe("Listing Detail", () => {
   })
 
   it("initializes Google Tag Manager for a sales listing", async () => {
+    const mockedDate = new Date()
     axios.get.mockResolvedValue({
       data: { listing: habitatListing, units: habitatListing.Units, ami: [] },
     })
+    jest.useFakeTimers()
+    jest.setSystemTime(mockedDate)
     await renderAndLoadAsync(<ListingDetail assetPaths="/" />)
 
     expect(TagManager.dataLayer).toHaveBeenCalledWith({
@@ -95,6 +98,8 @@ describe("Listing Detail", () => {
         listing_record_type: "Ownership",
         listing_status: "Active",
         listing_tenure: "New sale",
+        event_timestamp: mockedDate.toISOString(),
+        listingType: undefined,
       },
     })
   })

--- a/app/javascript/authentication/context/UserProvider.tsx
+++ b/app/javascript/authentication/context/UserProvider.tsx
@@ -13,8 +13,8 @@ import {
 } from "./userActions"
 import UserContext, { ContextProps } from "./UserContext"
 import UserReducer from "./UserReducer"
-import { useGTMDataLayer } from "../../hooks/analytics/useGTMDataLayer"
 import { AxiosError } from "axios"
+import { useGTMDataLayerWithoutUserContext } from "../../hooks/analytics/useGTMDataLayer"
 
 interface UserProviderProps {
   children?: React.ReactNode
@@ -26,7 +26,7 @@ const UserProvider = (props: UserProviderProps) => {
     initialStateLoaded: false,
   })
 
-  const { pushToDataLayer } = useGTMDataLayer()
+  const { pushToDataLayer } = useGTMDataLayerWithoutUserContext()
 
   // Load our profile as soon as we have an access token available
   useEffect(() => {
@@ -47,7 +47,7 @@ const UserProvider = (props: UserProviderProps) => {
         .catch((error) => {
           if (error?.message === "Token expired") {
             pushToDataLayer("logout", {
-              user_id: state?.profile?.id || undefined,
+              user_id: undefined,
               reason: "Token expire",
             })
 
@@ -81,7 +81,7 @@ const UserProvider = (props: UserProviderProps) => {
         })
         .catch((error: AxiosError<{ error: string; email: string }>) => {
           pushToDataLayer("login_failed", {
-            user_id: null,
+            user_id: undefined,
             origin,
             error_reason: error.response?.data.error,
           })

--- a/app/javascript/authentication/context/UserProvider.tsx
+++ b/app/javascript/authentication/context/UserProvider.tsx
@@ -83,7 +83,7 @@ const UserProvider = (props: UserProviderProps) => {
           pushToDataLayer("login_failed", {
             user_id: undefined,
             origin,
-            error_reason: error.response?.data.error,
+            reason: error.response?.data.error,
           })
           throw error
         })

--- a/app/javascript/hooks/analytics/useGTMDataLayer.tsx
+++ b/app/javascript/hooks/analytics/useGTMDataLayer.tsx
@@ -1,21 +1,41 @@
-import { useCallback } from "react"
+import { useCallback, useContext } from "react"
 import TagManager from "react-gtm-module"
+import UserContext from "../../authentication/context/UserContext"
 
+const validateAndPushData = (event, data) => {
+  if (!data || typeof data !== "object") {
+    console.error("Data must be an object when pushing to the data layer.")
+    return
+  }
+  if (!event) {
+    console.error("An event must be provided when pushing to the data layer.")
+    return
+  }
+  if (data?.event || data?.event_timestamp) {
+    console.error("Data object cannot contain an 'event' or 'event_timestamp' key.")
+    return
+  }
+  TagManager.dataLayer({ dataLayer: { event, event_timestamp: new Date().toISOString(), ...data } })
+}
+
+// Only use this hook if it is within the UserContext
 export const useGTMDataLayer = () => {
+  const { profile } = useContext(UserContext)
+
+  const pushToDataLayer = useCallback(
+    (event, data) => {
+      validateAndPushData(event, { user_id: profile?.id || undefined, ...data })
+    },
+    [profile?.id]
+  )
+
+  return { pushToDataLayer }
+}
+
+// A pure version of the hook that does not rely on any context
+export const useGTMDataLayerWithoutUserContext = () => {
   const pushToDataLayer = useCallback((event, data) => {
-    if (!data || typeof data !== "object") {
-      console.error("Data must be an object when pushing to the data layer.")
-      return
-    }
-    if (!event) {
-      console.error("An event must be provided when pushing to the data layer.")
-      return
-    }
-    if (data?.event) {
-      console.error("Data object cannot contain an 'event' key.")
-      return
-    }
-    TagManager.dataLayer({ dataLayer: { event, ...data } })
+    validateAndPushData(event, data)
   }, [])
 
   return { pushToDataLayer }


### PR DESCRIPTION
## Description

The user_id and timestamp will now be sent with every event. In the case that the user is not signed in, we will send undefined for the user_id value. This will allow us to have more information about user behavior and leverage GA's user_id tracking feature.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3052

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)