### PR TITLE
fix: DAH-3285 Prevent Autocapitalization of Visible Password

### DIFF
--- a/app/javascript/__tests__/pages/account/__snapshots__/account-settings.test.tsx.snap
+++ b/app/javascript/__tests__/pages/account/__snapshots__/account-settings.test.tsx.snap
@@ -614,6 +614,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             <input
                               aria-describedby="currentPassword-error"
                               aria-invalid="false"
+                              autocapitalize="none"
                               class="input"
                               data-testid="password-field"
                               id="currentPassword"
@@ -698,6 +699,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                             <input
                               aria-describedby="newPasswordInstructions"
                               aria-invalid="false"
+                              autocapitalize="none"
                               class="input"
                               data-testid="password-field"
                               id="password"
@@ -1482,6 +1484,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                           <input
                             aria-describedby="currentPassword-error"
                             aria-invalid="false"
+                            autocapitalize="none"
                             class="input"
                             data-testid="password-field"
                             id="currentPassword"
@@ -1566,6 +1569,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 1`] = 
                           <input
                             aria-describedby="newPasswordInstructions"
                             aria-invalid="false"
+                            autocapitalize="none"
                             class="input"
                             data-testid="password-field"
                             id="password"
@@ -2383,6 +2387,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             <input
                               aria-describedby="currentPassword-error"
                               aria-invalid="false"
+                              autocapitalize="none"
                               class="input"
                               data-testid="password-field"
                               id="currentPassword"
@@ -2467,6 +2472,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                             <input
                               aria-describedby="newPasswordInstructions"
                               aria-invalid="false"
+                              autocapitalize="none"
                               class="input"
                               data-testid="password-field"
                               id="password"
@@ -3227,6 +3233,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                           <input
                             aria-describedby="currentPassword-error"
                             aria-invalid="false"
+                            autocapitalize="none"
                             class="input"
                             data-testid="password-field"
                             id="currentPassword"
@@ -3311,6 +3318,7 @@ exports[`<AccountSettingsPage /> when the user is signed in resize events 2`] = 
                           <input
                             aria-describedby="newPasswordInstructions"
                             aria-invalid="false"
+                            autocapitalize="none"
                             class="input"
                             data-testid="password-field"
                             id="password"

--- a/app/javascript/pages/account/components/PasswordFieldset.tsx
+++ b/app/javascript/pages/account/components/PasswordFieldset.tsx
@@ -143,7 +143,7 @@ const PasswordField = ({ passwordVisibilityDefault = false, ...props }: Password
         dataTestId="password-field"
         {...props}
         type={showPassword ? "text" : "password"}
-        inputProps={{ className: "input", required: true }}
+        inputProps={{ className: "input", required: true, autoCapitalize: "none" }}
       />
       <div className="field">
         <input


### PR DESCRIPTION
## Description

On mobile devices with the auto-capitalize setting turned on, make sure visible password fields do not get auto-capitalized.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3285

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)