### PR TITLE
fix: DAH-3126 translation character encoding

### DIFF
--- a/app/assets/json/translations/locale-zh.json
+++ b/app/assets/json/translations/locale-zh.json
@@ -512,7 +512,7 @@
                 "contact_us": "如果您對您的申請有疑問，請與我們聯絡。請發送電子郵件至 sfhousinginfo@sfgov.org。",
                 "get_help": "獲取協助",
                 "keep_this_number": "您需要這個號碼來查看您的結果。請將其存放在安全的地方。",
-                "lottery_date": "抽籤日期：％{lottery_date}",
+                "lottery_date": "抽籤日期：%{lottery_date}",
                 "subject": "我們已收到您的 %{listing_name} 申請表",
                 "submitted": "提交日期：%{submission_date}，%{submission_time} 太平洋時間",
                 "we_contact_applicants": "我們將按照抽籤結果的順序聯絡申請人，直到貸款資金全數分配完畢",


### PR DESCRIPTION
## Description

In the xliff file provided by lionbridge the character encoding for `emailer.submission_confirmation_dalp.lottery_date` in the zh file was causing rendering issues in email. 

### Review Instructions

This change is not straight forward to PA test since it involves emails which we do not have a standard solution for local and review app environments. 

To validate we can check that all localized files have the same encoding for `%{lottery_date}` in `emailer.submission_confirmation_dalp.lottery_date`. In the ticket DAH-3126 it was confirmed that the email renderings worked correctly for all languages except `zh`

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3126

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)