### PR TITLE
chore: DAH-4182 Remove PII from Rails logs and expand filter_parameters

### DIFF
--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -73,15 +73,11 @@ class Api::V1::ShortFormController < ApiController
     if response.present?
       Rails.logger.info(
         'ShortFormController#submit_application: [' \
-        "'#{params[:locale]}', " \
-        "'#{params.dig('application', 'primaryApplicant', 'email')}', " \
-        "'#{params.dig('application', 'listingID')}', " \
-        "'#{response['lotteryNumber']}', " \
-        "'#{response['primaryApplicant']['firstName']}', " \
-        "'#{response['primaryApplicant']['lastName']}'" \
+        "locale='#{params[:locale]}', " \
+        "listingID='#{params.dig('application', 'listingID')}', " \
+        "lotteryNumber='#{response['lotteryNumber']}'" \
         ']',
       )
-      Rails.logger.info("ShortFormController#submit_application: response: #{response}")
       process_submit_app_response(response)
       render json: response
     else

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -72,11 +72,10 @@ class Api::V1::ShortFormController < ApiController
       Force::ShortFormService.create_or_update(application_params, applicant_attrs)
     if response.present?
       Rails.logger.info(
-        'ShortFormController#submit_application: [' \
+        'ShortFormController#submit_application: ' \
         "locale='#{params[:locale]}', " \
         "listingID='#{params.dig('application', 'listingID')}', " \
-        "lotteryNumber='#{response['lotteryNumber']}'" \
-        ']',
+        "lotteryNumber='#{response['lotteryNumber']}'"
       )
       process_submit_app_response(response)
       render json: response

--- a/app/controllers/overrides/registrations_controller.rb
+++ b/app/controllers/overrides/registrations_controller.rb
@@ -105,10 +105,7 @@ module Overrides
     end
 
     def handle_registration_success
-      Rails.logger.info(
-        'RegistrationsController#handle_registration_success: ' \
-        "'#{@resource.email.downcase}'",
-      )
+      Rails.logger.info('RegistrationsController#handle_registration_success: new account registered')
       if !@resource.confirmed?
         # user will require email authentication
         @resource.send_confirmation_instructions(

--- a/app/controllers/overrides/registrations_controller.rb
+++ b/app/controllers/overrides/registrations_controller.rb
@@ -105,7 +105,9 @@ module Overrides
     end
 
     def handle_registration_success
-      Rails.logger.info('RegistrationsController#handle_registration_success: new account registered')
+      Rails.logger.info(
+        "RegistrationsController#handle_registration_success: new account registered, id=#{@resource.id}",
+      )
       if !@resource.confirmed?
         # user will require email authentication
         @resource.send_confirmation_instructions(

--- a/app/services/address_validation_service.rb
+++ b/app/services/address_validation_service.rb
@@ -74,7 +74,9 @@ class AddressValidationService
 
     if @validation.present? && !@validation.verifications.delivery.success
       errors = Array(@validation.verifications.delivery.errors).map(&:code).compact
-      Rails.logger.warn("Address validation: EasyPost validation failed - error codes: #{errors.join(', ')}")
+      Rails.logger.warn(
+        "Address validation: EasyPost validation failed - error codes: #{errors.join(', ')}",
+      )
       return true
     end
 

--- a/app/services/address_validation_service.rb
+++ b/app/services/address_validation_service.rb
@@ -73,8 +73,8 @@ class AddressValidationService
     end
 
     if @validation.present? && !@validation.verifications.delivery.success
-      errors = @validation.verifications.delivery.errors.map(&:code)
-      Rails.logger.warn("Address validation: EasyPost validation failed - error codes: #{errors}")
+      errors = Array(@validation.verifications.delivery.errors).map(&:code).compact
+      Rails.logger.warn("Address validation: EasyPost validation failed - error codes: #{errors.join(', ')}")
       return true
     end
 

--- a/app/services/address_validation_service.rb
+++ b/app/services/address_validation_service.rb
@@ -63,22 +63,18 @@ class AddressValidationService
 
     # we do not accept PO Boxes
     if po_box?(@validation)
-      Rails.logger.info(
-        'Address validation: ' \
-        "Raised an address validation error for a PO Box #{@validation.to_json}",
-      )
+      Rails.logger.info('Address validation: Raised an address validation error for a PO Box')
       return true
     end
 
     if duplicate_unit?(@validation)
-      Rails.logger.info("Address validation: Duplicate unit #{@validation.to_json}")
+      Rails.logger.info('Address validation: Duplicate unit detected')
       return true
     end
 
     if @validation.present? && !@validation.verifications.delivery.success
-      Rails.logger.warn(
-        "Address validation: Easypost validation failed #{@validation.to_json}",
-      )
+      errors = @validation.verifications.delivery.errors.map(&:code)
+      Rails.logger.warn("Address validation: EasyPost validation failed - error codes: #{errors}")
       return true
     end
 

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -88,7 +88,11 @@ module DahliaBackend
                                                          _application_number, _app_id, _action)
       return if fields.nil?
 
-      log_info("Prepared fields for I2X response: action=#{_action.inspect}, listingId=#{(fields[:listingId] || listing_id).inspect}, applicationIdsCount=#{Array(fields.dig(:data, :applicationIds)).length}")
+      log_info(
+        "Prepared fields for I2X response: action=#{_action.inspect}, " \
+        "listingId=#{(fields[:listingId] || listing_id).inspect}, " \
+        "applicationIdsCount=#{Array(fields.dig(:data, :applicationIds)).length}",
+      )
 
       endpoint = get_response_endpoint(_action, _response)
       return log_error("Invalid action type: #{_action}", nil) unless endpoint

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -88,7 +88,7 @@ module DahliaBackend
                                                          _application_number, _app_id, _action)
       return if fields.nil?
 
