### PR TITLE
chore: DAH-0000 reduce CircleCI storage and speed up e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ commands:
   start-server:
     description: "Start Rails server in background"
     steps:
-      - setup-webdriver
       - run:
           name: Run rails server in background
           command: bundle exec rails server -p 3000
@@ -139,6 +138,7 @@ commands:
         default: "./spec/e2e/test-feature-path.feature"
     steps:
       - setup
+      - setup-webdriver
       - start-server
       - run: yarn run protractor spec/e2e/conf.js --specs '<< parameters.path >>'
 
@@ -242,6 +242,7 @@ jobs:
     parallelism: 4
     steps:
       - setup
+      - setup-webdriver
       - start-server
       - run:
           name: Run e2e tests using test splitting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ commands:
     steps:
       - run:
           name: Run rails server in background
-          command: bundle exec rails server -p 3000
+          command: bundle exec rails server -p 3000 2>&1 | tee /tmp/rails-server.log
           background: true
       - run:
           name: Wait for server
@@ -241,6 +241,9 @@ jobs:
           name: Run Cypress e2e tests
           command: yarn test:e2e
           no_output_timeout: 20m
+      - store_artifacts:
+          path: /tmp/rails-server.log
+          destination: rails-server.log
   coverage:
     <<: *defaults
     steps:
@@ -274,6 +277,9 @@ jobs:
             echo $LIST
             npm run protractor -- --specs $LIST
           no_output_timeout: 20m
+      - store_artifacts:
+          path: /tmp/rails-server.log
+          destination: rails-server.log
   cleanup-test-data:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ jobs:
           paths:
             - node_modules/
             - /home/circleci/.cache/Cypress
+            - lib/assets/bower_components
       - upgrade-bundler
       - run:
           name: Bundle install
@@ -179,6 +180,7 @@ jobs:
             - db/schema.rb
             - public/packs
             - public/packs-test
+            - lib/assets/bower_components
   lint:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,15 +234,20 @@ jobs:
       - run: bundle exec rake jasmine:ci
   e2e:
     <<: *defaults
+    parallelism: 3
     environment:
       SIGN_IN_PAGE_REACT: "true"
     steps:
       - setup
       - start-server
       - run:
-          name: Run Cypress e2e tests
-          command: yarn test:e2e
+          name: Run Cypress e2e tests using test splitting
+          command: |
+            TESTFILES=$(circleci tests glob "cypress/e2e/**/*.e2e.ts" | circleci tests split --split-by=timings)
+            yarn cypress run --browser chrome --spec "$TESTFILES"
           no_output_timeout: 20m
+      - store_test_results:
+          path: cypress/results
       - store_artifacts:
           path: /tmp/rails-server.log
           destination: rails-server.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,10 @@ commands:
       - prepare_workspace
       - upgrade-bundler
       - run: bundle config set path vendor/bundle
-      - run: bundle install
+      - run:
+          name: Bundle install
+          command: bundle install
+          no_output_timeout: 10m
       - run: bundle exec rails db:migrate
   start-server:
     description: "Start Rails server in background"
@@ -178,8 +181,6 @@ jobs:
           root: .
           paths:
             - db/schema.rb
-            - public/packs
-            - public/packs-test
             - lib/assets/bower_components
   lint:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,17 +251,6 @@ jobs:
     steps:
       - checkout
       - *attach_workspace
-      - run:
-          name: Verify coverage files exist
-          command: |
-            echo "=== Jest coverage ==="
-            ls -lh jest-test-coverage/ || echo "MISSING: jest-test-coverage/"
-            echo "=== RSpec coverage ==="
-            ls -lh coverage/ || echo "MISSING: coverage/"
-            echo "=== lcov.info ==="
-            wc -l jest-test-coverage/lcov.info || echo "MISSING: lcov.info"
-            echo "=== coverage.json ==="
-            wc -c coverage/coverage.json || echo "MISSING: coverage.json"
       - qlty/coverage_publish:
           files: jest-test-coverage/lcov.info, coverage/coverage.json
   e2e-legacy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
             bundle config set deployment true
             bundle config set path vendor/bundle
             bundle install
