### PR TITLE
fix: DAH-3322 Downgrade chromedriver to v131 to match chrome browser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "chai": "4.0.2",
     "chai-as-promised": "7.1.1",
     "chance": "1.0.10",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^131.0.0",
     "coffee-script": "1.12.7",
     "coffeelint": "^2.1.0",
     "coffeelint-forbidden-regex": "0.1.1",


### PR DESCRIPTION
## Description

Downgrade chromedriver NPM package to match chrome browser version that is installed with CircleCI config.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3322

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)