-      log_info("Prepared fields for I2X response: #{fields.inspect}")
+      log_info("Prepared fields for I2X response: action=#{_action.inspect}, listingId=#{fields.dig(:data, :applicationIds)&.length || fields[:listingId]}")
 
       endpoint = get_response_endpoint(_action, _response)
       return log_error("Invalid action type: #{_action}", nil) unless endpoint
@@ -220,14 +220,14 @@ module DahliaBackend
     # @param [Hash] fields Message fields
     # @return [Object, nil] Response from API or nil if sending fails
     def send_message(endpoint, fields)
-      log_info("Sending message to #{endpoint}: #{fields}")
+      log_info("Sending message to #{endpoint}")
       response = client.post(endpoint, fields)
 
       if response
-        log_info("Successfully sent message to: #{fields[:email]}")
+        log_info("Successfully sent message to #{endpoint}")
         response
       else
-        log_error("Failed to send message to #{endpoint}: #{fields.to_json}", nil)
+        log_error("Failed to send message to #{endpoint}", nil)
         nil
       end
     end

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -88,12 +88,10 @@ module DahliaBackend
                                                          _application_number, _app_id, _action)
       return if fields.nil?
 
-      applicants_count = Array(fields.dig(:data, :applicationIds)).length +
-        Array(fields[:applicants]).length
       log_info(
         "Prepared fields for I2X response: action=#{_action.inspect}, " \
         "listingId=#{(fields[:listingId] || listing_id).inspect}, " \
-        "applicantsCount=#{applicants_count}",
+        "appId=#{_app_id.inspect}",
       )
 
       endpoint = get_response_endpoint(_action, _response)

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -88,7 +88,7 @@ module DahliaBackend
                                                          _application_number, _app_id, _action)
       return if fields.nil?
 
-      log_info("Prepared fields for I2X response: action=#{_action.inspect}, listingId=#{fields.dig(:data, :applicationIds)&.length || fields[:listingId]}")
+      log_info("Prepared fields for I2X response: action=#{_action.inspect}, listingId=#{(fields[:listingId] || listing_id).inspect}, applicationIdsCount=#{Array(fields.dig(:data, :applicationIds)).length}")
 
       endpoint = get_response_endpoint(_action, _response)
       return log_error("Invalid action type: #{_action}", nil) unless endpoint

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -58,7 +58,9 @@ module DahliaBackend
       fields = prepare_submission_fields(application_params, application_response, locale)
       return if fields.nil?
 
-      send_message(ENDPOINTS[:application_submission], fields)
+      send_message('/messages/application-submission', fields, {
+                     listingId: fields[:listingId],
+                   })
     rescue StandardError => e
       log_error('Error sending confirmation', e)
       nil
@@ -97,7 +99,11 @@ module DahliaBackend
       endpoint = get_response_endpoint(_action, _response)
       return log_error("Invalid action type: #{_action}", nil) unless endpoint
 
-      send_message(endpoint, fields)
+      send_message(endpoint, fields, {
+                     action: _action,
+                     listingId: fields[:listingId] || listing_id,
+                     appId: _app_id,
+                   })
     rescue StandardError => e
       log_error('Error sending I2X response', e)
       nil
@@ -223,17 +229,23 @@ module DahliaBackend
     # @param [String] endpoint API endpoint
     # @param [Hash] fields Message fields
     # @return [Object, nil] Response from API or nil if sending fails