+          no_output_timeout: 10m
       - save_cache:
           name: Save Bundle cache
           key: webapp-{{ .Environment.CACHE_VERSION }}-bundle-dependencies-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
@@ -175,7 +176,12 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - vendor/bundle
+            - node_modules
+            - .bundle
+            - db/schema.rb
+            - public/packs
+            - public/packs-test
   lint:
     <<: *defaults
     steps:
@@ -186,11 +192,13 @@ jobs:
     <<: *defaults
     steps:
       - setup
-      - run: yarn cache clean
-      - run: yarn install
-      - run: yarn test
+      - run:
+          name: Run React unit tests
+          command: yarn test
+          no_output_timeout: 10m
       - store_artifacts:
           path: jest-test-coverage
+          destination: jest-test-coverage
       - persist_to_workspace:
           root: .
           paths:
@@ -204,9 +212,13 @@ jobs:
       - run: sudo apt-get install graphicsmagick
       - run: RAILS_ENV=test bundle exec rails db:create
       - run: RAILS_ENV=test bundle exec rails db:test:prepare
-      - run: bundle exec rake spec
+      - run:
+          name: Run RSpec tests
+          command: bundle exec rake spec
+          no_output_timeout: 15m
       - store_artifacts:
           path: coverage
+          destination: coverage
       - persist_to_workspace:
           root: .
           paths:
@@ -220,7 +232,6 @@ jobs:
           command: echo "export OPENSSL_CONF=/etc/ssl/" >> $BASH_ENV
       - run: RAILS_ENV=test bundle exec rails db:create
       - run: RAILS_ENV=test bundle exec rails db:test:prepare
-      - run: yarn install
       - run: bundle exec rake jasmine:ci
   e2e:
     <<: *defaults
@@ -229,12 +240,26 @@ jobs:
     steps:
       - setup
       - start-server
-      - run: yarn test:e2e
+      - run:
+          name: Run Cypress e2e tests
+          command: yarn test:e2e
+          no_output_timeout: 20m
   coverage:
     <<: *defaults
     steps:
       - checkout
       - *attach_workspace
+      - run:
+          name: Verify coverage files exist
+          command: |
+            echo "=== Jest coverage ==="
+            ls -lh jest-test-coverage/ || echo "MISSING: jest-test-coverage/"
+            echo "=== RSpec coverage ==="
+            ls -lh coverage/ || echo "MISSING: coverage/"
+            echo "=== lcov.info ==="
+            wc -l jest-test-coverage/lcov.info || echo "MISSING: lcov.info"
+            echo "=== coverage.json ==="
+            wc -c coverage/coverage.json || echo "MISSING: coverage.json"
       - qlty/coverage_publish:
           files: jest-test-coverage/lcov.info, coverage/coverage.json
   e2e-legacy:
@@ -251,6 +276,7 @@ jobs:
             LIST=$(echo $TESTFILES | awk '{ gsub(" ", ",") ; system( "echo "  $0) }')
             echo $LIST
             npm run protractor -- --specs $LIST
+          no_output_timeout: 20m
   cleanup-test-data:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,9 +176,6 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - vendor/bundle
-            - node_modules
-            - .bundle
             - db/schema.rb
             - public/packs
             - public/packs-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
       - run:
           name: Run Cypress e2e tests using test splitting
           command: |
-            TESTFILES=$(circleci tests glob "cypress/e2e/**/*.e2e.ts" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "cypress/e2e/**/*.e2e.ts" | circleci tests split --split-by=timings | tr '\n' ',' | sed 's/,$//')
             yarn cypress run --browser chrome --spec "$TESTFILES"
           no_output_timeout: 20m
       - store_test_results:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,11 +1,16 @@
-import "dotenv/config"
+import { existsSync } from "fs"
 import { defineConfig } from "cypress"
