### PR TITLE
fix: DAH-3478 Prevent auto-filled applications from bypassing senior listing restrictions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,7 @@ jobs:
       - run: ./tmp/cc-test-reporter format-coverage -t lcov -o tmp/codeclimate.unit-react.json app/javascript/test-coverage/lcov.info
       - run: ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.unit-rspec.json coverage/coverage.json
       - run: ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json -p 2 -o tmp/codeclimate.total.json
+      - run: cat tmp/codeclimate.total.json
       - run: ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate.total.json
       - qlty/coverage_publish:
           files: app/javascript/test-coverage/lcov.info, coverage/coverage.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ jobs:
       - run: ./tmp/cc-test-reporter format-coverage -t lcov -o tmp/codeclimate.unit-react.json app/javascript/test-coverage/lcov.info
       - run: ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.unit-rspec.json coverage/coverage.json
       - run: ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json -p 2 -o tmp/codeclimate.total.json
-      - run: cat tmp/codeclimate.total.json
       - run: ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate.total.json
       - qlty/coverage_publish:
           files: app/javascript/test-coverage/lcov.info, coverage/coverage.json

--- a/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
+++ b/app/assets/javascripts/short-form/ShortFormApplicationController.js.coffee
@@ -692,6 +692,12 @@ ShortFormApplicationController = (
       $scope.handleErrorState()
       return
 
+    # this check is needed here for household members that are added via auto-fill
+    if _.some $scope.householdMembers, ShortFormApplicationService.applicantDoesNotmeetAllSeniorBuildingRequirements
+      ShortFormApplicationService.addSeniorEligibilityError()
+      $scope.handleErrorState()
+      return
+
     # skip the check if we're doing an incomeMatch and the applicant has vouchers
     if match == 'incomeMatch' && $scope.application.householdVouchersSubsidies == 'Yes'
       ShortFormNavigationService.goToSection('Preferences')

--- a/lib/tasks/preload_user.rake
+++ b/lib/tasks/preload_user.rake
@@ -12,7 +12,7 @@ namespace :preload do
       email: user.email,
       firstName: 'Test',
       lastName: 'User',
-      DOB: '1990-01-01',
+      DOB: '1950-01-01',
     )
 
     if salesforce_contact && salesforce_contact['contactId'].present?


### PR DESCRIPTION
## Description

Senior listing applications have requirements on minimum age of household members, but auto-filled applications can bypass these requirements. Fix this by validating the age of auto-filled household members.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3478

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [x] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug
  - not writing Angular tests because of the brittleness of our Angular tooling

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag