### PR TITLE
fix: DAH-3341 Don't run GH Title Check for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -19,6 +19,12 @@ jobs:
           jira_regex="^(build|ci|docs|feat|fix|perf|refactor|revert|style|test): DAH-[0-9]+ .+|^chore: .+"
           urgent_regex="^urgent: \S+"
 
+          # Skip validation for Dependabot PRs
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "PR created by Dependabot - skipping title validation."
+            exit 0
+          fi
+
           if [[ "${PR_TITLE}" =~ $urgent_regex ]]; then
             echo "PR title contains 'urgent'. Skipping JIRA check but validating description."
           elif [[ "${PR_TITLE}" =~ $jira_regex ]]; then


### PR DESCRIPTION
## Description

This PR amends the Github Title Checker action to ignore dependabot PRs.

Documentation can be found [here](https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows).

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3342

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)