### PR TITLE
Fix: DAH-3434 anchor link to buy now doesnt jump to section

### DIFF
--- a/app/javascript/modules/listings/GenericDirectory.tsx
+++ b/app/javascript/modules/listings/GenericDirectory.tsx
@@ -108,6 +108,15 @@ export const GenericDirectory = (props: RentalDirectoryProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters])
 
+  useEffect(() => {
+    if (!loading) {
+      const hash = window.location.hash
+      if (hash) {
+        window.location.href = hash
+      }
+    }
+  }, [loading])
+
   const hasFiltersSet = filters !== null
   const directorySections =
     props.directoryType === DIRECTORY_TYPE_SALES

--- a/cypress/e2e/rentalListings.e2e.ts
+++ b/cypress/e2e/rentalListings.e2e.ts
@@ -42,4 +42,11 @@ describe("Rental listings directory page", () => {
     cy.get(".listings-group__button button").first().click()
     cy.contains("Show Upcoming Lotteries")
   })
+
+  it("redirects to the correct section", () => {
+    cy.viewport(640, 960)
+    cy.visit("/listings/for-rent#upcoming-lotteries")
+    cy.wait("@listings")
+    cy.get("#upcoming-lotteries").isInViewport()
+  })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -25,3 +25,13 @@ Cypress.Commands.add("addReactQueryParam", () => {
     cy.visit(newUrl)
   })
 })
+
+/* eslint-disable jest/valid-expect */
+Cypress.Commands.addQuery("isInViewport", () => {
+  return (subject) => {
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const { top, left, bottom, right } = subject[0].getBoundingClientRect()
+    expect(top).to.be.at.least(0)
+    expect(left).to.be.at.least(0)
+  }
+})

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -10,6 +10,8 @@ declare global {
       signIn(email?: string): Chainable<any>
 
       addReactQueryParam(): Chainable<any>
+
+      isInViewport(): Chainable<any>
     }
   }
   interface Window {


### PR DESCRIPTION
## Description

Add code to jump to section after listings have been loaded

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3434

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag