### PR TITLE
fix: DAH-3920 Standardize I2A Link Styling

### DIFF
--- a/app/javascript/__tests__/components/__snapshots__/BeforeApplyingForSale.test.tsx.snap
+++ b/app/javascript/__tests__/components/__snapshots__/BeforeApplyingForSale.test.tsx.snap
@@ -27,7 +27,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is Habitat list
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Go to a 
           <a
             href="http://www.habitatgsf.org/innes-ave"
@@ -45,7 +47,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is Habitat list
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Meet the 
           <a
             href="https://media.api.sf.gov/documents/DALP_Manual_-_2025.pdf"
@@ -64,7 +68,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is Habitat list
     <div
       class="text-gray-750 primary-lighter-markup-link-desktop"
     >
-      <p>
+      <p
+        class="primary-lighter-markup-link"
+      >
         Read 
         <a
           href="http://www.habitatgsf.org/innes-ave"
@@ -105,7 +111,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is directory 1`
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <span>
+        <span
+          class="primary-lighter-markup-link"
+        >
           Meet our 
           <a
             href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -118,7 +126,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is directory 1`
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <span>
+        <span
+          class="primary-lighter-markup-link"
+        >
           Complete 
           <a
             href="https://sf.gov/sign-complete-homebuyer-education"
@@ -131,7 +141,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is directory 1`
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <span>
+        <span
+          class="primary-lighter-markup-link"
+        >
           Get pre-approved for a mortgage loan by a 
           <a
             href="https://sf.gov/reports/october-2023/find-lender-below-market-rate-program"
@@ -150,7 +162,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is directory 1`
     <div
       class="text-gray-750 primary-lighter-markup-link-desktop"
     >
-      <span>
+      <span
+        class="primary-lighter-markup-link"
+      >
         Read 
         <a
           href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -197,7 +211,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is listing deta
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <span>
+        <span
+          class="primary-lighter-markup-link"
+        >
           Meet our 
           <a
             href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -210,7 +226,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is listing deta
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <span>
+        <span
+          class="primary-lighter-markup-link"
+        >
           Complete 
           <a
             href="https://sf.gov/sign-complete-homebuyer-education"
@@ -223,7 +241,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is listing deta
       <li
         class="text-gray-750 primary-lighter-markup-link"
       >
-        <span>
+        <span
+          class="primary-lighter-markup-link"
+        >
           Get pre-approved for a mortgage loan by a 
           <a
             href="https://sf.gov/reports/october-2023/find-lender-below-market-rate-program"
