### PR TITLE
feat: DAH-4028 Update SF LGBT Center languages to English, Taiwanese, and Mandarin

### DIFF
--- a/app/assets/json/housing_counselors.json
+++ b/app/assets/json/housing_counselors.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "San Francisco LGBT Community Center",
-      "languages":["English"],
+      "languages":["English", "Taiwanese", "Mandarin"],
       "address": "1800 Market Street",
       "citystate": "San Francisco, CA 94102",
       "phone": "(415) 865-5555",

--- a/app/assets/json/housing_counselors_react.json
+++ b/app/assets/json/housing_counselors_react.json
@@ -77,8 +77,9 @@
                 "ownership"
             ],
             "languages": [
-                "cantonese",
-                "english"
+                "english",
+                "mandarin",
+                "taiwanese"
             ],
             "address": [
                 {

--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -119,6 +119,7 @@
   "assistance.housingCounselors.services.languages.mandarin": "Mandarin",
   "assistance.housingCounselors.services.languages.russian": "Russian",
   "assistance.housingCounselors.services.languages.spanish": "Spanish",
+  "assistance.housingCounselors.services.languages.taiwanese": "Taiwanese",
   "assistance.housingCounselors.services.languages.vietnamese": "Vietnamese",
   "assistance.housingCounselors.services.ownership": "Ownership",
   "assistance.housingCounselors.services.rental": "Rental",

--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -119,6 +119,7 @@
   "assistance.housingCounselors.services.languages.mandarin": "Mandarín",
   "assistance.housingCounselors.services.languages.russian": "Ruso",
   "assistance.housingCounselors.services.languages.spanish": "Español",
+  "assistance.housingCounselors.services.languages.taiwanese": "Taiwanés",
   "assistance.housingCounselors.services.languages.vietnamese": "Vietnamita",
   "assistance.housingCounselors.services.ownership": "Propiedad",
   "assistance.housingCounselors.services.rental": "Alquiler",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -119,6 +119,7 @@
   "assistance.housingCounselors.services.languages.mandarin": "Mandarin",
   "assistance.housingCounselors.services.languages.russian": "Russian",
   "assistance.housingCounselors.services.languages.spanish": "Espanyol",
+  "assistance.housingCounselors.services.languages.taiwanese": "Taiwanese",
   "assistance.housingCounselors.services.languages.vietnamese": "Vietnamese",
   "assistance.housingCounselors.services.ownership": "Pagmamay-ari",
   "assistance.housingCounselors.services.rental": "Pagrenta",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -119,6 +119,7 @@
   "assistance.housingCounselors.services.languages.mandarin": "華語",
   "assistance.housingCounselors.services.languages.russian": "俄羅斯語",
   "assistance.housingCounselors.services.languages.spanish": "西班牙語",
+  "assistance.housingCounselors.services.languages.taiwanese": "臺語",
   "assistance.housingCounselors.services.languages.vietnamese": "越南語",
   "assistance.housingCounselors.services.ownership": "房屋所有權",
   "assistance.housingCounselors.services.rental": "租賃",

--- a/app/javascript/pages/getAssistance/counselor-filter.tsx
+++ b/app/javascript/pages/getAssistance/counselor-filter.tsx
@@ -43,6 +43,7 @@ const CounselorFilter = ({ handleFilterData, clearClick }: CounselorFilterProps)
     { label: t("assistance.housingCounselors.services.languages.spanish"), value: "spanish" },
     { label: t("assistance.housingCounselors.services.languages.mandarin"), value: "mandarin" },
     { label: t("assistance.housingCounselors.services.languages.russian"), value: "russian" },
+    { label: t("assistance.housingCounselors.services.languages.taiwanese"), value: "taiwanese" },
     { label: t("assistance.housingCounselors.services.languages.vietnamese"), value: "vietnamese" },
   ]
   // TODO(DAH-1575)

--- a/app/javascript/pages/getAssistance/counselor-filter.tsx
+++ b/app/javascript/pages/getAssistance/counselor-filter.tsx
@@ -40,9 +40,9 @@ const CounselorFilter = ({ handleFilterData, clearClick }: CounselorFilterProps)
     { label: t("assistance.housingCounselors.services.languages.cantonese"), value: "cantonese" },
     { label: t("assistance.housingCounselors.services.languages.english"), value: "english" },
     { label: t("assistance.housingCounselors.services.languages.french"), value: "french" },
-    { label: t("assistance.housingCounselors.services.languages.spanish"), value: "spanish" },
     { label: t("assistance.housingCounselors.services.languages.mandarin"), value: "mandarin" },
     { label: t("assistance.housingCounselors.services.languages.russian"), value: "russian" },
+    { label: t("assistance.housingCounselors.services.languages.spanish"), value: "spanish" },
     { label: t("assistance.housingCounselors.services.languages.taiwanese"), value: "taiwanese" },
     { label: t("assistance.housingCounselors.services.languages.vietnamese"), value: "vietnamese" },
   ]


### PR DESCRIPTION
## Summary

Update the SF LGBT Center DAHLIA webpage to remove Cantonese from listed languages and replace with English, Taiwanese, and Mandarin.

## Changes

- **housing_counselors.json** (legacy Angular): Updated languages from `["English"]` to `["English", "Taiwanese", "Mandarin"]`
- **housing_counselors_react.json** (React): Updated languages from `["cantonese", "english"]` to `["english", "mandarin", "taiwanese"]`
- Alphabetize the menu items based on the English names (which was already mostly the case)

<img width="668" height="792" alt="image" src="https://github.com/user-attachments/assets/6a2359fd-136e-44c1-a034-b38be2a71654" />

<br>
<br>

<img width="287" height="392" alt="image" src="https://github.com/user-attachments/assets/e2971f2d-91ac-4347-8a0c-623f0b96c94a" />

## Ticket

DAH-4028