### PR TITLE
feat: DAH-3337 remove deprecated ssl options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
         RAILS_ENV: development
         PGHOST: 127.0.0.1
         PGUSER: root
-        NODE_OPTIONS: --openssl-legacy-provider --max_old_space_size=4096
+        NODE_OPTIONS: --max_old_space_size=4096
     - image: cimg/postgres:9.6
       environment:
         POSTGRES_USER: root

--- a/README.md
+++ b/README.md
@@ -68,11 +68,10 @@ More information about getting started can be found on the team confluence.
 - `yarn client` to start the webpack dev server alone
 - `yarn server` to start rails server alone, which will now be running at <http://localhost:3000> by default
 - `yarn start` to start both servers with a single command
+- Alternatively you can start the servers using the webpack and rails command directly
 
-1. Alternatively you can start the servers using the webpack and rails command directly
-
-- `NODE_OPTIONS=--openssl-legacy-provider ./bin/shakapacker-dev-server` to start webpack
-  - This command might fail with `Command "webpack-dev-server" not found.`. In that case, you'll need to reinstall webpacker with `bundle exec rails:shakapacker:install`. During the install it will ask if you want to overwrite a few config files, do not overwrite them.
+  - `./bin/shakapacker-dev-server` to start webpack
+    - This command might fail with `Command "webpack-dev-server" not found.`. In that case, you'll need to reinstall webpacker with `bundle exec rails:shakapacker:install`. During the install it will ask if you want to overwrite a few config files, do not overwrite them.
 - In another terminal tab, run `rails s` to start the rails server
 
 ## How to migrate a page from AngularJS to React

--- a/app.json
+++ b/app.json
@@ -108,7 +108,7 @@
     },
     "NODE_OPTIONS": {
       "required": false,
-      "value": "--openssl-legacy-provider --max_old_space_size=4096"
+      "value": "--max_old_space_size=4096"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -140,9 +140,9 @@
     "webpack:analyze": "yarn webpack:build_json && yarn webpack:analyze_json",
     "webpack:build_json": "RAILS_ENV=${RAILS_ENV:-production} NODE_ENV=${NODE_ENV:-production} bin/webpack --profile --json > tmp/webpack-stats.json",
     "webpack:analyze_json": "webpack-bundle-analyzer tmp/webpack-stats.json public/packs",
-    "start": "concurrently --names \"SERVER,CLIENT\" -c \"bgBlue.bold,bgMagenta.bold\" \"bundle exec rails s -p 3000\" \"NODE_OPTIONS=\"--openssl-legacy-provider\" ./bin/shakapacker-dev-server\"",
+    "start": "concurrently --names \"SERVER,CLIENT\" -c \"bgBlue.bold,bgMagenta.bold\" \"bundle exec rails s -p 3000\" \"NODE_OPTIONS=\"\" ./bin/shakapacker-dev-server\"",
     "server": "bundle exec rails s -p 3000",
-    "client": "NODE_OPTIONS=\"--openssl-legacy-provider\" ./bin/shakapacker-dev-server"
+    "client": "./bin/shakapacker-dev-server"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
## Description

Locally and in Heroku we are already using openssl 3, this PR removes the unnecessary legacy ssl options during app startup.

## Jira ticket

[DAH-3337](https://sfgovdt.jira.com/browse/DAH-3337)

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag

[DAH-3337]: https://sfgovdt.jira.com/browse/DAH-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