@@ -242,7 +262,9 @@ exports[`BeforeApplyingForSale display Before Applying when type is listing deta
     <div
       class="text-gray-750 primary-lighter-markup-link-desktop"
     >
-      <span>
+      <span
+        class="primary-lighter-markup-link"
+      >
         Read 
         <a
           href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"

--- a/app/javascript/__tests__/layouts/__snapshots__/HeaderSidebarLayout.test.tsx.snap
+++ b/app/javascript/__tests__/layouts/__snapshots__/HeaderSidebarLayout.test.tsx.snap
@@ -126,7 +126,9 @@ exports[`<HeaderSidebarLayout /> Contact Bar renders Contact Information 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -276,7 +278,9 @@ exports[`<HeaderSidebarLayout /> Contact Bar renders Contact Information 1`] = `
                   </span>
                   <br />
                    
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     Contact the agent shown on the listing page.
                   </span>
                 </p>
@@ -289,7 +293,9 @@ exports[`<HeaderSidebarLayout /> Contact Bar renders Contact Information 1`] = `
                     For help with San Francisco services 24 hours a day, 7 days a week:
                   </span>
                   <br />
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     Call 
                     <a
                       href="tel:311"
@@ -313,7 +319,9 @@ exports[`<HeaderSidebarLayout /> Contact Bar renders Contact Information 1`] = `
                   </span>
                   <br />
                   <div>
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       <a
                         href="https://sf.gov/departments/mayors-office-housing-and-community-development"
                         target="_blank"
@@ -326,7 +334,9 @@ exports[`<HeaderSidebarLayout /> Contact Bar renders Contact Information 1`] = `
                   <div
                     class="mt-1"
                   >
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       Email 
                       <a
                         href="mailto:sfhousinginfo@sfgov.org"

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsAdditionalInformation.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsAdditionalInformation.test.tsx.snap
@@ -59,9 +59,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Lottery winners will be required to fill out a building application and provide a copy of your current credit report, 3 most recent paystubs, current tax returns and W-2, and 3 most recent bank statements.
             </span>
           </div>
@@ -79,9 +81,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               All BMR renters must review and acknowledge the 
               <a
                 href="http://sf-moh.org/index.aspx?page=295"
@@ -177,9 +181,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           Special Notes
         </h3>
         <div
-          class="text-xs inline primary-lighter-markup-link translate"
+          class="text-xs inline translate"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Some other excessively formatted listing notes.
           </span>
         </div>
@@ -196,9 +202,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Proof of residence
 
               <br />
@@ -222,9 +230,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Some important program rules with bullets:
               <br />
               Rule oneRule two
@@ -244,9 +254,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               The CC&R's explain the rules of the homeowners' association, and restrict how you can modify the property.
             </span>
           </div>
@@ -287,9 +299,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
             </span>
             <span>
               <div
-                class="text-xs inline primary-lighter-markup-link translate"
+                class="text-xs inline translate"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Register with the Leasing Agent
                 </span>
               </div>
@@ -309,9 +323,11 @@ exports[`ListingDetailsAdditionalInformation displays additional information sec
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               A BMR unit will be resold at a restricted price to a household that meets the first‐time homebuyer and income qualifications for the program. Please review the 
               <a
                 href="http://sf-moh.org/index.aspx?page=295"
@@ -410,9 +426,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission section
           Special Notes
         </h3>
         <div
-          class="text-xs inline primary-lighter-markup-link translate"
+          class="text-xs inline translate"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Some other excessively formatted listing notes.
           </span>
         </div>
@@ -429,9 +447,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission section
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Proof of residence
 
               <br />
@@ -455,9 +475,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission section
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Some important program rules with bullets:
               <br />
               Rule oneRule two
@@ -477,9 +499,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission section
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               The CC&R's explain the rules of the homeowners' association, and restrict how you can modify the property.
             </span>
           </div>
@@ -520,9 +544,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission section
             </span>
             <span>
               <div
-                class="text-xs inline primary-lighter-markup-link translate"
+                class="text-xs inline translate"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Register with the Leasing Agent
                 </span>
               </div>
@@ -542,9 +568,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission section
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               A BMR unit will be resold at a restricted price to a household that meets the first‐time homebuyer and income qualifications for the program. Please review the 
               <a
                 href="http://sf-moh.org/index.aspx?page=295"
@@ -643,9 +671,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission text if
           Special Notes
         </h3>
         <div
-          class="text-xs inline primary-lighter-markup-link translate"
+          class="text-xs inline translate"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Some other excessively formatted listing notes.
           </span>
         </div>
@@ -662,9 +692,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission text if
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Proof of residence
 
               <br />
@@ -688,9 +720,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission text if
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Some important program rules with bullets:
               <br />
               Rule oneRule two
@@ -710,9 +744,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission text if
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               The CC&R's explain the rules of the homeowners' association, and restrict how you can modify the property.
             </span>
           </div>
@@ -753,9 +789,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission text if
             </span>
             <span>
               <div
-                class="text-xs inline primary-lighter-markup-link translate"
+                class="text-xs inline translate"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Register with the Leasing Agent
                 </span>
               </div>
@@ -775,9 +813,11 @@ exports[`ListingDetailsAdditionalInformation displays realtor commission text if
           class="text-xs"
         >
           <div
-            class="text-xs inline primary-lighter-markup-link translate"
+            class="text-xs inline translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               A BMR unit will be resold at a restricted price to a household that meets the first‐time homebuyer and income qualifications for the program. Please review the 
               <a
                 href="http://sf-moh.org/index.aspx?page=295"

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsAside.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsAside.test.tsx.snap
@@ -158,7 +158,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component fcfs 1`] = `
                     <span
                       class="links-space translate"
                     >
-                      <span>
+                      <span
+                        class="primary-lighter-markup-link"
+                      >
                         MOHCD
                       </span>
                     </span>
@@ -282,7 +284,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component fcfs 1`] = `
                           <span
                             class="links-space translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               SFPL
                             </span>
                           </span>
@@ -415,7 +419,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component fcfs 1`] = `
                 <p
                   class="text-sm"
                 >
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     8-4 Mon-Thurs
 
                     <br />
@@ -630,7 +636,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component rental 1`] = 
                 <div
                   class="text-gray-700"
                 >
-                  <div>
+                  <div
+                    class="primary-lighter-markup-link"
+                  >
                     <p>
                       The lottery will not be in person, but instead will be a virtual lottery.
                     </p>
@@ -720,7 +728,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component rental 1`] = 
                     <span
                       class="links-space translate"
                     >
-                      <span>
+                      <span
+                        class="primary-lighter-markup-link"
+                      >
                         Library
                       </span>
                     </span>
@@ -892,7 +902,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component sales 1`] = `
                     <span
                       class="links-space translate"
                     >
-                      <span>
+                      <span
+                        class="primary-lighter-markup-link"
+                      >
                         MOHCD
                       </span>
                     </span>
@@ -921,7 +933,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component sales 1`] = `
                 <p
                   class="mb-4"
                 >
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     Make sure you fulfill the 
                     <a
                       href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -1018,7 +1032,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component sales 1`] = `
                           <span
                             class="links-space translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               SFPL
                             </span>
                           </span>
@@ -1151,7 +1167,9 @@ exports[`ListingDetailsAside renders ListingDetailsAside component sales 1`] = `
                 <p
                   class="text-sm"
                 >
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     8-4 Mon-Thurs
 
                     <br />

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsEligibility.test.tsx.snap
@@ -74,7 +74,9 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
                 class="ml-0 mt-1"
               >
                 <li>
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     Be an employee of 
                     <b>
                       <a
@@ -92,6 +94,7 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
               </ul>
               <p>
                 <a
+                  class="primary-lighter-markup-link"
                   href="https://sf.gov/apply-shirley-chisholm-village-housing"
                   target="_blank"
                 >
@@ -101,6 +104,7 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
               <p>
                 If you do not work at SF Unified School District, check back in Summer 2024 to apply. 
                 <a
+                  class="primary-lighter-markup-link"
                   href="https://confirmsubscription.com/h/y/C3BAFCD742D47910"
                   target="_blank"
                 >
@@ -130,14 +134,18 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -441,7 +449,9 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
                     If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                   </p>
                   <p>
-                    <b>
+                    <b
+                      class="primary-lighter-markup-link"
+                    >
                       Priority for certain groups - San Francisco Unified School District employees
                     </b>
                     <br />
@@ -452,6 +462,7 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
                   >
                     <li>
                       <a
+                        class="primary-lighter-markup-link"
                         href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                         target="_blank"
                       >
@@ -460,6 +471,7 @@ exports[`ListingDetailsEligibility displays ListingDetailsChisholmPreferences fo
                     </li>
                     <li>
                       <a
+                        class="primary-lighter-markup-link"
                         href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                         target="_blank"
                       >
@@ -716,7 +728,9 @@ exports[`ListingDetailsEligibility displays custom listing details 'check if you
                 </b>
               </p>
               <p>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   If you work at 
                   <a
                     href="https://www.sfusd.edu/"
@@ -771,14 +785,18 @@ exports[`ListingDetailsEligibility displays custom listing details 'check if you
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -1341,7 +1359,9 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                 class="ml-0 mt-1"
               >
                 <li>
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     Be an employee of 
                     <b>
                       <a
@@ -1359,6 +1379,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
               </ul>
               <p>
                 <a
+                  class="primary-lighter-markup-link"
                   href="https://sf.gov/apply-shirley-chisholm-village-housing"
                   target="_blank"
                 >
@@ -1368,6 +1389,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
               <p>
                 If you do not work at SF Unified School District, check back in Summer 2024 to apply. 
                 <a
+                  class="primary-lighter-markup-link"
                   href="https://confirmsubscription.com/h/y/C3BAFCD742D47910"
                   target="_blank"
                 >
@@ -1397,14 +1419,18 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -1708,7 +1734,9 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                     If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                   </p>
                   <p>
-                    <b>
+                    <b
+                      class="primary-lighter-markup-link"
+                    >
                       Priority for certain groups - San Francisco Unified School District employees
                     </b>
                     <br />
@@ -1719,6 +1747,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                   >
                     <li>
                       <a
+                        class="primary-lighter-markup-link"
                         href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                         target="_blank"
                       >
@@ -1727,6 +1756,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                     </li>
                     <li>
                       <a
+                        class="primary-lighter-markup-link"
                         href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                         target="_blank"
                       >
@@ -1994,7 +2024,9 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                 class="ml-0 my-1"
               >
                 <li>
-                  <span>
+                  <span
+                    class="primary-lighter-markup-link"
+                  >
                     Be an employee of 
                     <b>
                       <a
@@ -2012,6 +2044,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
               </ul>
               <p>
                 <a
+                  class="primary-lighter-markup-link"
                   href="https://sf.gov/apply-shirley-chisholm-village-housing"
                   target="_blank"
                 >
@@ -2023,6 +2056,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
               </p>
               <p>
                 <a
+                  class="primary-lighter-markup-link"
                   href="#chisholm-preferences"
                   target="_self"
                 >
@@ -2052,14 +2086,18 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -2363,7 +2401,9 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                     If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                   </p>
                   <p>
-                    <b>
+                    <b
+                      class="primary-lighter-markup-link"
+                    >
                       Priority for certain groups - San Francisco Unified School District employees
                     </b>
                     <br />
@@ -2374,6 +2414,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                   >
                     <li>
                       <a
+                        class="primary-lighter-markup-link"
                         href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                         target="_blank"
                       >
@@ -2382,6 +2423,7 @@ exports[`ListingDetailsEligibility displays custom listing details check if you'
                     </li>
                     <li>
                       <a
+                        class="primary-lighter-markup-link"
                         href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                         target="_blank"
                       >
@@ -2627,14 +2669,18 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -3296,14 +3342,18 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -3974,14 +4024,18 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -4661,7 +4715,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Meet our 
               <a
                 href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -4674,7 +4730,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Complete 
               <a
                 href="https://sf.gov/sign-complete-homebuyer-education"
@@ -4687,7 +4745,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Get pre-approved for a mortgage loan by a 
               <a
                 href="https://sf.gov/reports/october-2023/find-lender-below-market-rate-program"
@@ -4706,7 +4766,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         <div
           class="text-gray-750 primary-lighter-markup-link-desktop"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Read 
             <a
               href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -4737,14 +4799,18 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -5294,14 +5360,18 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -5993,14 +6063,18 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -6675,7 +6749,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <p>
+            <p
+              class="primary-lighter-markup-link"
+            >
               Go to a 
               <a
                 href="http://www.habitatgsf.org/innes-ave"
@@ -6693,7 +6769,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <p>
+            <p
+              class="primary-lighter-markup-link"
+            >
               Meet the 
               <a
                 href="https://media.api.sf.gov/documents/DALP_Manual_-_2025.pdf"
@@ -6712,7 +6790,9 @@ exports[`ListingDetailsEligibility displays listing details eligibility section 
         <div
           class="text-gray-750 primary-lighter-markup-link-desktop"
         >
-          <p>
+          <p
+            class="primary-lighter-markup-link"
+          >
             Read 
             <a
               href="http://www.habitatgsf.org/innes-ave"
@@ -7068,14 +7148,18 @@ exports[`ListingDetailsEligibility does not display ListingDetailsChisholmPrefer
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"
@@ -7625,7 +7709,9 @@ exports[`ListingDetailsEligibility does not display lottery preferences for fcfs
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Meet our 
               <a
                 href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -7638,7 +7724,9 @@ exports[`ListingDetailsEligibility does not display lottery preferences for fcfs
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Complete 
               <a
                 href="https://sf.gov/sign-complete-homebuyer-education"
@@ -7651,7 +7739,9 @@ exports[`ListingDetailsEligibility does not display lottery preferences for fcfs
           <li
             class="text-gray-750 primary-lighter-markup-link"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Get pre-approved for a mortgage loan by a 
               <a
                 href="https://sf.gov/reports/october-2023/find-lender-below-market-rate-program"
@@ -7670,7 +7760,9 @@ exports[`ListingDetailsEligibility does not display lottery preferences for fcfs
         <div
           class="text-gray-750 primary-lighter-markup-link-desktop"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Read 
             <a
               href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -7701,14 +7793,18 @@ exports[`ListingDetailsEligibility does not display lottery preferences for fcfs
                 <div
                   class="mb-4"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     For income calculations, household size includes everyone (all ages) living in the unit.
                   </p>
                 </div>
                 <div
                   class="mb-4 primary-lighter-markup-link-desktop"
                 >
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     People in your household may need 
                     <a
                       href="https://sf.gov/information/special-calculations-household-income"

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsFeatures.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsFeatures.test.tsx.snap
@@ -573,7 +573,9 @@ exports[`ListingDetailsFeatures displays listing details features section when r
             <span
               class="translate"
             >
-              <p>
+              <p
+                class="primary-lighter-markup-link"
+              >
                 Tenants pay for gas, electricity.
 
                 <br />

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsHabitat.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsHabitat.test.tsx.snap
@@ -32,7 +32,9 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
       Application Process
     </h4>
     <span>
-      <p>
+      <p
+        class="primary-lighter-markup-link"
+      >
         These units are offered by 
         <a
           href="http://www.habitatgsf.org/innes-ave"
@@ -47,7 +49,9 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
       class="list-decimal ml-8 mt-4"
     >
       <li>
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           You must go to a 
           <a
             href="http://www.habitatgsf.org/innes-ave"
@@ -102,7 +106,9 @@ exports[`ListingDetailsHabitat displays habitat info when habitat listing 1`] = 
     <div
       class="mt-4"
     >
-      <p>
+      <p
+        class="primary-lighter-markup-link"
+      >
         People in your household may need 
         <a
           href="https://sf.gov/information/special-calculations-household-income"

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsPricingTable.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsPricingTable.test.tsx.snap
@@ -37,7 +37,9 @@ exports[`ListingDetailsPricingTable 415 rental listing renders ListingDetailsPri
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -346,7 +348,9 @@ exports[`ListingDetailsPricingTable 415 rental listing renders ListingDetailsPri
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -838,7 +842,9 @@ exports[`ListingDetailsPricingTable 415 rental listing renders ListingDetailsPri
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -1265,7 +1271,9 @@ exports[`ListingDetailsPricingTable 415 rental listing renders ListingDetailsPri
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -1574,7 +1582,9 @@ exports[`ListingDetailsPricingTable 415 rental listing renders ListingDetailsPri
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -1892,7 +1902,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -2945,7 +2957,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -4388,7 +4402,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -5441,7 +5457,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -6494,7 +6512,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -7547,7 +7567,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -8210,7 +8232,9 @@ exports[`ListingDetailsPricingTable open rental listing renders ListingDetailsPr
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -8882,7 +8906,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -9073,7 +9099,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -9382,7 +9410,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -9821,7 +9851,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -10260,7 +10292,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -10699,7 +10733,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -10899,7 +10935,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -10968,7 +11006,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11028,7 +11068,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11088,7 +11130,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11148,7 +11192,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11208,7 +11254,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11268,7 +11316,9 @@ exports[`ListingDetailsPricingTable renders ListingDetailsPricingTable component
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11420,7 +11470,9 @@ exports[`ListingDetailsPricingTable rent as a percent of income listings renders
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11611,7 +11663,9 @@ exports[`ListingDetailsPricingTable rent as a percent of income listings renders
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"
@@ -11802,7 +11856,9 @@ exports[`ListingDetailsPricingTable rent as a percent of income listings renders
               class="flex items-center mr-2 text-sm md:text-base text-left md:text-center"
             >
               <div>
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Income 
                   <span
                     class="font-semibold"

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsProcess.test.tsx.snap
@@ -116,7 +116,9 @@ exports[`ListingDetailsProcess renders leasing agent section if exists 1`] = `
           <span
             class="translate"
           >
-            <span>
+            <span
+              class="primary-lighter-markup-link"
+            >
               Monday - Friday 10:00 AM - 6:00 PM
             </span>
           </span>

--- a/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsSeeTheUnit.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetails/__snapshots__/ListingDetailsSeeTheUnit.test.tsx.snap
@@ -161,7 +161,9 @@ exports[`ListingDetailsSeeTheUnit renders SeeDetailsOnline when both MLS and Lis
                   <span
                     class="links-space translate"
                   >
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       SFPL
                     </span>
                   </span>
@@ -302,7 +304,9 @@ exports[`ListingDetailsSeeTheUnit renders SeeDetailsOnline when both MLS and Lis
         <p
           class="text-sm"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             8-4 Mon-Thurs
 
             <br />
@@ -391,7 +395,9 @@ exports[`ListingDetailsSeeTheUnit renders SeeDetailsOnline when only Listing_Onl
                   <span
                     class="links-space translate"
                   >
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       SFPL
                     </span>
                   </span>
@@ -524,7 +530,9 @@ exports[`ListingDetailsSeeTheUnit renders SeeDetailsOnline when only Listing_Onl
         <p
           class="text-sm"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             8-4 Mon-Thurs
 
             <br />
@@ -613,7 +621,9 @@ exports[`ListingDetailsSeeTheUnit renders SeeDetailsOnline when only MLS is set 
                   <span
                     class="links-space translate"
                   >
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       SFPL
                     </span>
                   </span>
@@ -746,7 +756,9 @@ exports[`ListingDetailsSeeTheUnit renders SeeDetailsOnline when only MLS is set 
         <p
           class="text-sm"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             8-4 Mon-Thurs
 
             <br />

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsApply.test.tsx.snap
@@ -19,7 +19,9 @@ exports[`ListingDetailsApply displays habitat link for eligibility requirements 
         <p
           class="mb-4"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Make sure you fulfill the 
             <a
               href="http://www.habitatgsf.org/innes-ave/"
@@ -69,7 +71,9 @@ exports[`ListingDetailsApply renders if listing is open 1`] = `
         <p
           class="mb-4"
         >
-          <span>
+          <span
+            class="primary-lighter-markup-link"
+          >
             Make sure you fulfill the 
             <a
               href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsInfoSession.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/ListingDetailsInfoSession.test.tsx.snap
@@ -41,7 +41,9 @@ exports[`ListingDetailsInfoSession renders ListingDetailsInfoSession component 1
             <span
               class="links-space translate"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 MOHCD
               </span>
             </span>

--- a/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/MobileListingDetailsProcess.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsAside/__snapshots__/MobileListingDetailsProcess.test.tsx.snap
@@ -83,7 +83,9 @@ exports[`MobileListingDetailsProcess renders with listing with open application 
               <span
                 class="links-space translate"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   MOHCD
                 </span>
               </span>
@@ -150,7 +152,9 @@ exports[`MobileListingDetailsProcess renders with listing with open application 
               <span
                 class="links-space translate"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   SFPL
                 </span>
               </span>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryInfo.test.tsx.snap
@@ -31,7 +31,9 @@ exports[`ListingDetailsLotteryInfo displays when listing has upcoming lottery 1`
         <div
           class="text-gray-700"
         >
-          <div>
+          <div
+            class="primary-lighter-markup-link"
+          >
             <p>
               The lottery will not be in person, but instead will be a virtual lottery.
             </p>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferences.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`ListingDetailsLotteryPreferences displays 2 preferences - NRHP, L/W 1`]
       <div
         class="pb-4 text-gray-700 text-xs mx-8 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -124,7 +126,9 @@ exports[`ListingDetailsLotteryPreferences displays 3 default preferences - COP, 
       <div
         class="pb-4 text-gray-700 text-xs mx-8 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferencesEducator.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryPreferencesEducator.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`ListingDetailsLotteryPreferencesEducator displays 2 preferences - NRHP,
       <div
         class="pb-4 text-gray-700 text-xs mx-8 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -387,7 +389,9 @@ exports[`ListingDetailsLotteryPreferencesEducator displays 3 default preferences
       <div
         class="pb-4 text-gray-700 text-xs mx-8 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -758,7 +762,9 @@ exports[`ListingDetailsLotteryPreferencesEducator educator 1 displays 2 preferen
       <div
         class="pb-4 text-gray-700 text-xs mx-8 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -1000,7 +1006,9 @@ exports[`ListingDetailsLotteryPreferencesEducator educator 1 displays 3 default 
       <div
         class="pb-4 text-gray-700 text-xs mx-8 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryRanking.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for educator 1`] 
       <div
         class="pb-4 text-gray-700 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -602,7 +604,9 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for educator one 
       <div
         class="pb-4 text-gray-700 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -1044,7 +1048,9 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with o
       <div
         class="pb-4 text-gray-700 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -1144,7 +1150,9 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for rental with t
       <div
         class="pb-4 text-gray-700 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"
@@ -1260,7 +1268,9 @@ exports[`ListingDetailsLotteryRanking displays lottery ranking for sale with gen
       <div
         class="pb-4 text-gray-700 translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           Ranking in these lists is considered in the order shown here. 
           <a
             href="https://www.youtube.com/watch?v=oW56bUsrSW4"

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotteryResults.test.tsx.snap
@@ -50,7 +50,9 @@ exports[`ListingDetailsLotteryResults displays with summary if lottery is comple
       <div
         class="mb-3 mx-2 text-gray-700 text-xs translate"
       >
-        <p>
+        <p
+          class="primary-lighter-markup-link"
+        >
           <strong>
             Applications are being accepted on a first come, first served basis starting 01/26/2022 at 8:00 AM PST
           </strong>

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/ListingDetailsLotterySearchForm.test.tsx.snap
@@ -98,7 +98,9 @@ exports[`ListingDetailsLotteryModal displays initial view with form and listing 
           <div
             class="pb-4 text-gray-700 text-xs mx-8 translate"
           >
-            <p>
+            <p
+              class="primary-lighter-markup-link"
+            >
               Ranking in these lists is considered in the order shown here. 
               <a
                 href="https://www.youtube.com/watch?v=oW56bUsrSW4"

--- a/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/MobileListingDetailsLottery.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listingDetailsLottery/__snapshots__/MobileListingDetailsLottery.test.tsx.snap
@@ -75,7 +75,9 @@ exports[`MobileListingDetailsLottery does display when lottery listing is closed
           <div
             class="text-gray-700"
           >
-            <div>
+            <div
+              class="primary-lighter-markup-link"
+            >
               <p>
                 The lottery will not be in person, but instead will be a virtual lottery.
               </p>
@@ -165,7 +167,9 @@ exports[`MobileListingDetailsLottery does display when lottery listing is closed
               <span
                 class="links-space translate"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Library
                 </span>
               </span>

--- a/app/javascript/__tests__/modules/listings/__snapshots__/BuyHeader.test.tsx.snap
+++ b/app/javascript/__tests__/modules/listings/__snapshots__/BuyHeader.test.tsx.snap
@@ -53,7 +53,9 @@ exports[`BuyHeader renders BuyHeader component with See homes for sale button 1`
               <li
                 class="text-gray-750 primary-lighter-markup-link"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Meet our 
                   <a
                     href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -66,7 +68,9 @@ exports[`BuyHeader renders BuyHeader component with See homes for sale button 1`
               <li
                 class="text-gray-750 primary-lighter-markup-link"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Complete 
                   <a
                     href="https://sf.gov/sign-complete-homebuyer-education"
@@ -79,7 +83,9 @@ exports[`BuyHeader renders BuyHeader component with See homes for sale button 1`
               <li
                 class="text-gray-750 primary-lighter-markup-link"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Get pre-approved for a mortgage loan by a 
                   <a
                     href="https://sf.gov/reports/october-2023/find-lender-below-market-rate-program"
@@ -98,7 +104,9 @@ exports[`BuyHeader renders BuyHeader component with See homes for sale button 1`
             <div
               class="text-gray-750 primary-lighter-markup-link-desktop"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 Read 
                 <a
                   href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -141,6 +149,7 @@ exports[`BuyHeader renders BuyHeader component with See homes for sale button 1`
               class="mb-4"
             >
               <a
+                class="primary-lighter-markup-link"
                 href="https://www.sf.gov/apply-downpayment-loan-buy-market-rate-home"
                 target="_blank"
               >

--- a/app/javascript/__tests__/pages/__snapshots__/GenericDirectory.test.tsx.snap
+++ b/app/javascript/__tests__/pages/__snapshots__/GenericDirectory.test.tsx.snap
@@ -110,7 +110,9 @@ exports[`GenericDirectory displays the directory no matches page with no listing
             <p
               class="page-header-text-block"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 For more help, we suggest talking with a housing counselor to explore your options. 
                 <a
                   href="/housing-counselors"

--- a/app/javascript/__tests__/pages/how-to-apply/__snapshots__/how-to-apply.test.tsx.snap
+++ b/app/javascript/__tests__/pages/how-to-apply/__snapshots__/how-to-apply.test.tsx.snap
@@ -126,7 +126,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -338,12 +340,16 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                         class="mb-0 pt-2"
                       >
                         <li>
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Not have owned residential property in the past 3 years
                           </span>
                         </li>
                         <li>
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Meet our 
                             <a
                               class="underline"
@@ -355,7 +361,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                           </span>
                         </li>
                         <li>
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Have completed 
                             <a
                               class="underline"
@@ -367,7 +375,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                           </span>
                         </li>
                         <li>
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Be pre-approved for a mortgage by a 
                             <a
                               class="underline"
@@ -379,7 +389,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                           </span>
                         </li>
                         <li>
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Have enough in savings for closing costs and downpayment
                           </span>
                         </li>
@@ -535,7 +547,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                             <div
                               class="text-base"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 If you cannot combine everything into 1 file, you can upload multiple files. Name each file as shown above and include the type of document. 
                                 <i>
                                   Example: 1288 Howard - Chow, Tania - Proof of Income
@@ -556,7 +570,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                             <div
                               class="text-base pb-2"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 <a
                                   class="underline"
                                   href="https://account.box.com/signup/personal?tc=annual"
@@ -606,7 +622,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                               <li
                                 class="text-base"
                               >
-                                <span>
+                                <span
+                                  class="primary-lighter-markup-link"
+                                >
                                   Fill out your information and get a link to upload your 
                                   <a
                                     class="underline"
@@ -671,7 +689,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                     <div
                       class="pt-4"
                     >
-                      <span>
+                      <span
+                        class="primary-lighter-markup-link"
+                      >
                         We will email you your place in line within 
                         <b>
                           2 business days
@@ -682,7 +702,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
                     <div
                       class="py-2"
                     >
-                      <span>
+                      <span
+                        class="primary-lighter-markup-link"
+                      >
                         If your application is approved, you will need to enter a purchase agreement within 
                         <b>
                           7 days
@@ -717,7 +739,9 @@ exports[`<HowToApply /> renders HowToApply component 1`] = `
               <p
                 class="mb-4"
               >
-                <span>
+                <span
+                  class="primary-lighter-markup-link"
+                >
                   Housing counselors can help with your application. Support is available in many languages.
                 </span>
               </p>

--- a/app/javascript/__tests__/pages/listings/__snapshots__/ForRent.test.tsx.snap
+++ b/app/javascript/__tests__/pages/listings/__snapshots__/ForRent.test.tsx.snap
@@ -126,7 +126,9 @@ exports[`For Rent renders ForRent component 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -425,7 +427,9 @@ exports[`For Rent renders ForRent component 1`] = `
                         />
                       </svg>
                     </span>
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       <a
                         href="https://confirmsubscription.com/h/y/C3BAFCD742D47910"
                         target="_blank"

--- a/app/javascript/__tests__/pages/listings/__snapshots__/ForSale.test.tsx.snap
+++ b/app/javascript/__tests__/pages/listings/__snapshots__/ForSale.test.tsx.snap
@@ -126,7 +126,9 @@ exports[`For Sale renders ForSale component 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -283,7 +285,9 @@ exports[`For Sale renders ForSale component 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Meet our 
                             <a
                               href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -296,7 +300,9 @@ exports[`For Sale renders ForSale component 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Complete 
                             <a
                               href="https://sf.gov/sign-complete-homebuyer-education"
@@ -309,7 +315,9 @@ exports[`For Sale renders ForSale component 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Get pre-approved for a mortgage loan by a 
                             <a
                               href="https://sf.gov/reports/october-2023/find-lender-below-market-rate-program"
@@ -328,7 +336,9 @@ exports[`For Sale renders ForSale component 1`] = `
                       <div
                         class="text-gray-750 primary-lighter-markup-link-desktop"
                       >
-                        <span>
+                        <span
+                          class="primary-lighter-markup-link"
+                        >
                           Read 
                           <a
                             href="https://sf.gov/determine-if-you-can-buy-affordable-housing-program"
@@ -371,6 +381,7 @@ exports[`For Sale renders ForSale component 1`] = `
                         class="mb-4"
                       >
                         <a
+                          class="primary-lighter-markup-link"
                           href="https://www.sf.gov/apply-downpayment-loan-buy-market-rate-home"
                           target="_blank"
                         >
@@ -545,7 +556,9 @@ exports[`For Sale renders ForSale component 1`] = `
                         />
                       </svg>
                     </span>
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       <a
                         href="https://confirmsubscription.com/h/y/C3BAFCD742D47910"
                         target="_blank"
@@ -614,7 +627,9 @@ exports[`For Sale renders ForSale component 1`] = `
                         />
                       </svg>
                     </span>
-                    <span>
+                    <span
+                      class="primary-lighter-markup-link"
+                    >
                       <a
                         href="https://confirmsubscription.com/h/y/C3BAFCD742D47910"
                         target="_blank"

--- a/app/javascript/__tests__/pages/listings/__snapshots__/ListingDetail.test.tsx.snap
+++ b/app/javascript/__tests__/pages/listings/__snapshots__/ListingDetail.test.tsx.snap
@@ -127,7 +127,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -394,7 +396,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                 Application Process
               </h4>
               <span>
-                <p>
+                <p
+                  class="primary-lighter-markup-link"
+                >
                   These units are offered by 
                   <a
                     href="http://www.habitatgsf.org/innes-ave"
@@ -409,7 +413,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                 class="list-decimal ml-8 mt-4"
               >
                 <li>
-                  <p>
+                  <p
+                    class="primary-lighter-markup-link"
+                  >
                     You must go to a 
                     <a
                       href="http://www.habitatgsf.org/innes-ave"
@@ -464,7 +470,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
               <div
                 class="mt-4"
               >
-                <p>
+                <p
+                  class="primary-lighter-markup-link"
+                >
                   People in your household may need 
                   <a
                     href="https://sf.gov/information/special-calculations-household-income"
@@ -1489,7 +1497,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                           <li
                             class="text-gray-750 primary-lighter-markup-link"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Go to a 
                               <a
                                 href="http://www.habitatgsf.org/innes-ave"
@@ -1507,7 +1517,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                           <li
                             class="text-gray-750 primary-lighter-markup-link"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Meet the 
                               <a
                                 href="https://media.api.sf.gov/documents/DALP_Manual_-_2025.pdf"
@@ -1526,7 +1538,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <div
                           class="text-gray-750 primary-lighter-markup-link-desktop"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Read 
                             <a
                               href="http://www.habitatgsf.org/innes-ave"
@@ -1711,7 +1725,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Go to a 
                             <a
                               href="http://www.habitatgsf.org/innes-ave"
@@ -1729,7 +1745,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Meet the 
                             <a
                               href="https://media.api.sf.gov/documents/DALP_Manual_-_2025.pdf"
@@ -1748,7 +1766,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                       <div
                         class="text-gray-750 primary-lighter-markup-link-desktop"
                       >
-                        <p>
+                        <p
+                          class="primary-lighter-markup-link"
+                        >
                           Read 
                           <a
                             href="http://www.habitatgsf.org/innes-ave"
@@ -1972,7 +1992,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Go to a 
                             <a
                               href="http://www.habitatgsf.org/innes-ave"
@@ -1990,7 +2012,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Meet the 
                             <a
                               href="https://media.api.sf.gov/documents/DALP_Manual_-_2025.pdf"
@@ -2009,7 +2033,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                       <div
                         class="text-gray-750 primary-lighter-markup-link-desktop"
                       >
-                        <p>
+                        <p
+                          class="primary-lighter-markup-link"
+                        >
                           Read 
                           <a
                             href="http://www.habitatgsf.org/innes-ave"
@@ -3628,9 +3654,11 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                           class="text-xs"
                         >
                           <div
-                            class="text-xs inline primary-lighter-markup-link translate"
+                            class="text-xs inline translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               Cissy can write in here whatever she needs to say.
                             </span>
                           </div>
@@ -3669,9 +3697,11 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Cissy can write in here whatever she needs to say.
                           </span>
                         </div>
@@ -3751,9 +3781,11 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Cissy can write in here whatever she needs to say.
                           </span>
                         </div>
@@ -4055,7 +4087,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Go to a 
                             <a
                               href="http://www.habitatgsf.org/innes-ave"
@@ -4073,7 +4107,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         <li
                           class="text-gray-750 primary-lighter-markup-link"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Meet the 
                             <a
                               href="https://media.api.sf.gov/documents/DALP_Manual_-_2025.pdf"
@@ -4092,7 +4128,9 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                       <div
                         class="text-gray-750 primary-lighter-markup-link-desktop"
                       >
-                        <p>
+                        <p
+                          class="primary-lighter-markup-link"
+                        >
                           Read 
                           <a
                             href="http://www.habitatgsf.org/innes-ave"
@@ -4723,9 +4761,11 @@ exports[`Listing Detail renders a habitat listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Cissy can write in here whatever she needs to say.
                           </span>
                         </div>
@@ -5144,7 +5184,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -5522,7 +5564,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           <div
                             class="text-gray-700"
                           >
-                            <div>
+                            <div
+                              class="primary-lighter-markup-link"
+                            >
                               <p>
                                 The lottery will not be in person, but instead will be a virtual lottery.
                               </p>
@@ -5612,7 +5656,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                               <span
                                 class="links-space translate"
                               >
-                                <span>
+                                <span
+                                  class="primary-lighter-markup-link"
+                                >
                                   Library
                                 </span>
                               </span>
@@ -5801,7 +5847,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           <div
                             class="text-gray-700"
                           >
-                            <div>
+                            <div
+                              class="primary-lighter-markup-link"
+                            >
                               <p>
                                 The lottery will not be in person, but instead will be a virtual lottery.
                               </p>
@@ -5891,7 +5939,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                               <span
                                 class="links-space translate"
                               >
-                                <span>
+                                <span
+                                  class="primary-lighter-markup-link"
+                                >
                                   Library
                                 </span>
                               </span>
@@ -5980,7 +6030,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         <div
                           class="text-gray-700"
                         >
-                          <div>
+                          <div
+                            class="primary-lighter-markup-link"
+                          >
                             <p>
                               The lottery will not be in person, but instead will be a virtual lottery.
                             </p>
@@ -6070,7 +6122,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                             <span
                               class="links-space translate"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 Library
                               </span>
                             </span>
@@ -6200,7 +6254,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         <div
                           class="text-gray-700"
                         >
-                          <div>
+                          <div
+                            class="primary-lighter-markup-link"
+                          >
                             <p>
                               The lottery will not be in person, but instead will be a virtual lottery.
                             </p>
@@ -6290,7 +6346,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                             <span
                               class="links-space translate"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 Library
                               </span>
                             </span>
@@ -6475,14 +6533,18 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                                 <div
                                   class="mb-4"
                                 >
-                                  <p>
+                                  <p
+                                    class="primary-lighter-markup-link"
+                                  >
                                     For income calculations, household size includes everyone (all ages) living in the unit.
                                   </p>
                                 </div>
                                 <div
                                   class="mb-4 primary-lighter-markup-link-desktop"
                                 >
-                                  <p>
+                                  <p
+                                    class="primary-lighter-markup-link"
+                                  >
                                     People in your household may need 
                                     <a
                                       href="https://sf.gov/information/special-calculations-household-income"
@@ -6808,14 +6870,18 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                               <div
                                 class="mb-4"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   For income calculations, household size includes everyone (all ages) living in the unit.
                                 </p>
                               </div>
                               <div
                                 class="mb-4 primary-lighter-markup-link-desktop"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   People in your household may need 
                                   <a
                                     href="https://sf.gov/information/special-calculations-household-income"
@@ -7182,14 +7248,18 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                               <div
                                 class="mb-4"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   For income calculations, household size includes everyone (all ages) living in the unit.
                                 </p>
                               </div>
                               <div
                                 class="mb-4 primary-lighter-markup-link-desktop"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   People in your household may need 
                                   <a
                                     href="https://sf.gov/information/special-calculations-household-income"
@@ -7779,7 +7849,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                             <span
                               class="translate"
                             >
-                              <p>
+                              <p
+                                class="primary-lighter-markup-link"
+                              >
                                 Tenants pay for gas, electricity.
 
                                 <br />
@@ -7979,7 +8051,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           <span
                             class="translate"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Tenants pay for gas, electricity.
 
                               <br />
@@ -8220,7 +8294,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           <span
                             class="translate"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Tenants pay for gas, electricity.
 
                               <br />
@@ -8361,9 +8437,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           class="text-xs"
                         >
                           <div
-                            class="text-xs inline primary-lighter-markup-link translate"
+                            class="text-xs inline translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               Lottery winners will be required to fill out a building application and provide a copy of your current credit report, 3 most recent paystubs, current tax returns and W-2, and 3 most recent bank statements.
                             </span>
                           </div>
@@ -8381,9 +8459,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           class="text-xs"
                         >
                           <div
-                            class="text-xs inline primary-lighter-markup-link translate"
+                            class="text-xs inline translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               All BMR renters must review and acknowledge the 
                               <a
                                 href="http://sf-moh.org/index.aspx?page=295"
@@ -8435,9 +8515,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Lottery winners will be required to fill out a building application and provide a copy of your current credit report, 3 most recent paystubs, current tax returns and W-2, and 3 most recent bank statements.
                           </span>
                         </div>
@@ -8455,9 +8537,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             All BMR renters must review and acknowledge the 
                             <a
                               href="http://sf-moh.org/index.aspx?page=295"
@@ -8550,9 +8634,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Lottery winners will be required to fill out a building application and provide a copy of your current credit report, 3 most recent paystubs, current tax returns and W-2, and 3 most recent bank statements.
                           </span>
                         </div>
@@ -8570,9 +8656,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             All BMR renters must review and acknowledge the 
                             <a
                               href="http://sf-moh.org/index.aspx?page=295"
@@ -8715,7 +8803,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         <div
                           class="text-gray-700"
                         >
-                          <div>
+                          <div
+                            class="primary-lighter-markup-link"
+                          >
                             <p>
                               The lottery will not be in person, but instead will be a virtual lottery.
                             </p>
@@ -8805,7 +8895,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                             <span
                               class="links-space translate"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 Library
                               </span>
                             </span>
@@ -8926,14 +9018,18 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                               <div
                                 class="mb-4"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   For income calculations, household size includes everyone (all ages) living in the unit.
                                 </p>
                               </div>
                               <div
                                 class="mb-4 primary-lighter-markup-link-desktop"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   People in your household may need 
                                   <a
                                     href="https://sf.gov/information/special-calculations-household-income"
@@ -9459,7 +9555,9 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                           <span
                             class="translate"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Tenants pay for gas, electricity.
 
                               <br />
@@ -9536,9 +9634,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Lottery winners will be required to fill out a building application and provide a copy of your current credit report, 3 most recent paystubs, current tax returns and W-2, and 3 most recent bank statements.
                           </span>
                         </div>
@@ -9556,9 +9656,11 @@ exports[`Listing Detail renders a listing with sro units 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             All BMR renters must review and acknowledge the 
                             <a
                               href="http://sf-moh.org/index.aspx?page=295"
@@ -9990,7 +10092,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
             <div
               class="feedback-link"
             >
-              <span>
+              <span
+                class="primary-lighter-markup-link"
+              >
                 We'd love to get 
                 <a
                   href="https://airtable.com/appUW1tM8te0Lmf6q/pagyZulZJCm1V4G8D/form?prefill_Last%20visited=%2F&hide_Last%20visited=true"
@@ -10355,7 +10459,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <div
                             class="text-gray-700"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Virtual lottery today. 
                               <a
                                 href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDg4YmYzYTQtMjY3MS00NTliLWJkYzEtMWM3MDU3NTQ0M2Nl%40thread.v2/0?context=%7b%22Tid%22%3a%2222d5c2cf-ce3e-443d-9a7f-dfcc0231f73f%22%2c%22Oid%22%3a%22a1924752-de5c-4553-b0c3-e21c56e7651f%22%2c%22IsBroadcastMeeting%22%3atrue%7d&amp;btype=a&amp;role=a"
@@ -10544,7 +10650,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             <span
                               class="translate"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 Monday - Friday 
 
                                 <br />
@@ -10700,7 +10808,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <div
                             class="text-gray-700"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Virtual lottery today. 
                               <a
                                 href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDg4YmYzYTQtMjY3MS00NTliLWJkYzEtMWM3MDU3NTQ0M2Nl%40thread.v2/0?context=%7b%22Tid%22%3a%2222d5c2cf-ce3e-443d-9a7f-dfcc0231f73f%22%2c%22Oid%22%3a%22a1924752-de5c-4553-b0c3-e21c56e7651f%22%2c%22IsBroadcastMeeting%22%3atrue%7d&amp;btype=a&amp;role=a"
@@ -10860,7 +10970,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             <span
                               class="translate"
                             >
-                              <span>
+                              <span
+                                class="primary-lighter-markup-link"
+                              >
                                 Monday - Friday 
 
                                 <br />
@@ -10916,7 +11028,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         <div
                           class="text-gray-700"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Virtual lottery today. 
                             <a
                               href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDg4YmYzYTQtMjY3MS00NTliLWJkYzEtMWM3MDU3NTQ0M2Nl%40thread.v2/0?context=%7b%22Tid%22%3a%2222d5c2cf-ce3e-443d-9a7f-dfcc0231f73f%22%2c%22Oid%22%3a%22a1924752-de5c-4553-b0c3-e21c56e7651f%22%2c%22IsBroadcastMeeting%22%3atrue%7d&amp;btype=a&amp;role=a"
@@ -11076,7 +11190,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               Monday - Friday 
 
                               <br />
@@ -11173,7 +11289,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         <div
                           class="text-gray-700"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Virtual lottery today. 
                             <a
                               href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDg4YmYzYTQtMjY3MS00NTliLWJkYzEtMWM3MDU3NTQ0M2Nl%40thread.v2/0?context=%7b%22Tid%22%3a%2222d5c2cf-ce3e-443d-9a7f-dfcc0231f73f%22%2c%22Oid%22%3a%22a1924752-de5c-4553-b0c3-e21c56e7651f%22%2c%22IsBroadcastMeeting%22%3atrue%7d&amp;btype=a&amp;role=a"
@@ -11333,7 +11451,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               Monday - Friday 
 
                               <br />
@@ -11507,7 +11627,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                 class="ml-0 my-1"
                               >
                                 <li>
-                                  <span>
+                                  <span
+                                    class="primary-lighter-markup-link"
+                                  >
                                     Be an employee of 
                                     <b>
                                       <a
@@ -11525,6 +11647,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               </ul>
                               <p>
                                 <a
+                                  class="primary-lighter-markup-link"
                                   href="https://sf.gov/apply-shirley-chisholm-village-housing"
                                   target="_blank"
                                 >
@@ -11536,6 +11659,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               </p>
                               <p>
                                 <a
+                                  class="primary-lighter-markup-link"
                                   href="#chisholm-preferences"
                                   target="_self"
                                 >
@@ -11565,14 +11689,18 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                 <div
                                   class="mb-4"
                                 >
-                                  <p>
+                                  <p
+                                    class="primary-lighter-markup-link"
+                                  >
                                     For income calculations, household size includes everyone (all ages) living in the unit.
                                   </p>
                                 </div>
                                 <div
                                   class="mb-4 primary-lighter-markup-link-desktop"
                                 >
-                                  <p>
+                                  <p
+                                    class="primary-lighter-markup-link"
+                                  >
                                     People in your household may need 
                                     <a
                                       href="https://sf.gov/information/special-calculations-household-income"
@@ -11771,7 +11899,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                     If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                                   </p>
                                   <p>
-                                    <b>
+                                    <b
+                                      class="primary-lighter-markup-link"
+                                    >
                                       Priority for certain groups - San Francisco Unified School District employees
                                     </b>
                                     <br />
@@ -11782,6 +11912,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   >
                                     <li>
                                       <a
+                                        class="primary-lighter-markup-link"
                                         href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                                         target="_blank"
                                       >
@@ -11790,6 +11921,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                     </li>
                                     <li>
                                       <a
+                                        class="primary-lighter-markup-link"
                                         href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                                         target="_blank"
                                       >
@@ -12046,7 +12178,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               class="ml-0 my-1"
                             >
                               <li>
-                                <span>
+                                <span
+                                  class="primary-lighter-markup-link"
+                                >
                                   Be an employee of 
                                   <b>
                                     <a
@@ -12064,6 +12198,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             </ul>
                             <p>
                               <a
+                                class="primary-lighter-markup-link"
                                 href="https://sf.gov/apply-shirley-chisholm-village-housing"
                                 target="_blank"
                               >
@@ -12075,6 +12210,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             </p>
                             <p>
                               <a
+                                class="primary-lighter-markup-link"
                                 href="#chisholm-preferences"
                                 target="_self"
                               >
@@ -12104,14 +12240,18 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               <div
                                 class="mb-4"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   For income calculations, household size includes everyone (all ages) living in the unit.
                                 </p>
                               </div>
                               <div
                                 class="mb-4 primary-lighter-markup-link-desktop"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   People in your household may need 
                                   <a
                                     href="https://sf.gov/information/special-calculations-household-income"
@@ -12310,7 +12450,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                                 </p>
                                 <p>
-                                  <b>
+                                  <b
+                                    class="primary-lighter-markup-link"
+                                  >
                                     Priority for certain groups - San Francisco Unified School District employees
                                   </b>
                                   <br />
@@ -12321,6 +12463,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                 >
                                   <li>
                                     <a
+                                      class="primary-lighter-markup-link"
                                       href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                                       target="_blank"
                                     >
@@ -12329,6 +12472,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   </li>
                                   <li>
                                     <a
+                                      class="primary-lighter-markup-link"
                                       href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                                       target="_blank"
                                     >
@@ -12626,7 +12770,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               class="ml-0 my-1"
                             >
                               <li>
-                                <span>
+                                <span
+                                  class="primary-lighter-markup-link"
+                                >
                                   Be an employee of 
                                   <b>
                                     <a
@@ -12644,6 +12790,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             </ul>
                             <p>
                               <a
+                                class="primary-lighter-markup-link"
                                 href="https://sf.gov/apply-shirley-chisholm-village-housing"
                                 target="_blank"
                               >
@@ -12655,6 +12802,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             </p>
                             <p>
                               <a
+                                class="primary-lighter-markup-link"
                                 href="#chisholm-preferences"
                                 target="_self"
                               >
@@ -12684,14 +12832,18 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               <div
                                 class="mb-4"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   For income calculations, household size includes everyone (all ages) living in the unit.
                                 </p>
                               </div>
                               <div
                                 class="mb-4 primary-lighter-markup-link-desktop"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   People in your household may need 
                                   <a
                                     href="https://sf.gov/information/special-calculations-household-income"
@@ -12890,7 +13042,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                                 </p>
                                 <p>
-                                  <b>
+                                  <b
+                                    class="primary-lighter-markup-link"
+                                  >
                                     Priority for certain groups - San Francisco Unified School District employees
                                   </b>
                                   <br />
@@ -12901,6 +13055,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                 >
                                   <li>
                                     <a
+                                      class="primary-lighter-markup-link"
                                       href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                                       target="_blank"
                                     >
@@ -12909,6 +13064,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   </li>
                                   <li>
                                     <a
+                                      class="primary-lighter-markup-link"
                                       href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                                       target="_blank"
                                     >
@@ -13522,7 +13678,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             <span
                               class="translate"
                             >
-                              <p>
+                              <p
+                                class="primary-lighter-markup-link"
+                              >
                                 Late payments Fees $20.00, NSF checks $35.00, FOB Replacement $50.00, Front Door Key Replacement $25.00, Residents pay for PG&E.
                               </p>
                             </span>
@@ -13825,7 +13983,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="translate"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Late payments Fees $20.00, NSF checks $35.00, FOB Replacement $50.00, Front Door Key Replacement $25.00, Residents pay for PG&E.
                             </p>
                           </span>
@@ -14169,7 +14329,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="translate"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Late payments Fees $20.00, NSF checks $35.00, FOB Replacement $50.00, Front Door Key Replacement $25.00, Residents pay for PG&E.
                             </p>
                           </span>
@@ -14638,9 +14800,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           class="text-xs"
                         >
                           <div
-                            class="text-xs inline primary-lighter-markup-link translate"
+                            class="text-xs inline translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               Post-Lottery Application
                             </span>
                           </div>
@@ -14658,9 +14822,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           class="text-xs"
                         >
                           <div
-                            class="text-xs inline primary-lighter-markup-link translate"
+                            class="text-xs inline translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               <p>
                                 The 
                                 <a
@@ -14698,9 +14864,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Post-Lottery Application
                           </span>
                         </div>
@@ -14718,9 +14886,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             <p>
                               The 
                               <a
@@ -14799,9 +14969,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Post-Lottery Application
                           </span>
                         </div>
@@ -14819,9 +14991,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             <p>
                               The 
                               <a
@@ -14950,7 +15124,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         <div
                           class="text-gray-700"
                         >
-                          <p>
+                          <p
+                            class="primary-lighter-markup-link"
+                          >
                             Virtual lottery today. 
                             <a
                               href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDg4YmYzYTQtMjY3MS00NTliLWJkYzEtMWM3MDU3NTQ0M2Nl%40thread.v2/0?context=%7b%22Tid%22%3a%2222d5c2cf-ce3e-443d-9a7f-dfcc0231f73f%22%2c%22Oid%22%3a%22a1924752-de5c-4553-b0c3-e21c56e7651f%22%2c%22IsBroadcastMeeting%22%3atrue%7d&amp;btype=a&amp;role=a"
@@ -15110,7 +15286,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="translate"
                           >
-                            <span>
+                            <span
+                              class="primary-lighter-markup-link"
+                            >
                               Monday - Friday 
 
                               <br />
@@ -15220,7 +15398,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               class="ml-0 my-1"
                             >
                               <li>
-                                <span>
+                                <span
+                                  class="primary-lighter-markup-link"
+                                >
                                   Be an employee of 
                                   <b>
                                     <a
@@ -15238,6 +15418,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             </ul>
                             <p>
                               <a
+                                class="primary-lighter-markup-link"
                                 href="https://sf.gov/apply-shirley-chisholm-village-housing"
                                 target="_blank"
                               >
@@ -15249,6 +15430,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                             </p>
                             <p>
                               <a
+                                class="primary-lighter-markup-link"
                                 href="#chisholm-preferences"
                                 target="_self"
                               >
@@ -15278,14 +15460,18 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                               <div
                                 class="mb-4"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   For income calculations, household size includes everyone (all ages) living in the unit.
                                 </p>
                               </div>
                               <div
                                 class="mb-4 primary-lighter-markup-link-desktop"
                               >
-                                <p>
+                                <p
+                                  class="primary-lighter-markup-link"
+                                >
                                   People in your household may need 
                                   <a
                                     href="https://sf.gov/information/special-calculations-household-income"
@@ -15484,7 +15670,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   If you qualify for a preference, you have a better chance in the lottery. After the lottery, all applicants are ranked and ordered by preference category. If you do not qualify for a preference, you will be ranked below those who do. 
                                 </p>
                                 <p>
-                                  <b>
+                                  <b
+                                    class="primary-lighter-markup-link"
+                                  >
                                     Priority for certain groups - San Francisco Unified School District employees
                                   </b>
                                   <br />
@@ -15495,6 +15683,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                 >
                                   <li>
                                     <a
+                                      class="primary-lighter-markup-link"
                                       href="https://www.sf.gov/learn-how-lottery-works-shirley-chisholm-village"
                                       target="_blank"
                                     >
@@ -15503,6 +15692,7 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                                   </li>
                                   <li>
                                     <a
+                                      class="primary-lighter-markup-link"
                                       href="https://sf.gov/information/learn-about-housing-lottery-preference-programs"
                                       target="_blank"
                                     >
@@ -16052,7 +16242,9 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                           <span
                             class="translate"
                           >
-                            <p>
+                            <p
+                              class="primary-lighter-markup-link"
+                            >
                               Late payments Fees $20.00, NSF checks $35.00, FOB Replacement $50.00, Front Door Key Replacement $25.00, Residents pay for PG&E.
                             </p>
                           </span>
@@ -16215,9 +16407,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             Post-Lottery Application
                           </span>
                         </div>
@@ -16235,9 +16429,11 @@ exports[`Listing Detail renders an open rental listing 1`] = `
                         class="text-xs"
                       >
                         <div
-                          class="text-xs inline primary-lighter-markup-link translate"
+                          class="text-xs inline translate"
                         >
-                          <span>
+                          <span
+                            class="primary-lighter-markup-link"
+                          >
                             <p>
                               The 
                               <a

--- a/app/javascript/components/base.scss
+++ b/app/javascript/components/base.scss
@@ -252,13 +252,13 @@ nav {
 }
 
 .primary-lighter-markup-link a {
-  color: var(--bloom-color-blue-700);
+  color: var(--bloom-color-blue-500);
   text-decoration: underline;
 }
 
 .primary-lighter-markup-link-desktop a {
   @media (min-width: $screen-md) {
-    color: var(--bloom-color-blue-700);
+    color: var(--bloom-color-blue-500);
     text-decoration: underline;
   }
 }

--- a/app/javascript/components/base.scss
+++ b/app/javascript/components/base.scss
@@ -187,7 +187,6 @@ $colors: (
       -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.7);
     }
   }
-
   .ag-root-wrapper {
     @apply border-b-0;
     @apply rounded-t-md;
@@ -254,11 +253,13 @@ nav {
 
 .primary-lighter-markup-link a {
   color: var(--bloom-color-blue-700);
+  text-decoration: underline;
 }
 
 .primary-lighter-markup-link-desktop a {
   @media (min-width: $screen-md) {
     color: var(--bloom-color-blue-700);
+    text-decoration: underline;
   }
 }
 

--- a/app/javascript/modules/listingDetails/ListingDetailsAdditionalInformation.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsAdditionalInformation.tsx
@@ -29,7 +29,7 @@ const RequiredDocuments = ({
       <h3 className="text-serif-xl">{t("listings.requiredDocuments")}</h3>
       <div className="text-xs">
         <TextTruncate
-          className="primary-lighter-markup-link translate"
+          className="translate"
           buttonClassName="text-blue-700"
           text={stripMostTags(
             getTranslatedString(
@@ -82,7 +82,7 @@ export const ListingDetailsAdditionalInformation = ({
           <div className="info-card bg-gray-100 border-0">
             <h3 className="text-serif-xl">{t("listings.specialNotes")}</h3>
             <TextTruncate
-              className="primary-lighter-markup-link translate"
+              className="translate"
               buttonClassName="text-blue-700"
               text={stripMostTags(
                 getTranslatedString(
@@ -105,7 +105,7 @@ export const ListingDetailsAdditionalInformation = ({
                 isLotterySalesListing(listing) && !isHabitatListing(listing) && (
                   <div className="text-xs mt-4">
                     <TextTruncate
-                      className="primary-lighter-markup-link translate"
+                      className="translate"
                       buttonClassName="text-blue-700"
                       text={t("listings.requiredDocumentsAfterApplying", {
                         url: "https://www.sf.gov/after-bmr-homebuyer-lottery",
@@ -129,7 +129,7 @@ export const ListingDetailsAdditionalInformation = ({
                     listing.translations
                   )
                 )}
-                className="primary-lighter-markup-link translate"
+                className="translate"
                 buttonClassName="text-blue-500"
               />
             </div>
@@ -140,7 +140,7 @@ export const ListingDetailsAdditionalInformation = ({
             <h3 className="text-serif-xl">{t("listings.cc&r")}</h3>
             <div className="text-xs">
               <TextTruncate
-                className="primary-lighter-markup-link translate"
+                className="translate"
                 buttonClassName="text-blue-500"
                 text={t("listings.cc&rDescription")}
               />
@@ -166,7 +166,7 @@ export const ListingDetailsAdditionalInformation = ({
                   <span className={"font-bold"}>{t("listings.agentCompensationInfo")}</span>
                   <span>
                     <TextTruncate
-                      className="primary-lighter-markup-link translate"
+                      className="translate"
                       buttonClassName="text-blue-500"
                       text={stripMostTags(
                         getTranslatedString(
@@ -187,7 +187,7 @@ export const ListingDetailsAdditionalInformation = ({
             <h3 className="text-serif-xl">{t("listings.rePricing")}</h3>
             <div className="text-xs">
               <TextTruncate
-                className="primary-lighter-markup-link translate"
+                className="translate"
                 buttonClassName="text-blue-500"
                 text={stripMostTags(
                   getTranslatedString(

--- a/app/javascript/pages/inviteTo/invite-to.module.scss
+++ b/app/javascript/pages/inviteTo/invite-to.module.scss
@@ -205,7 +205,7 @@
     flex-direction: column;
     padding: var(--seeds-spacer-section);
     background: var(--seeds-color-primary-lighter);
-    gap: var(--seeds-spacer-text);
+    gap: var(--seeds-s4);
   }
 }
 

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -163,17 +163,21 @@ export const getSfGovUrl = (enLink: string, path?: string) => {
  */
 export function renderMarkup(translatedString: string, allowedTags?: string) {
   return (
-    <Markdown options={{ forceBlock: true, namedCodesToUnicode: { "#39": "\u0027" } }}>
-      {stripMostTags(translatedString, allowedTags)}
-    </Markdown>
+    <span className="primary-lighter-markup-link">
+      <Markdown options={{ forceBlock: true, namedCodesToUnicode: { "#39": "\u0027" } }}>
+        {stripMostTags(translatedString, allowedTags)}
+      </Markdown>
+    </span>
   )
 }
 
 export function renderInlineMarkup(translatedString: string, allowedTags?: string) {
   return (
-    <Markdown options={{ namedCodesToUnicode: { "#39": "\u0027" } }}>
-      {stripMostTags(translatedString, allowedTags)}
-    </Markdown>
+    <span className="primary-lighter-markup-link">
+      <Markdown options={{ namedCodesToUnicode: { "#39": "\u0027" } }}>
+        {stripMostTags(translatedString, allowedTags)}
+      </Markdown>
+    </span>
   )
 }
 

--- a/app/javascript/util/languageUtil.tsx
+++ b/app/javascript/util/languageUtil.tsx
@@ -163,21 +163,23 @@ export const getSfGovUrl = (enLink: string, path?: string) => {
  */
 export function renderMarkup(translatedString: string, allowedTags?: string) {
   return (
-    <span className="primary-lighter-markup-link">
-      <Markdown options={{ forceBlock: true, namedCodesToUnicode: { "#39": "\u0027" } }}>
-        {stripMostTags(translatedString, allowedTags)}
-      </Markdown>
-    </span>
+    <Markdown
+      options={{ forceBlock: true, namedCodesToUnicode: { "#39": "\u0027" } }}
+      className="primary-lighter-markup-link"
+    >
+      {stripMostTags(translatedString, allowedTags)}
+    </Markdown>
   )
 }
 
 export function renderInlineMarkup(translatedString: string, allowedTags?: string) {
   return (
-    <span className="primary-lighter-markup-link">
-      <Markdown options={{ namedCodesToUnicode: { "#39": "\u0027" } }}>
-        {stripMostTags(translatedString, allowedTags)}
-      </Markdown>
-    </span>
+    <Markdown
+      options={{ namedCodesToUnicode: { "#39": "\u0027" } }}
+      className="primary-lighter-markup-link"
+    >
+      {stripMostTags(translatedString, allowedTags)}
+    </Markdown>
   )
 }
 


### PR DESCRIPTION
## Description

Adds underline styling to hyperlinks and adds increased gap spacing to Contact Me content

Note: A lot of diffs! This PR requires updating Jest snapshots - adding link styling to our `renderInline` and `renderInlineMarkup` functions felt like a safer approach rather than adding a global link styling to all `a` tags

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3920

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [x] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag