### PR TITLE
fix: DAH-4086 I2I response confirmations 

### DIFF
--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -54,7 +54,7 @@ module DahliaBackend
         when 'submit' then '/messages/invite-to-apply/response/submit'
         end
       elsif act.present?
-        '/api/v1/messages'
+        '/api/v1/message'
       else
         nil
       end

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -119,7 +119,7 @@ module DahliaBackend
 
       if application_number.blank? && action.present?
         return {
-          action: action,
+          action: action.upcase,
           data: {
             applicationIds: [app_id],
             isTestEmail: false,

--- a/spec/services/dahlia_backend/message_service_spec.rb
+++ b/spec/services/dahlia_backend/message_service_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe DahliaBackend::MessageService do
       end
 
       it 'sends the invite response for "yes"' do
-        expect(client).to receive(:post).with('/api/v1/messages', hash_including(
+        expect(client).to receive(:post).with('/api/v1/message', hash_including(
                                                                                           listingId: listing_id,
                                                                                           listingName: 'Test Listing',
                                                                                           deadlineDate: deadline,
@@ -250,7 +250,7 @@ RSpec.describe DahliaBackend::MessageService do
       end
 
       it 'sends the invite response for "no"' do
-        expect(client).to receive(:post).with('/api/v1/messages', anything)
+        expect(client).to receive(:post).with('/api/v1/message', anything)
 
         service.send_invite_to_response(deadline, application_id, application_number, 'no', 'no',
                                               listing_id)
@@ -258,7 +258,7 @@ RSpec.describe DahliaBackend::MessageService do
 
       it 'sends the invite response for "contact"' do
         expect(client).to receive(:post).with(
-          '/api/v1/messages', anything
+          '/api/v1/message', anything
         )
 
         service.send_invite_to_response(deadline, application_id, application_number, 'contact', 'contact',
@@ -267,7 +267,7 @@ RSpec.describe DahliaBackend::MessageService do
 
       it 'sends the invite response for "submit"' do
         expect(client).to receive(:post).with(
-          '/api/v1/messages', anything
+          '/api/v1/message', anything
         )
 
         service.send_invite_to_response(deadline, application_id, application_number, 'submit', 'submit',


### PR DESCRIPTION
## Description

Use consistent /message endpoint in backend. 

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4086

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag