### PR TITLE
fix: DAH-0000 Update relative path for reset email link

### DIFF
--- a/app/javascript/__tests__/api/authApiService.test.ts
+++ b/app/javascript/__tests__/api/authApiService.test.ts
@@ -102,7 +102,7 @@ describe("authApiService", () => {
       expect(post).toHaveBeenCalledWith(url, {
         email,
         locale: "en",
-        redirect_url: "/reset-password",
+        redirect_url: `${window.location.origin}/reset-password`,
       })
     })
   })

--- a/app/javascript/api/authApiService.ts
+++ b/app/javascript/api/authApiService.ts
@@ -61,7 +61,7 @@ export const deleteApplication = async (id: string) =>
 export const forgotPassword = async (email: string): Promise<string> =>
   post<{ message: string }>("/api/v1/auth/password", {
     email,
-    redirect_url: getResetPasswordPath(),
+    redirect_url: `${window.location.origin}${getResetPasswordPath()}`,
     locale: getCurrentLanguage(),
   }).then(({ data }) => data.message)
 


### PR DESCRIPTION
## Description

Reformats the email link for Devise Token Auth that directs to the reset password page. To review, verify the reset password flow works as expected. 

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag