### PR TITLE
feat: DAH-2826 Auto populate user

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,7 @@
         "heroku-postgresql"
       ],
       "scripts": {
-        "postdeploy": "rake db:migrate"
+        "postdeploy": "rake db:migrate && rake preload:user"
       }
     }
   },

--- a/lib/tasks/preload_user.rake
+++ b/lib/tasks/preload_user.rake
@@ -1,0 +1,10 @@
+# This should only be run for apps in the review category
+namespace :preload do
+  task user: :environment do
+    user = User.find_or_create_by(email: 'test@test.com') do |u|
+      u.password = 'abcd1234'
+      u.password_confirmation = 'abcd1234'
+    end
+    user.confirm unless user.confirmed?
+  end
+end

--- a/lib/tasks/preload_user.rake
+++ b/lib/tasks/preload_user.rake
@@ -1,10 +1,26 @@
-# This should only be run for apps in the review category
 namespace :preload do
   task user: :environment do
     user = User.find_or_create_by(email: 'test@test.com') do |u|
       u.password = 'abcd1234'
       u.password_confirmation = 'abcd1234'
     end
-    user.confirm unless user.confirmed?
+
+    raise 'Failed to create user' unless user.persisted?
+
+    salesforce_contact = Force::AccountService.create_or_update(
+      webAppID: user.id,
+      email: user.email,
+      firstName: 'Test',
+      lastName: 'User',
+      DOB: '1990-01-01',
+    )
+
+    if salesforce_contact && salesforce_contact['contactId'].present?
+      user.update(salesforce_contact_id: salesforce_contact['contactId'])
+      user.confirm unless user.confirmed?
+    else
+      user.destroy
+      raise 'Failed to sync with Salesforce'
+    end
   end
 end


### PR DESCRIPTION
## Description

Introduces a script that automatically creates a new user on the first build of a PR (review) app. The script should not run for any other environment.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-2826

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [x] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)