### PR TITLE
fix: DAH-0000 Update account settings e2e tests

### DIFF
--- a/cypress/e2e/accounts/accountSettings.e2e.ts
+++ b/cypress/e2e/accounts/accountSettings.e2e.ts
@@ -33,7 +33,7 @@ describe("Account Settings", () => {
       "/api/v1/account/update",
       userObjectGenerator({ firstName: "Jane", lastName: "Smith" })
     ).as("updateName")
-    cy.get('button[type="submit"]').contains("Update").first().click()
+    cy.get('input[name="firstName"]').closest("form").find('button[type="submit"]').click()
     cy.wait("@updateName").its("response.statusCode").should("eq", 200)
     // Commenting out the below line because the page is not updating with the success message consistently in the e2e test
     // cy.contains("Your changes have been saved.")
@@ -56,7 +56,7 @@ describe("Account Settings", () => {
       "/api/v1/account/update",
       userObjectGenerator({ firstName: "Jane", lastName: "Smith", DOB: "2000-12-10" })
     ).as("updateDOB")
-    cy.get('button[type="submit"]').eq(1).contains("Update").click()
+    cy.get("input#dobObject\\.birthMonth").closest("form").find('button[type="submit"]').click()
     cy.wait("@updateDOB").its("response.statusCode").should("eq", 200)
 
     // Create DOB error
@@ -82,7 +82,7 @@ describe("Account Settings", () => {
     cy.get("button").contains("Email missing a dot ‘.’ in the domain").click().type(".com")
 
     cy.intercept("/api/v1/auth", AUTH).as("emailChange")
-    cy.get('button[type="submit"]').eq(2).contains("Update").click()
+    cy.get('input[name="email"]').closest("form").find('button[type="submit"]').click()
     cy.contains(
       "We sent you an email. Check your email and follow the link to finish changing your information."
     )
@@ -101,7 +101,7 @@ describe("Account Settings", () => {
       message: "Your password has been successfully updated.",
       ...AUTH,
     }).as("passwordChange")
-    cy.get('button[type="submit"]').eq(3).contains("Update").click()
+    cy.get('input[name="currentPassword"]').closest("form").find('button[type="submit"]').click()
     cy.wait("@passwordChange").its("response.statusCode").should("eq", 200)
     // cy.contains("Your changes have been saved.")
   })


### PR DESCRIPTION
## Description

Gets the account settings buttons using its corresponding input instead of the string. This allows for the different strings between old and new account pages (like "Update" vs. "Save name").

To review, ensure circleCI e2e tests pass with the account layout flag turned on and off. 

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag