### PR TITLE
Hotfix DAH-3305 Use Priorities Descriptor for eligible units

### DIFF
--- a/app/javascript/__tests__/pages/listings/__snapshots__/ListingDetail.test.tsx.snap
+++ b/app/javascript/__tests__/pages/listings/__snapshots__/ListingDetail.test.tsx.snap
@@ -11666,7 +11666,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             <span
                               class="info-card__subtitle"
                             >
-                              7 Units
+                              8 Units
                             </span>
                           </div>
                           <p
@@ -11684,7 +11684,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             <h3
                               class="info-card__title"
                             >
-                              Vision and/or Hearing Impairments
+                              Hearing/Vision (Communication)
                             </h3>
                             <span
                               class="info-card__subtitle"
@@ -11695,7 +11695,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <p
                             class="text-sm text-gray-700"
                           >
-                             These units have accessibility features for people with impaired vision and/or hearing.
+                            These units have accessibility features for people with impaired hearing and/or vision (communication).
                           </p>
                         </div>
                       </li>
@@ -12233,7 +12233,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="info-card__subtitle"
                           >
-                            7 Units
+                            8 Units
                           </span>
                         </div>
                         <p
@@ -12251,7 +12251,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <h3
                             class="info-card__title"
                           >
-                            Vision and/or Hearing Impairments
+                            Hearing/Vision (Communication)
                           </h3>
                           <span
                             class="info-card__subtitle"
@@ -12262,7 +12262,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         <p
                           class="text-sm text-gray-700"
                         >
-                           These units have accessibility features for people with impaired vision and/or hearing.
+                          These units have accessibility features for people with impaired hearing and/or vision (communication).
                         </p>
                       </div>
                     </li>
@@ -12841,7 +12841,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="info-card__subtitle"
                           >
-                            7 Units
+                            8 Units
                           </span>
                         </div>
                         <p
@@ -12859,7 +12859,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <h3
                             class="info-card__title"
                           >
-                            Vision and/or Hearing Impairments
+                            Hearing/Vision (Communication)
                           </h3>
                           <span
                             class="info-card__subtitle"
@@ -12870,7 +12870,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         <p
                           class="text-sm text-gray-700"
                         >
-                           These units have accessibility features for people with impaired vision and/or hearing.
+                          These units have accessibility features for people with impaired hearing and/or vision (communication).
                         </p>
                       </div>
                     </li>
@@ -15293,7 +15293,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="info-card__subtitle"
                           >
-                            7 Units
+                            8 Units
                           </span>
                         </div>
                         <p
@@ -15311,7 +15311,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <h3
                             class="info-card__title"
                           >
-                            Vision and/or Hearing Impairments
+                            Hearing/Vision (Communication)
                           </h3>
                           <span
                             class="info-card__subtitle"
@@ -15322,7 +15322,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         <p
                           class="text-sm text-gray-700"
                         >
-                           These units have accessibility features for people with impaired vision and/or hearing.
+                          These units have accessibility features for people with impaired hearing and/or vision (communication).
                         </p>
                       </div>
                     </li>

--- a/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
@@ -10,6 +10,7 @@ import {
 } from "@bloom-housing/ui-components"
 import { RailsListing } from "../listings/SharedHelpers"
 import {
+  getPriorityUnits,
   isEducator,
   isEducatorOne,
   isFcfsSalesListing,
@@ -30,7 +31,6 @@ import {
 } from "../../util/languageUtil"
 import { BeforeApplyingForSale, BeforeApplyingType } from "../../components/BeforeApplyingForSale"
 import { ListingDetailsPreferences } from "./ListingDetailsPreferences"
-import type RailsUnit from "../../api/types/rails/listings/RailsUnit"
 import ErrorBoundary, { BoundaryScope } from "../../components/ErrorBoundary"
 import { ListingDetailsHMITable } from "./ListingDetailsHMITable"
 import "./ListingDetailsEligibility.scss"
@@ -54,24 +54,7 @@ export const ListingDetailsEligibility = ({
 }: ListingDetailsEligibilityProps) => {
   const isAllSRO = listingHasOnlySROUnits(listing)
   const isSomeSRO = listingHasSROUnits(listing)
-  const priorityUnits = []
-
-  listing.Units?.forEach((unit: RailsUnit) => {
-    const priorityUnit = priorityUnits?.find((priorityUnit: ReducedUnit) => {
-      return priorityUnit.name === unit.Priority_Type
-    })
-
-    if (unit.Priority_Type && !priorityUnit) {
-      priorityUnits.push({
-        name: unit.Priority_Type,
-        numberOfUnits: 1,
-      })
-    }
-
-    if (unit.Priority_Type && priorityUnit) {
-      priorityUnit.numberOfUnits++
-    }
-  })
+  const priorityUnits = listing.prioritiesDescriptor || getPriorityUnits(listing.Units)
 
   let occupancySubtitle = ""
   if (isSale(listing)) {

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -709,3 +709,24 @@ export const listingHasVeteransPreference = (listing: RailsListing): boolean => 
 export const forceRecacheParam = () => ({
   params: window.location.search.includes("preview=true") ? { force: true } : {},
 })
+
+export const getPriorityUnits = (units: RailsUnit[]) => {
+  const priorityUnits = []
+  units.forEach((unit: RailsUnit) => {
+    const priorityUnit = priorityUnits?.find((priorityUnit) => {
+      return priorityUnit.name === unit.Priority_Type
+    })
+
+    if (unit.Priority_Type && !priorityUnit) {
+      priorityUnits.push({
+        name: unit.Priority_Type,
+        numberOfUnits: 1,
+      })
+    }
+
+    if (unit.Priority_Type && priorityUnit) {
+      priorityUnit.numberOfUnits++
+    }
+  })
+  return priorityUnits
+}


### PR DESCRIPTION
## Description

Use `listing.prioritiesDescriptor` to populate unit eligibility section, instead of `listing.Units`. For listings with over ~180 units, `listing.Units` will only show a truncated set of Units.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3305

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)