### PR TITLE
fix: DAH-3354 Fix padding in housing counselor page

### DIFF
--- a/app/javascript/pages/getAssistance/housing-counselors.tsx
+++ b/app/javascript/pages/getAssistance/housing-counselors.tsx
@@ -80,7 +80,7 @@ const HousingCounselor = (housingCounselor: CounselorData) => {
       <div className="mt-4 flex flex-col gap-2">
         {housingCounselor.address.map((address, index) => {
           return (
-            <div key={index} className="icon-item flex gap-2">
+            <div key={index} className="icon-item flex">
               <Icon className="address-icon" symbol="map" size="medium" />
               <div className="flex flex-col">
                 {address.label_key && <span className="font-semibold">{t(address.label_key)}</span>}


### PR DESCRIPTION
## Description

This PR fixes an issue where there was a gap between the location icon and address on the housing counselor tiles.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3354

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)