### PR TITLE
fix: DAH-3478 Prevent auto-filled applications from bypassing senior listing restrictions

### DIFF
--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -692,6 +692,13 @@ ShortFormApplicationController = (
       $scope.handleErrorState()
       return
 
+    # this check is needed for when household members are added via auto-fill
+    if _.some $scope.householdMembers, ShortFormApplicationService.applicantDoesNotmeetAllSeniorBuildingRequirements
+      ShortFormApplicationService.addSeniorEligibilityError()
+      $scope.handleErrorState()
+      return
+
+
     # skip the check if we're doing an incomeMatch and the applicant has vouchers
     if match == 'incomeMatch' && $scope.application.householdVouchersSubsidies == 'Yes'
       ShortFormNavigationService.goToSection('Preferences')


### PR DESCRIPTION
## Description

Senior listing applications have requirements on minimum age of household members, but auto-filled applications can bypass these requirements. Fix this by validating the age of auto-filled household members.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3478

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag