### PR TITLE
feat: DAH-3441 feature flag and guard clause for initial test listing

### DIFF
--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -223,6 +223,19 @@ class Api::V1::ShortFormController < ApiController
   def send_submit_app_confirmation(response)
     DahliaBackend::MessageService.send_application_confirmation(application_params,
                                                                 response)
+
+    if Rails.configuration.unleash.is_enabled?('temp.webapp.messaging.enableInitialListingSend')
+      test_listing_id = ENV.fetch('TEMP_EMAIL_LISTING_ID', nil)
+
+      # Guard clause for test listing
+      Rails.logger.info("ShortFormController#send_submit_app_confirmation: Don't send old email for initial test listing #{test_listing_id}")
+
+      if application_params[:listingID] == test_listing_id
+        Rails.logger.info("ShortFormController#send_submit_app_confirmation: Skipping send old email for initial test listing #{test_listing_id}")
+        return
+      end
+    end
+
     Emailer.submission_confirmation(
       locale: params[:locale],
       email: application_params[:primaryApplicant][:email],

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -228,10 +228,10 @@ class Api::V1::ShortFormController < ApiController
       initial_listing_id = ENV.fetch('TEMP_EMAIL_LISTING_ID', nil)
 
       # Guard clause for test listing
-      Rails.logger.info("ShortFormController#send_submit_app_confirmation: Don't send old email for initial test listing #{test_listing_id}")
+      Rails.logger.info("ShortFormController#send_submit_app_confirmation: Don't send old email for initial test listing #{initial_listing_id}")
 
       if application_params[:listingID] == initial_listing_id
-        Rails.logger.info("ShortFormController#send_submit_app_confirmation: Skipping send old email for initial test listing #{test_listing_id}")
+        Rails.logger.info("ShortFormController#send_submit_app_confirmation: Skipping send old email for initial test listing #{initial_listing_id}")
         return
       end
     end

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -225,12 +225,12 @@ class Api::V1::ShortFormController < ApiController
                                                                 response)
 
     if Rails.configuration.unleash.is_enabled?('temp.webapp.messaging.enableInitialListingSend')
-      test_listing_id = ENV.fetch('TEMP_EMAIL_LISTING_ID', nil)
+      initial_listing_id = ENV.fetch('TEMP_EMAIL_LISTING_ID', nil)
 
       # Guard clause for test listing
       Rails.logger.info("ShortFormController#send_submit_app_confirmation: Don't send old email for initial test listing #{test_listing_id}")
 
-      if application_params[:listingID] == test_listing_id
+      if application_params[:listingID] == initial_listing_id
         Rails.logger.info("ShortFormController#send_submit_app_confirmation: Skipping send old email for initial test listing #{test_listing_id}")
         return
       end


### PR DESCRIPTION
## Description

Add temp feature toggle: https://dahlia-feature-service-fbc319c3f542.herokuapp.com/projects/default/features/temp.webapp.messaging.enableInitialListingSend

Add ENV Variable: TEMP_EMAIL_LISTING_ID

If the feature toggle is enabled, check if the incoming application is for the TEMP_EMAIL_LISTING_ID. If it is, we are NOT calling the old email messaging logic. 

This PR makes the change to allow the new email service to send messages for the TEMP_EMAIL_LISTING_ID: https://github.com/SFDigitalServices/sf-dahlia-backend/pull/27

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3441

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`. If the PR is urgent and does not need a ticket then use the format `urgent: Description`

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [ ] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance testing

- [ ] Code change is behind a feature flag
- [ ] If code change is not behind a feature flag, it has been PA tested in the review environment (use `needs product acceptance` label to indicate that the PR is waiting for PA testing)