+
+// Only load .env if it exists (CI may not have one)
+if (existsSync(".env")) {
+  require("dotenv").config()
+}
 
 export default defineConfig({
   defaultCommandTimeout: 180000, // 3 mins
   projectId: "dahlia-housing-portal",
   pageLoadTimeout: 180000, // 3 mins
-  reporter: "mocha-junit-reporter",
+  reporter: "junit",
   reporterOptions: {
     mochaFile: "cypress/results/tests-[hash].xml",
     toConsole: true,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   defaultCommandTimeout: 180000, // 3 mins
   projectId: "dahlia-housing-portal",
   pageLoadTimeout: 180000, // 3 mins
+  reporter: "mocha-junit-reporter",
   reporterOptions: {
     mochaFile: "cypress/results/tests-[hash].xml",
     toConsole: true,

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "jest-fail-on-console": "^3.3.1",
     "jest-junit": "^16.0.0",
     "lint-staged": "^10.5.4",
+    "mocha-junit-reporter": "^2.2.1",
     "node-jq": "^6.0.1",
     "prettier": "3.6.2",
     "protractor": "^5.4.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "jest-fail-on-console": "^3.3.1",
     "jest-junit": "^16.0.0",
     "lint-staged": "^10.5.4",
-    "mocha-junit-reporter": "^2.2.1",
     "node-jq": "^6.0.1",
     "prettier": "3.6.2",
     "protractor": "^5.4.2",


### PR DESCRIPTION
## Description

### Reduce CircleCI storage usage and parallelize e2e tests

We're currently using 172.4 GB-Months against a 2 GB-Months plan, with workspace storage (118.6 GB) as the dominant cost. The root cause was `persist_to_workspace: paths: [.]` in the `build` job — persisting the entire working directory, including `node_modules` and `vendor/bundle`, to every downstream job.

### Changes

- **Workspace scope reduced**: `build` now persists only build artifacts that downstream jobs can't get from cache (`db/schema.rb`, `public/packs`, `public/packs-test`, `lib/assets/bower_components`). Dependencies (`node_modules`, `vendor/bundle`) are served exclusively by `restore_cache`. Source code is re-checked out fresh in each job via `checkout`.
- **Coverage persistence separated**: `unit-react` persists `jest-test-coverage/` and `unit-rspec` persists `coverage/` independently, rather than one job redundantly persisting both.
- **`no_output_timeout` added** to long-running steps (`bundle install`, RSpec, Cypress, Protractor) to prevent silent hangs from being killed with a misleading error.
- **Cypress e2e parallelized**: `e2e` job now runs with `parallelism: 3`, splitting specs across containers using `circleci tests split --split-by=timings` for faster wall-clock time.
- **JUnit reporting added**: Cypress configured with the built-in `junit` reporter and `store_test_results` to feed timing data back to CircleCI for smarter test splitting.
- **Dotenv hardened**: `cypress.config.ts` now guards against missing `.env` file in CI instead of throwing on import.
- Move `setup-webdriver` from `start-server` into `e2e-legacy` and `run-e2e-tests-for-path `only.


### **What to do after merging**

- Set workspace retention to 1 - 3 days in CircleCI Project Settings → Advanced if not already set.

### Savings

The biggest change is in reducing the amount of data stored in the workspace, which had been storing the entire installation directory.  That meant over 800MB getting stored on each run, can copied to each job.  Now the installed packages are shared in the cache across jobs, and just some of the built artifacts are persisted:

            - db/schema.rb
            - public/packs
            - public/packs-test
            - lib/assets/bower_components


**Before:**

<img width="836" height="230" alt="image" src="https://github.com/user-attachments/assets/fec0be7a-1e56-4ad7-93c4-19d77250a43a" />

**After:**

<img width="836" height="230" alt="image" src="https://github.com/user-attachments/assets/c9bff41c-d2ec-4563-bbd6-7919008691a5" />

<br>
<br>

Enabling parallelization on the e2e tests also reduced the overall job time by about 4.5 minutes.  

**Before:**

<img width="1118" height="269" alt="image" src="https://github.com/user-attachments/assets/0f927331-b35d-45ab-ae6a-11b7a26ecd6a" />

**After:**

<img width="1121" height="280" alt="image" src="https://github.com/user-attachments/assets/a3681db1-581c-407d-8081-b44d06c83fa8" />


## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag