### PR TITLE
fix: DAH-3144 Add Angular timeout onclose callback

### DIFF
--- a/app/assets/javascripts/config/angularInitialize.js.coffee
+++ b/app/assets/javascripts/config/angularInitialize.js.coffee
@@ -38,14 +38,24 @@
         content.message = $translate.instant('t.session_inactivity')
         AnalyticsService.trackEvent('session_exp_warning_shown', {label_prefix, is_during_application_flow: isInShortForm, user_id: undefined, url: window.location.href})
       ModalService.alert content,
-        onConfirm: ->
-          AnalyticsService.trackEvent('session_exp_warning_action', {
-            label_prefix,
-            is_during_application_flow: isInShortForm,
-            user_id: undefined,
-            action: "user prevented",
-            url: window.location.href
-          })
+        {
+          onConfirm: ->
+            AnalyticsService.trackEvent('session_exp_warning_action', {
+              label_prefix,
+              is_during_application_flow: isInShortForm,
+              user_id: undefined,
+              action: "user prevented",
+              url: window.location.href
+            })
+          onClose: ->
+            AnalyticsService.trackEvent('session_exp_warning_action', {
+              label_prefix,
+              is_during_application_flow: isInShortForm,
+              user_id: undefined,
+              action: "user prevented",
+              url: window.location.href
+            })
+        }
         { nativeAlert: true }
 
     $rootScope.$on 'IdleTimeout', ->

--- a/app/assets/javascripts/shared/ModalInstanceController.js.coffee
+++ b/app/assets/javascripts/shared/ModalInstanceController.js.coffee
@@ -2,6 +2,7 @@ ModalInstanceController = ($scope, ModalService) ->
   $scope.content = ModalService.content
 
   $scope.closeModal = () ->
+    ModalService.callbacks.onConfirm() if ModalService.callbacks.onConfirm
     ModalService.closeModal()
 
   $scope.confirm = ->

--- a/app/assets/javascripts/shared/ModalInstanceController.js.coffee
+++ b/app/assets/javascripts/shared/ModalInstanceController.js.coffee
@@ -1,13 +1,14 @@
 ModalInstanceController = ($scope, ModalService) ->
   $scope.content = ModalService.content
 
-  $scope.closeModal = () ->
-    ModalService.callbacks.onClose() if ModalService.callbacks.onClose
+  $scope.closeModal = (shouldCallOnClose = true) ->
+    if shouldCallOnClose
+      ModalService.callbacks.onClose() if ModalService.callbacks.onClose
     ModalService.closeModal()
 
   $scope.confirm = ->
     ModalService.callbacks.onConfirm() if ModalService.callbacks.onConfirm
-    $scope.closeModal()
+    $scope.closeModal(false)
 
 ModalInstanceController.$inject = ['$scope', 'ModalService']
 

--- a/app/assets/javascripts/shared/ModalInstanceController.js.coffee
+++ b/app/assets/javascripts/shared/ModalInstanceController.js.coffee
@@ -2,7 +2,7 @@ ModalInstanceController = ($scope, ModalService) ->
   $scope.content = ModalService.content
 
   $scope.closeModal = () ->
-    ModalService.callbacks.onConfirm() if ModalService.callbacks.onConfirm
+    ModalService.callbacks.onClose() if ModalService.callbacks.onClose
     ModalService.closeModal()
 
   $scope.confirm = ->

--- a/app/assets/javascripts/shared/ModalService.js.coffee
+++ b/app/assets/javascripts/shared/ModalService.js.coffee
@@ -22,6 +22,7 @@ ModalService = ($modal, $window) ->
   Service.alert = (content, opts = {}) ->
     angular.copy(content, Service.content)
     Service.callbacks.onConfirm = opts.onConfirm if opts.onConfirm
+    Service.callbacks.onClose = opts.onClose if opts.onClose
     nativeAlert = !!opts.nativeAlert
     if nativeAlert && !$window.navigator.userAgent.match(/iPhone|iPad|iPod/i)
       $window.alert(content.message)


### PR DESCRIPTION
## Description

This PR fixes an issue with the previous timeout analytics work where we did not send an event when the user hits the "x" button on the timeout dialog.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3144

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)