### PR TITLE
fix: DAH-3274 Restore isDALP function

### DIFF
--- a/app/assets/javascripts/short-form/components/applicationSummary.js.coffee
+++ b/app/assets/javascripts/short-form/components/applicationSummary.js.coffee
@@ -16,8 +16,8 @@ angular.module('dahlia.components')
     showVeteransApplicationQuestion: '<'
     applicantHasClaimedDalpPriority: '<'
   controller: [
-    '$filter', '$state', '$translate', 'LendingInstitutionService', 'ShortFormHelperService', 'ShortFormNavigationService', 'ShortFormRaceEthnicityService',
-    ($filter, $state, $translate, LendingInstitutionService, ShortFormHelperService, ShortFormNavigationService, ShortFormRaceEthnicityService) ->
+    '$filter', '$state', '$translate', 'LendingInstitutionService', 'ShortFormHelperService', 'ShortFormNavigationService', 'ShortFormRaceEthnicityService', 'ListingDataService'
+    ($filter, $state, $translate, LendingInstitutionService, ShortFormHelperService, ShortFormNavigationService, ShortFormRaceEthnicityService, ListingDataService) ->
       ctrl = @
 
       ctrl.$onInit = ->
@@ -133,6 +133,9 @@ angular.module('dahlia.components')
 
       ctrl.getIsNonPrimaryMemberVeteran = ->
         ctrl.translatedYesNoNoAnswer(ctrl.application.isNonPrimaryMemberVeteran)
+
+      ctrl.isDALPListing = ->
+        ListingDataService.listing.Custom_Listing_Type == 'Downpayment Assistance Loan Program'
 
       ctrl.qualifySectionHref = ->
         if ctrl.isDALPListing()


### PR DESCRIPTION
## Description

Restores a function that was mistakenly removed, needed to jump to the DALP section from the Application Summary page.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3274

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)