-    def send_message(endpoint, fields)
-      log_info("Sending message to #{endpoint}")
+    def send_message(endpoint, fields, context = {})
+      context_suffix = context.present? ? " (#{format_log_context(context)})" : ''
+
+      log_info("Sending message to #{endpoint}#{context_suffix}")
       response = client.post(endpoint, fields)
 
       if response
-        log_info("Successfully sent message to #{endpoint}")
+        log_info("Successfully sent message to #{endpoint}#{context_suffix}")
         response
       else
-        log_error("Failed to send message to #{endpoint}", nil)
+        log_error("Failed to send message to #{endpoint}#{context_suffix}", nil)
         nil
       end
+    end
+
+    def format_log_context(context)
+      context.map { |key, value| "#{key}=#{value.inspect}" }.join(', ')
     end
 
     def valid_params?(application_params, application_response)

--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -88,10 +88,12 @@ module DahliaBackend
                                                          _application_number, _app_id, _action)
       return if fields.nil?
 
+      applicants_count = Array(fields.dig(:data, :applicationIds)).length +
+        Array(fields[:applicants]).length
       log_info(
         "Prepared fields for I2X response: action=#{_action.inspect}, " \
         "listingId=#{(fields[:listingId] || listing_id).inspect}, " \
-        "applicationIdsCount=#{Array(fields.dig(:data, :applicationIds)).length}",
+        "applicantsCount=#{applicants_count}",
       )
 
       endpoint = get_response_endpoint(_action, _response)

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -20,6 +20,8 @@ Rails.application.config.filter_parameters += [
   :address1,
   :mailingAddress,
   :street,
+  :street1,
+  :street2,
   :city,
   :state,
   :zip,

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -18,6 +18,7 @@ Rails.application.config.filter_parameters += [
   # address fields
   :address,
   :address1,
+  :company,
   :mailingAddress,
   :street,
   :street1,

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,35 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+# Keep this list in sync with any new PII fields added to forms or API params.
+Rails.application.config.filter_parameters += [
+  :password,
+  :password_confirmation,
+  # contact / identity
+  :email,
+  :firstName,
+  :lastName,
+  :middleName,
+  :phone,
+  :alternatePhone,
+  :additionalPhone,
+  :dob,
+  :DOB,
+  # address fields
+  :address,
+  :address1,
+  :mailingAddress,
+  :street,
+  :city,
+  :state,
+  :zip,
+  :mailingCity,
+  :mailingState,
+  :mailingZip,
+  # auth tokens
+  :token,
+  :auth_token,
+  :reset_password_token,
+  :confirmation_token,
+  :unlock_token,
+]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -15,7 +15,13 @@ Rails.application.config.filter_parameters += [
   :additionalPhone,
   :dob,
   :DOB,
-  # address fields
+  # sensitive demographics / location (short form)
+  :gender,
+  :raceEthnicity,
+  :sexualOrientation,
+  :hiv,
+  :xCoordinate,
+  :yCoordinate,
   :address,
   :address1,
   :company,


### PR DESCRIPTION
## Summary

Audited all Rails logger calls and identified several places where PII was being written to Papertrail logs. This PR addresses the high-priority findings.

## Changes

**`config/initializers/filter_parameter_logging.rb`**
Expanded from only `:password` to cover all common PII fields: email, first/last/middle name, phone, DOB, all address fields, and auth tokens. These now appear as `[FILTERED]` in request logs.

**`app/controllers/api/v1/short_form_controller.rb`**
Removed applicant email, first name, and last name from the `submit_application` log line. Also removed the full Salesforce response object dump (`response: #{response}`). Now logs only locale, listingID, and lotteryNumber.

**`app/controllers/overrides/registrations_controller.rb`**
Replaced `@resource.email.downcase` in the registration success log with a static message. The event is still traceable by timestamp and user ID context.

**`app/services/address_validation_service.rb`**
Removed three `@validation.to_json` calls that included the full normalized street address. Failure cases now log only EasyPost error codes (e.g. `E.BOX_NUMBER.INVALID`).

**`app/services/dahlia_backend/message_service.rb`**
Removed the full `fields` hash from `send_message` logs (contained email, name, phone). Removed `fields[:email]` from success log and `fields.to_json` from failure log. Cleaned up the I2X debug log to omit applicant contact fields.

## What was not changed

- Angular/Raven Sentry user context — tracked separately as legacy Angular cleanup
- `gis_controller.rb` DOB/name in error logs (medium risk, no user-visible trigger) — can be a follow-up
- Sentry initializer — confirmed Sentry has no DSN configured, so `Sentry.capture_exception` calls are currently no-ops

## Testing

These are logging-only changes with no behavior impact. Existing specs continue to pass.