### PR TITLE
fix: DAH-0000 Update React account layouts flag

### DIFF
--- a/app/javascript/__tests__/pages/account/account.test.tsx
+++ b/app/javascript/__tests__/pages/account/account.test.tsx
@@ -16,6 +16,10 @@ jest.mock("react-gtm-module", () => ({
   dataLayer: jest.fn(),
 }))
 
+jest.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ flagsReady: true, unleashFlag: true }),
+}))
+
 describe("<Account />", () => {
   beforeEach(() => {
     document.documentElement.lang = "en"

--- a/app/javascript/__tests__/pages/account/contact.test.tsx
+++ b/app/javascript/__tests__/pages/account/contact.test.tsx
@@ -16,6 +16,10 @@ jest.mock("react-gtm-module", () => ({
   dataLayer: jest.fn(),
 }))
 
+jest.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ flagsReady: true, unleashFlag: true }),
+}))
+
 describe("<Contact />", () => {
   beforeEach(() => {
     document.documentElement.lang = "en"

--- a/app/javascript/__tests__/pages/account/settings.test.tsx
+++ b/app/javascript/__tests__/pages/account/settings.test.tsx
@@ -14,6 +14,10 @@ jest.mock("../../../api/apiService", () => ({
   authenticatedPut: jest.fn(),
 }))
 
+jest.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ flagsReady: true, unleashFlag: true }),
+}))
+
 describe("<SettingsPage />", () => {
   describe("when the user is signed in", () => {
     let promise

--- a/app/javascript/pages/account/account.tsx
+++ b/app/javascript/pages/account/account.tsx
@@ -7,6 +7,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import Layout from "../../layouts/Layout"
 import AccountLayout from "../../layouts/AccountLayout"
 import withAppSetup from "../../layouts/withAppSetup"
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
+import { UNLEASH_FLAG } from "../../modules/constants"
 import {
   AppPages,
   RedirectType,
@@ -18,6 +20,7 @@ import { User } from "../../authentication/user"
 import { withAuthentication } from "../../authentication/withAuthentication"
 
 import ContactCard from "./components/ContactCard"
+import MyAccount from "./my-account"
 import styles from "./account.module.scss"
 
 const overviewSections = [
@@ -104,8 +107,18 @@ const AccountOverview = ({
   </>
 )
 
-const Account = () => {
+interface AccountProps {
+  assetPaths: unknown
+}
+
+const Account = ({ assetPaths }: AccountProps) => {
+  const { unleashFlag: accountLayoutEnabled } = useFeatureFlag(UNLEASH_FLAG.ACCOUNTS_LAYOUT, false)
   const { signOut, profile } = React.useContext(UserContext)
+
+  if (!accountLayoutEnabled) {
+    return <MyAccount assetPaths={assetPaths} />
+  }
+
   return (
     <Layout>
       <AccountLayout>

--- a/app/javascript/pages/account/applications.tsx
+++ b/app/javascript/pages/account/applications.tsx
@@ -22,6 +22,9 @@ import { DoubleSubmittedModal } from "./components/DoubleSubmittedModal"
 import { AlreadySubmittedModal } from "./components/AlreadySubmittedModal"
 import { extractModalParamsFromUrl } from "./components/util"
 import { withAuthentication } from "../../authentication/withAuthentication"
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
+import { UNLEASH_FLAG } from "../../modules/constants"
+import MyApplications from "./my-applications"
 import styles from "./styles/applications.module.scss"
 
 const noApplications = () => {
@@ -138,7 +141,11 @@ const determineApplicationItemList = (
   )
 }
 
-const Applications = () => {
+interface ApplicationsProps {
+  assetPaths: unknown
+}
+
+const ApplicationsPage = () => {
   const [error, setError] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState<boolean>(true)
   const [applications, setApplications] = React.useState<Application[]>([])
@@ -255,6 +262,16 @@ const Applications = () => {
       </AccountLayout>
     </Layout>
   )
+}
+
+const Applications = ({ assetPaths }: ApplicationsProps) => {
+  const { unleashFlag: accountLayoutEnabled } = useFeatureFlag(UNLEASH_FLAG.ACCOUNTS_LAYOUT, false)
+
+  if (!accountLayoutEnabled) {
+    return <MyApplications assetPaths={assetPaths} />
+  }
+
+  return <ApplicationsPage />
 }
 
 export default withAppSetup(

--- a/app/javascript/pages/account/contact.tsx
+++ b/app/javascript/pages/account/contact.tsx
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import React, { useContext } from "react"
+import { Navigate } from "react-router"
 import { t } from "@bloom-housing/ui-components"
 import { Message, Link, Card, Heading } from "@bloom-housing/ui-seeds"
 import Layout from "../../layouts/Layout"
 import AccountLayout from "../../layouts/AccountLayout"
 import withAppSetup from "../../layouts/withAppSetup"
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
+import { UNLEASH_FLAG } from "../../modules/constants"
 import {
   AppPages,
   getMyAccountPath,
@@ -18,8 +21,14 @@ import UserContext from "../../authentication/context/UserContext"
 import { renderInlineMarkup } from "../../util/languageUtil"
 
 const Contact = () => {
+  const { unleashFlag: accountLayoutEnabled } = useFeatureFlag(UNLEASH_FLAG.ACCOUNTS_LAYOUT, false)
   const { getAssetPath } = useContext(ConfigContext)
   const { profile } = useContext(UserContext)
+
+  if (!accountLayoutEnabled) {
+    return <Navigate to={getMyAccountPath()} replace />
+  }
+
   return (
     <Layout>
       <AccountLayout>

--- a/app/javascript/pages/account/settings.tsx
+++ b/app/javascript/pages/account/settings.tsx
@@ -43,6 +43,9 @@ import { AxiosError } from "axios"
 import { ErrorSummaryBanner } from "./components/ErrorSummaryBanner"
 import { ExpandedAccountAxiosError, getErrorMessage } from "./components/util"
 import { withAuthentication } from "../../authentication/withAuthentication"
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
+import { UNLEASH_FLAG } from "../../modules/constants"
+import MyAccountSettings from "./account-settings"
 
 const Banner = ({
   showBanner,
@@ -480,7 +483,17 @@ const AccountSettingsPage = () => {
   return <AccountSettings profile={profile} />
 }
 
-const Settings = () => {
+interface SettingsProps {
+  assetPaths: unknown
+}
+
+const Settings = ({ assetPaths }: SettingsProps) => {
+  const { unleashFlag: accountLayoutEnabled } = useFeatureFlag(UNLEASH_FLAG.ACCOUNTS_LAYOUT, false)
+
+  if (!accountLayoutEnabled) {
+    return <MyAccountSettings assetPaths={assetPaths} />
+  }
+
   return (
     <Layout>
       <AccountLayout>


### PR DESCRIPTION
## Description

Adds a client-side Unleash flag check for the new account layouts to display either the old or new React pages. To review, ensure you see the old accounts page with the flag off and the new accounts pages with the flag on. 

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag