### PR TITLE
fix: DAH-0000 separate angular route from My Applications page

### DIFF
--- a/app/javascript/__tests__/pages/account/applications.test.tsx
+++ b/app/javascript/__tests__/pages/account/applications.test.tsx
@@ -217,7 +217,7 @@ describe("<ApplicationsPage />", () => {
       const button = within(modal).getByRole("link", {
         name: /view application/i,
       })
-      expect(button).toHaveAttribute("href", "/account/applications/a0o6s000001cn02AAA")
+      expect(button).toHaveAttribute("href", "/applications/a0o6s000001cn02AAA")
     })
   })
 })

--- a/app/javascript/__tests__/pages/account/my-applications.test.tsx
+++ b/app/javascript/__tests__/pages/account/my-applications.test.tsx
@@ -219,7 +219,7 @@ describe("<MyApplications />", () => {
       const button = within(modal).getByRole("link", {
         name: /view application/i,
       })
-      expect(button).toHaveAttribute("href", "/account/applications/a0o6s000001cn02AAA")
+      expect(button).toHaveAttribute("href", "/applications/a0o6s000001cn02AAA")
     })
   })
 })

--- a/app/javascript/__tests__/util/routeUtil.test.ts
+++ b/app/javascript/__tests__/util/routeUtil.test.ts
@@ -2,7 +2,7 @@ import {
   getAssistancePath,
   getMyAccountSettingsPath,
   getApplicationPath,
-  getApplicationsPath,
+  getMyAccountApplicationsPath,
   getMyAccountPath,
   getNewLanguagePath,
   getRentalDirectoryPath,
@@ -35,9 +35,9 @@ describe("routeUtil", () => {
       expect(getMyAccountPath("")).toBe("/account")
     })
 
-    it("returns the correct path for getApplicationsPath", () => {
-      expect(getApplicationsPath("/es/sign-in")).toBe("/es/account/applications")
-      expect(getApplicationsPath("")).toBe("/account/applications")
+    it("returns the correct path for getMyAccountApplicationsPath", () => {
+      expect(getMyAccountApplicationsPath("/es/sign-in")).toBe("/es/account/applications")
+      expect(getMyAccountApplicationsPath("")).toBe("/account/applications")
     })
 
     it("returns the correct path for getApplicationPath", () => {

--- a/app/javascript/__tests__/util/routeUtil.test.ts
+++ b/app/javascript/__tests__/util/routeUtil.test.ts
@@ -2,6 +2,7 @@ import {
   getAssistancePath,
   getMyAccountSettingsPath,
   getApplicationPath,
+  getApplicationsPath,
   getMyAccountPath,
   getNewLanguagePath,
   getRentalDirectoryPath,
@@ -34,9 +35,14 @@ describe("routeUtil", () => {
       expect(getMyAccountPath("")).toBe("/account")
     })
 
+    it("returns the correct path for getApplicationsPath", () => {
+      expect(getApplicationsPath("/es/sign-in")).toBe("/es/account/applications")
+      expect(getApplicationsPath("")).toBe("/account/applications")
+    })
+
     it("returns the correct path for getApplicationPath", () => {
-      expect(getApplicationPath("/es/sign-in")).toBe("/es/account/applications")
-      expect(getApplicationPath("")).toBe("/account/applications")
+      expect(getApplicationPath("/es/sign-in")).toBe("/es/applications")
+      expect(getApplicationPath("")).toBe("/applications")
     })
 
     it("returns the correct path for getMyaccountSettingsPath", () => {

--- a/app/javascript/layouts/AccountNav.tsx
+++ b/app/javascript/layouts/AccountNav.tsx
@@ -7,7 +7,7 @@ import { ConfigContext } from "../lib/ConfigContext"
 import { getPathWithoutLanguagePrefix } from "../util/languageUtil"
 import {
   getMyAccountPath,
-  getApplicationsPath,
+  getMyAccountApplicationsPath,
   getMyAccountSettingsPath,
   getSignInPath,
   getMyAccountContactPath,
@@ -50,7 +50,10 @@ const AccountNav = () => {
             />
             {t("accountLayout.nav.contactInfo")}
           </Tabs.Tab>
-          <Tabs.Tab href={getApplicationsPath()} active={isNavActive(getApplicationsPath())}>
+          <Tabs.Tab
+            href={getMyAccountApplicationsPath()}
+            active={isNavActive(getMyAccountApplicationsPath())}
+          >
             <Icon size="md-large" symbol="application" className={styles.accountNavLinkIcon} />
             {t("accountLayout.nav.applications")}
           </Tabs.Tab>

--- a/app/javascript/layouts/AccountNav.tsx
+++ b/app/javascript/layouts/AccountNav.tsx
@@ -7,7 +7,7 @@ import { ConfigContext } from "../lib/ConfigContext"
 import { getPathWithoutLanguagePrefix } from "../util/languageUtil"
 import {
   getMyAccountPath,
-  getApplicationPath,
+  getApplicationsPath,
   getMyAccountSettingsPath,
   getSignInPath,
   getMyAccountContactPath,
@@ -50,7 +50,7 @@ const AccountNav = () => {
             />
             {t("accountLayout.nav.contactInfo")}
           </Tabs.Tab>
-          <Tabs.Tab href={getApplicationPath()} active={isNavActive(getApplicationPath())}>
+          <Tabs.Tab href={getApplicationsPath()} active={isNavActive(getApplicationsPath())}>
             <Icon size="md-large" symbol="application" className={styles.accountNavLinkIcon} />
             {t("accountLayout.nav.applications")}
           </Tabs.Tab>

--- a/app/javascript/pages/account/account.tsx
+++ b/app/javascript/pages/account/account.tsx
@@ -10,7 +10,7 @@ import withAppSetup from "../../layouts/withAppSetup"
 import {
   AppPages,
   RedirectType,
-  getApplicationsPath,
+  getMyAccountApplicationsPath,
   getMyAccountSettingsPath,
 } from "../../util/routeUtil"
 import UserContext from "../../authentication/context/UserContext"
@@ -26,7 +26,7 @@ const overviewSections = [
     heading: "accountLayout.nav.applications",
     text: "accountLayout.account.p1",
     buttonLabel: "accountLayout.account.seeApps",
-    href: getApplicationsPath(),
+    href: getMyAccountApplicationsPath(),
   },
   {
     icon: "settings",

--- a/app/javascript/pages/account/account.tsx
+++ b/app/javascript/pages/account/account.tsx
@@ -10,7 +10,7 @@ import withAppSetup from "../../layouts/withAppSetup"
 import {
   AppPages,
   RedirectType,
-  getApplicationPath,
+  getApplicationsPath,
   getMyAccountSettingsPath,
 } from "../../util/routeUtil"
 import UserContext from "../../authentication/context/UserContext"
@@ -26,7 +26,7 @@ const overviewSections = [
     heading: "accountLayout.nav.applications",
     text: "accountLayout.account.p1",
     buttonLabel: "accountLayout.account.seeApps",
-    href: getApplicationPath(),
+    href: getApplicationsPath(),
   },
   {
     icon: "settings",

--- a/app/javascript/pages/account/my-account.tsx
+++ b/app/javascript/pages/account/my-account.tsx
@@ -6,7 +6,7 @@ import { Icon, t, type UniversalIconType } from "@bloom-housing/ui-components"
 import {
   AppPages,
   getMyAccountSettingsPath,
-  getApplicationsPath,
+  getMyAccountApplicationsPath,
   RedirectType,
 } from "../../util/routeUtil"
 import { renderInlineMarkup } from "../../util/languageUtil"
@@ -69,7 +69,7 @@ const MyAccount = (_props: MyAccountProps) => {
             <AccountDashCard
               title={t("accountDashboard.myApplications.title")}
               description={t("accountDashboard.myApplications.description")}
-              link={getApplicationsPath()}
+              link={getMyAccountApplicationsPath()}
               icon="application"
               removeBottomBorder
             />

--- a/app/javascript/pages/account/my-account.tsx
+++ b/app/javascript/pages/account/my-account.tsx
@@ -6,7 +6,7 @@ import { Icon, t, type UniversalIconType } from "@bloom-housing/ui-components"
 import {
   AppPages,
   getMyAccountSettingsPath,
-  getApplicationPath,
+  getApplicationsPath,
   RedirectType,
 } from "../../util/routeUtil"
 import { renderInlineMarkup } from "../../util/languageUtil"
@@ -69,7 +69,7 @@ const MyAccount = (_props: MyAccountProps) => {
             <AccountDashCard
               title={t("accountDashboard.myApplications.title")}
               description={t("accountDashboard.myApplications.description")}
-              link={getApplicationPath()}
+              link={getApplicationsPath()}
               icon="application"
               removeBottomBorder
             />

--- a/app/javascript/pages/reset-password.tsx
+++ b/app/javascript/pages/reset-password.tsx
@@ -5,7 +5,7 @@ import { AppearanceStyleType, Button, Form, FormCard, Icon, t } from "@bloom-hou
 import withAppSetup from "../layouts/withAppSetup"
 import { Alert, Link } from "@bloom-housing/ui-seeds"
 import FormLayout from "../layouts/FormLayout"
-import { AppPages, getApplicationsPath, getSignInPath } from "../util/routeUtil"
+import { AppPages, getMyAccountApplicationsPath, getSignInPath } from "../util/routeUtil"
 import { useForm } from "react-hook-form"
 import PasswordFieldset from "./account/components/PasswordFieldset"
 import { resetPassword } from "../api/authApiService"
@@ -64,7 +64,7 @@ const ResetPassword = (_props: ResetPasswordProps) => {
     // TODO: DAH-2987 API integration
     resetPassword(data.password)
       .then(() => {
-        window.location.assign(getApplicationsPath())
+        window.location.assign(getMyAccountApplicationsPath())
       })
       .catch(() => {
         setServerError(t("error.account.genericServerError"))

--- a/app/javascript/pages/reset-password.tsx
+++ b/app/javascript/pages/reset-password.tsx
@@ -5,7 +5,7 @@ import { AppearanceStyleType, Button, Form, FormCard, Icon, t } from "@bloom-hou
 import withAppSetup from "../layouts/withAppSetup"
 import { Alert, Link } from "@bloom-housing/ui-seeds"
 import FormLayout from "../layouts/FormLayout"
-import { AppPages, getApplicationPath, getSignInPath } from "../util/routeUtil"
+import { AppPages, getApplicationsPath, getSignInPath } from "../util/routeUtil"
 import { useForm } from "react-hook-form"
 import PasswordFieldset from "./account/components/PasswordFieldset"
 import { resetPassword } from "../api/authApiService"
@@ -64,7 +64,7 @@ const ResetPassword = (_props: ResetPasswordProps) => {
     // TODO: DAH-2987 API integration
     resetPassword(data.password)
       .then(() => {
-        window.location.assign(getApplicationPath())
+        window.location.assign(getApplicationsPath())
       })
       .catch(() => {
         setServerError(t("error.account.genericServerError"))

--- a/app/javascript/util/routeUtil.ts
+++ b/app/javascript/util/routeUtil.ts
@@ -89,7 +89,7 @@ export const getResetPasswordPath = localizedPathGetter("/reset-password")
 
 // Accounts after signing in pages
 export const getMyAccountPath = localizedPathGetter("/account")
-export const getApplicationsPath = localizedPathGetter("/account/applications")
+export const getMyAccountApplicationsPath = localizedPathGetter("/account/applications")
 export const getApplicationPath = localizedPathGetter("/applications")
 export const getMyAccountSettingsPath = localizedPathGetter("/account/settings")
 export const getMyAccountContactPath = localizedPathGetter("/account/contact")
@@ -147,7 +147,7 @@ export const mapAlertParamToEnum = (param: string | null): AlertReason => {
 
 export const SignInRedirectUrls = {
   [RedirectType.Account]: getMyAccountPath(),
-  [RedirectType.Applications]: getApplicationsPath(),
+  [RedirectType.Applications]: getMyAccountApplicationsPath(),
   [RedirectType.Settings]: getMyAccountSettingsPath(),
   [RedirectType.Home]: getHomepagePath(),
 }

--- a/app/javascript/util/routeUtil.ts
+++ b/app/javascript/util/routeUtil.ts
@@ -89,7 +89,8 @@ export const getResetPasswordPath = localizedPathGetter("/reset-password")
 
 // Accounts after signing in pages
 export const getMyAccountPath = localizedPathGetter("/account")
-export const getApplicationPath = localizedPathGetter("/account/applications")
+export const getApplicationsPath = localizedPathGetter("/account/applications")
+export const getApplicationPath = localizedPathGetter("/applications")
 export const getMyAccountSettingsPath = localizedPathGetter("/account/settings")
 export const getMyAccountContactPath = localizedPathGetter("/account/contact")
 // Rental Listing Directory pages
@@ -146,7 +147,7 @@ export const mapAlertParamToEnum = (param: string | null): AlertReason => {
 
 export const SignInRedirectUrls = {
   [RedirectType.Account]: getMyAccountPath(),
-  [RedirectType.Applications]: getApplicationPath(),
+  [RedirectType.Applications]: getApplicationsPath(),
   [RedirectType.Settings]: getMyAccountSettingsPath(),
   [RedirectType.Home]: getHomepagePath(),
 }


### PR DESCRIPTION
## Description

Pages migrated from Angular to React generally have the same routes. However, the applications routes have recently changed so we need to ensure a separate /applications from /account/applications for when the user clicks to the Angular application from their My Applications page. Log into an account where your my applications page has "View / continue application" and confirm the link works. 

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag