### PR TITLE
feat: DAH-4190 Account layout breadcrumb navigation

### DIFF
--- a/app/javascript/layouts/AccountLayout.module.scss
+++ b/app/javascript/layouts/AccountLayout.module.scss
@@ -23,4 +23,19 @@
   flex: 1;
   min-width: 0;
   padding-top: var(--seeds-s7);
+  @media (max-width: theme("screens.md")) {
+    padding-top: 0;
+  }
+}
+
+.accountBreadcrumbs {
+  display: none;
+  @media (max-width: theme("screens.md")) {
+    display: block;
+    position: sticky;
+    z-index: 1;
+    top: 0;
+    background-color: var(--seeds-color-gray-300);
+    padding: var(--seeds-spacer-header);
+  }
 }

--- a/app/javascript/layouts/AccountLayout.tsx
+++ b/app/javascript/layouts/AccountLayout.tsx
@@ -1,14 +1,38 @@
 import React from "react"
 import AccountNav from "./AccountNav"
+import { Breadcrumbs, BreadcrumbLink, t } from "@bloom-housing/ui-components"
 import styles from "./AccountLayout.module.scss"
+import { getPathWithoutLanguagePrefix } from "../util/languageUtil"
+import { getMyAccountPath } from "../util/routeUtil"
 
 export interface AccountLayoutProps {
   children: React.ReactNode
 }
 
+const ACCOUNT_BREADCRUMB_LABELS: Record<string, string> = {
+  "/account/contact": "accountLayout.nav.contactInfo",
+  "/account/applications": "accountLayout.nav.applications",
+  "/account/settings": "accountSettings.title.sentenceCase",
+}
+
 const AccountLayout = ({ children }: AccountLayoutProps) => {
+  const breadcrumb =
+    ACCOUNT_BREADCRUMB_LABELS[getPathWithoutLanguagePrefix(window.location.pathname)]
+
   return (
     <div className={styles.accountLayoutBackground}>
+      {breadcrumb && (
+        <div className={styles.accountBreadcrumbs}>
+          <Breadcrumbs>
+            <BreadcrumbLink href={getMyAccountPath()}>
+              {t("accountLayout.nav.overview")}
+            </BreadcrumbLink>
+            <BreadcrumbLink href="" current>
+              {t(breadcrumb)}
+            </BreadcrumbLink>
+          </Breadcrumbs>
+        </div>
+      )}
       <div className={styles.accountLayout}>
         <AccountNav />
         <div className={styles.accountLayoutContent}>{children}</div>


### PR DESCRIPTION
## Description

Adds breadcrumb navigation to account layout mobile pages. 

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4190

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [x] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag