### PR TITLE
feat: DAH-3316 pass locale to messaging service

### DIFF
--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -222,7 +222,7 @@ class Api::V1::ShortFormController < ApiController
 
   def send_submit_app_confirmation(response)
     DahliaBackend::MessageService.send_application_confirmation(application_params,
-                                                                response)
+                                                                response, params[:locale])
 
     if Rails.configuration.unleash.is_enabled?('temp.webapp.messaging.enableInitialListingSend')
       initial_listing_id = ENV.fetch('TEMP_EMAIL_LISTING_ID', nil)

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -10,9 +10,12 @@ module DahliaBackend
       #
       # @param [Hash] application_params Parameters from the application
       # @param [Hash] application_response Response from the application submission
+      # @param [String] locale Locale for the message (default is 'en')
       # @return [Object, nil] Response from the message service or nil if service is disabled/error occurs
-      def send_application_confirmation(application_params, application_response)
-        new.send_application_confirmation(application_params, application_response)
+      def send_application_confirmation(application_params, application_response,
+                                        locale = 'en')
+        new.send_application_confirmation(application_params, application_response,
+                                          locale)
       end
 
       def service_enabled?
@@ -29,12 +32,14 @@ module DahliaBackend
     # Instance method implementation for application confirmation
     # @param [Hash] application_params Parameters from the application
     # @param [Hash] application_response Response from the application submission
+    # @param [String] locale Locale for the message (default is 'en')
     # @return [Object, nil] Response from the message service or nil if service is disabled/error occurs
-    def send_application_confirmation(application_params, application_response)
+    def send_application_confirmation(application_params, application_response,
+                                      locale = 'en')
       return unless self.class.service_enabled?
       return unless valid_params?(application_params, application_response)
 
-      fields = prepare_submission_fields(application_params, application_response)
+      fields = prepare_submission_fields(application_params, application_response, locale)
       return if fields.nil?
 
       send_message('/messages/application-submission', fields)
@@ -45,7 +50,8 @@ module DahliaBackend
 
     private
 
-    def prepare_submission_fields(application_params, application_response)
+    def prepare_submission_fields(application_params, application_response,
+                                  locale = 'en')
       listing_id = application_params[:listingID]
       email = application_params.dig(:primaryApplicant, :email).to_s
 
@@ -67,6 +73,7 @@ module DahliaBackend
           phone: listing.Leasing_Agent_Phone.to_s,
           officeHours: listing.Office_Hours.to_s,
         },
+        lang: locale,
       }
     end
 

--- a/spec/controllers/api/v1/short_form_controller_spec.rb
+++ b/spec/controllers/api/v1/short_form_controller_spec.rb
@@ -56,7 +56,7 @@ describe Api::V1::ShortFormController, type: :controller do
         .and_return(response_data)
 
       expect(DahliaBackend::MessageService).to receive(:send_application_confirmation)
-        .with(application_params, response_data)
+        .with(application_params, response_data, nil)
 
       post :submit_application
       expect(response).to have_http_status(:ok)

--- a/spec/services/dahlia_backend/message_service_spec.rb
+++ b/spec/services/dahlia_backend/message_service_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe DahliaBackend::MessageService do
   describe '.send_application_confirmation' do
     it 'delegates to instance method' do
       expect_any_instance_of(described_class).to receive(:send_application_confirmation)
-        .with(application_params, application_response)
+        .with(application_params, application_response, 'en')
       described_class.send_application_confirmation(application_params,
-                                                    application_response)
+                                                    application_response, 'en')
     end
   end
 


### PR DESCRIPTION
## Description

Passes the locale parameter as a body field to the application submission email api.

The backend changes are here: https://github.com/SFDigitalServices/sf-dahlia-backend/pull/30

Check the text and links for the email.


## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3316
## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag