### PR TITLE
feat: DAH-4237 record the invite-to response on the client to filter email-scanner bot clicks

### DIFF
--- a/app/controllers/api/v1/invite_to_response_controller.rb
+++ b/app/controllers/api/v1/invite_to_response_controller.rb
@@ -32,6 +32,40 @@ class Api::V1::InviteToResponseController < ApiController
     render json: { error: 'Submit response error' }, status: :internal_server_error
   end
 
+  # Shadow-mode endpoint: records nothing to Salesforce or the backend. It only logs
+  # that the client-side human-detection judged this page view to be a real human, so
+  # we can compare against the server-side GET recording during the shadow rollout.
+  # Safe to call repeatedly.
+  def log_human_verified
+    params.expect(record: %i[type deadline appId listingId act trigger elapsedMs])
+    type, deadline, application_id, listing_id, act, trigger, elapsed_ms =
+      params[:record].values_at(:type, :deadline, :appId, :listingId, :act, :trigger,
+                                :elapsedMs)
+
+    # Values come from an unauthenticated public endpoint, so .inspect each one to
+    # neutralize newline/control-character log forging and make nil/blank values legible.
+    Rails.logger.info(
+      'InviteToResponseController#log_human_verified: ' \
+      'human-verified click (shadow, not recorded) ' \
+      "type=#{type.inspect}, " \
+      "listingId=#{listing_id.inspect}, " \
+      "deadline=#{deadline.inspect}, " \
+      "appId=#{application_id.inspect}, " \
+      "act=#{act.inspect}, " \
+      "trigger=#{trigger.inspect}, " \
+      "elapsedMs=#{elapsed_ms.inspect}",
+    )
+    render json: { success: true }, status: :ok
+  rescue ActionController::ParameterMissing => e
+    # Malformed client request, not a server fault - keep it out of 5xx error rates.
+    Rails.logger.warn("Log human-verified click bad request: #{e.message}")
+    render json: { error: 'Log human-verified click bad request' }, status: :bad_request
+  rescue StandardError => e
+    Rails.logger.error("Log human-verified click error: #{e.message}")
+    render json: { error: 'Log human-verified click error' },
+           status: :internal_server_error
+  end
+
   private
 
   def deadline_has_passed?(deadline)

--- a/app/controllers/api/v1/invite_to_response_controller.rb
+++ b/app/controllers/api/v1/invite_to_response_controller.rb
@@ -32,9 +32,10 @@ class Api::V1::InviteToResponseController < ApiController
     render json: { error: 'Submit response error' }, status: :internal_server_error
   end
 
-  # Shadow-mode endpoint: records nothing to Salesforce or the backend. It only logs
-  # that the client-side human-detection judged this page view to be a real human, so
-  # we can compare against the server-side GET recording during the shadow rollout.
+  # Shadow-mode endpoint: records nothing - it never calls sf-dahlia-backend, so no
+  # Salesforce state changes and no applicant email is sent. It only logs that the
+  # client-side human-detection judged this page view to be a real human, so we can
+  # compare against the server-side GET recording during the shadow rollout.
   # Safe to call repeatedly.
   def log_human_verified
     params.expect(record: %i[type deadline appId listingId act trigger elapsedMs])

--- a/app/controllers/invite_to_controller.rb
+++ b/app/controllers/invite_to_controller.rb
@@ -1,5 +1,7 @@
 # Invite to X controller
 class InviteToController < ApplicationController
+  CLIENT_RECORDING_FLAG = 'temp.webapp.inviteToClientRecording'
+
   before_action :ignore_head_requests
 
   def index
@@ -18,7 +20,25 @@ class InviteToController < ApplicationController
         schedulingUrl: application['leaseupAppointmentSchedulingURL'],
       )
     end
-    record_response(decoded_params)
+    # 'on'     - client is the source of truth; skip server-side recording entirely.
+    # 'shadow' - keep recording server-side (unchanged behavior) but let the client run
+    #            its human-detection in parallel and log-only, so we can measure it
+    #            against real traffic before flipping to 'on'.
+    # 'off'    - legacy behavior: record server-side on GET.
+    if client_recording_mode == 'on'
+      # Resolve act/appId the same way props() does, so legacy links carrying
+      # 'response'/'applicationNumber' don't log misleading nils.
+      act = decoded_params['act'] || decoded_params['response']
+      app_id = decoded_params['appId'] || decoded_params['applicationNumber']
+      Rails.logger.info(
+        'InviteToController#index: *NOT* recording server-side, deferring to client ' \
+        "act=#{act.inspect}, " \
+        "appId=#{app_id.inspect}, " \
+        "deadline=#{decoded_params['deadline'].inspect}",
+      )
+    else
+      record_response(decoded_params)
+    end
     render 'invite_to'
   end
 
@@ -57,8 +77,26 @@ class InviteToController < ApplicationController
     {
       assetPaths: static_asset_paths,
       urlParams: url_params,
+      clientRecordingMode: client_recording_mode,
       submitPreviewLinkTokenParam: encode_token(url_params.except(:act, :response)),
     }.compact
+  end
+
+  # Resolves the rollout state of the client-side recording feature from the
+  # 'temp.webapp.inviteToClientRecording' Unleash flag:
+  #   flag disabled                       -> 'off'    (legacy server-side recording)
+  #   flag enabled, variant 'shadow'      -> 'shadow' (server records; client detects + logs)
+  #   flag enabled, any other/no variant  -> 'on'     (client records; server does not)
+  def client_recording_mode
+    return @client_recording_mode if defined?(@client_recording_mode)
+
+    @client_recording_mode =
+      if Rails.configuration.unleash.is_enabled?(CLIENT_RECORDING_FLAG)
+        variant = Rails.configuration.unleash.get_variant(CLIENT_RECORDING_FLAG)
+        variant&.name == 'shadow' ? 'shadow' : 'on'
+      else
+        'off'
+      end
   end
 
   def record_response(decoded_params)

--- a/app/controllers/invite_to_controller.rb
+++ b/app/controllers/invite_to_controller.rb
@@ -20,25 +20,12 @@ class InviteToController < ApplicationController
         schedulingUrl: application['leaseupAppointmentSchedulingURL'],
       )
     end
-    # 'on'     - client is the source of truth; skip server-side recording entirely.
-    # 'shadow' - keep recording server-side (unchanged behavior) but let the client run
-    #            its human-detection in parallel and log-only, so we can measure it
-    #            against real traffic before flipping to 'on'.
-    # 'off'    - legacy behavior: record server-side on GET.
-    if client_recording_mode == 'on'
-      # Resolve act/appId the same way props() does, so legacy links carrying
-      # 'response'/'applicationNumber' don't log misleading nils.
-      act = decoded_params['act'] || decoded_params['response']
-      app_id = decoded_params['appId'] || decoded_params['applicationNumber']
-      Rails.logger.info(
-        'InviteToController#index: *NOT* recording server-side, deferring to client ' \
-        "act=#{act.inspect}, " \
-        "appId=#{app_id.inspect}, " \
-        "deadline=#{decoded_params['deadline'].inspect}",
-      )
-    else
-      record_response(decoded_params)
-    end
+    # Recording always happens server-side on GET for now. When the flag is enabled the
+    # client additionally runs its human-detection in parallel and logs only ('shadow'),
+    # so we can measure bot vs. human clicks against real traffic. Moving the recording
+    # to the client is deferred until
+    # https://github.com/SFDigitalServices/sf-dahlia-web/pull/2993 lands.
+    record_response(decoded_params)
     render 'invite_to'
   end
 
@@ -84,19 +71,14 @@ class InviteToController < ApplicationController
 
   # Resolves the rollout state of the client-side recording feature from the
   # 'temp.webapp.inviteToClientRecording' Unleash flag:
-  #   flag disabled                       -> 'off'    (legacy server-side recording)
-  #   flag enabled, variant 'shadow'      -> 'shadow' (server records; client detects + logs)
-  #   flag enabled, any other/no variant  -> 'on'     (client records; server does not)
+  #   flag disabled -> 'off'    (client hook inert)
+  #   flag enabled  -> 'shadow' (server records on GET; client detects humans, logs only)
+  # There is deliberately no 'on' (client-records) state yet - see PR #2993.
   def client_recording_mode
     return @client_recording_mode if defined?(@client_recording_mode)
 
     @client_recording_mode =
-      if Rails.configuration.unleash.is_enabled?(CLIENT_RECORDING_FLAG)
-        variant = Rails.configuration.unleash.get_variant(CLIENT_RECORDING_FLAG)
-        variant&.name == 'shadow' ? 'shadow' : 'on'
-      else
-        'off'
-      end
+      Rails.configuration.unleash.is_enabled?(CLIENT_RECORDING_FLAG) ? 'shadow' : 'off'
   end
 
   def record_response(decoded_params)

--- a/app/javascript/__tests__/__util__/renderUtils.tsx
+++ b/app/javascript/__tests__/__util__/renderUtils.tsx
@@ -32,17 +32,21 @@ export const restoreWindowLocation = (originalLocation: typeof window.location):
  *
  * This is useful when a component loads in data with a useEffect()
  * hook.
+ *
+ * By default the MemoryRouter starts at "/" - pass `initialEntries` to render
+ * under a specific path (e.g. for components that parse an id out of the URL).
  */
 export const renderAndLoadAsync = async (
   ui: React.ReactElement,
-  options?: Omit<RenderOptions, "queries">
+  options?: Omit<RenderOptions, "queries">,
+  initialEntries: string[] = ["/"]
 ): Promise<RenderResult> => {
   let renderResponse: RenderResult = {} as RenderResult
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderResponse = render(ui, {
       wrapper: ({ children }: { children: React.ReactNode }) => (
-        <MemoryRouter>{children}</MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
       ),
       ...options,
     }) as RenderResult

--- a/app/javascript/__tests__/api/inviteToApiService.test.ts
+++ b/app/javascript/__tests__/api/inviteToApiService.test.ts
@@ -1,5 +1,5 @@
 import { post } from "../../api/apiService"
-import { recordResponse } from "../../api/inviteToApiService"
+import { recordResponse, logHumanVerifiedClick } from "../../api/inviteToApiService"
 import { INVITE_TO_X } from "../../modules/constants"
 
 jest.mock("../../api/apiService", () => ({
@@ -21,6 +21,22 @@ describe("inviteToApiService", () => {
       }
       await recordResponse(record)
       expect(post).toHaveBeenCalled()
+    })
+  })
+
+  describe("logHumanVerifiedClick", () => {
+    it("calls apiService post", async () => {
+      const record = {
+        listingId: "a0w123",
+        appId: "a0o123",
+        deadline: "2099-01-01",
+        act: "yes",
+        type: INVITE_TO_X.APPLY,
+        trigger: "interaction",
+        elapsedMs: 1234,
+      }
+      await logHumanVerifiedClick(record)
+      expect(post).toHaveBeenCalledWith("/api/v1/next-steps/log-human-verified", { record })
     })
   })
 })

--- a/app/javascript/__tests__/hooks/useAutoRecordInviteToResponse.test.tsx
+++ b/app/javascript/__tests__/hooks/useAutoRecordInviteToResponse.test.tsx
@@ -1,0 +1,260 @@
+import { renderHook, cleanup } from "@testing-library/react"
+import { useAutoRecordInviteToResponse } from "../../hooks/useAutoRecordInviteToResponse"
+import { recordResponse, logHumanVerifiedClick } from "../../api/inviteToApiService"
+
+jest.mock("../../api/inviteToApiService", () => ({
+  recordResponse: jest.fn(),
+  logHumanVerifiedClick: jest.fn(),
+}))
+
+const setVisibility = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  })
+}
+
+const fireVisibilityChange = () => {
+  document.dispatchEvent(new Event("visibilitychange"))
+}
+
+const flushRenderGateFrames = () => {
+  // Two nested requestAnimationFrame calls need to resolve.
+  jest.advanceTimersByTime(100)
+}
+
+const baseArgs = {
+  enabled: true,
+  act: "yes" as const,
+  appId: "app-1",
+  listingId: "listing-1",
+  deadline: "3000-01-01",
+  type: "I2A",
+}
+
+describe("useAutoRecordInviteToResponse", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+    sessionStorage.clear()
+    setVisibility("visible")
+    ;(recordResponse as jest.Mock).mockResolvedValue(undefined)
+    ;(logHumanVerifiedClick as jest.Mock).mockResolvedValue(undefined)
+    jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it("fires recordResponse once after the dwell timer when visible", () => {
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(2000)
+
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+    expect(recordResponse).toHaveBeenCalledWith({
+      appId: "app-1",
+      applicationNumber: "app-1",
+      listingId: "listing-1",
+      deadline: "3000-01-01",
+      action: "yes",
+      response: "yes",
+      type: "I2A",
+    })
+  })
+
+  it("fires early on pointermove before the dwell timer elapses, only once", () => {
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+
+    flushRenderGateFrames()
+    window.dispatchEvent(new Event("pointermove"))
+
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+
+    // Advancing past the dwell time should not cause a second call.
+    jest.advanceTimersByTime(2000)
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire while hidden; fires after visibilitychange to visible + dwell", () => {
+    setVisibility("hidden")
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+
+    setVisibility("visible")
+    fireVisibilityChange()
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(2000)
+
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire when enabled is false", () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, enabled: false }))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+
+  it("does not fire when act is missing", () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, act: undefined }))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when act is "submit"', () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, act: "submit" }))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+
+  it("does not fire when deadline has passed", () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, deadline: "2000-01-01" }))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+
+  it("does not fire when the sessionStorage guard is already set", () => {
+    sessionStorage.setItem(`i2x-recorded-${baseArgs.appId}-${baseArgs.act}`, "true")
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+
+  it("sets the sessionStorage guard so a remount does not fire again", () => {
+    const { unmount } = renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(2000)
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+    expect(sessionStorage.getItem(`i2x-recorded-${baseArgs.appId}-${baseArgs.act}`)).toBe("true")
+    unmount()
+
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+  })
+
+  describe("shadow mode", () => {
+    const shadowArgs = { ...baseArgs, mode: "shadow" as const }
+
+    it("fires logHumanVerifiedClick (not recordResponse) after dwell, with trigger and elapsed", () => {
+      renderHook(() => useAutoRecordInviteToResponse(shadowArgs))
+
+      flushRenderGateFrames()
+      jest.advanceTimersByTime(2000)
+
+      expect(recordResponse).not.toHaveBeenCalled()
+      expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
+      expect(logHumanVerifiedClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: "app-1",
+          listingId: "listing-1",
+          deadline: "3000-01-01",
+          act: "yes",
+          type: "I2A",
+          trigger: "dwell",
+        })
+      )
+    })
+
+    it("reports trigger 'interaction' when fired by a user event", () => {
+      renderHook(() => useAutoRecordInviteToResponse(shadowArgs))
+
+      flushRenderGateFrames()
+      window.dispatchEvent(new Event("pointermove"))
+
+      expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
+      expect(logHumanVerifiedClick).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: "interaction" })
+      )
+    })
+
+    it("uses a shadow-specific guard so an on-mode remount can still record", () => {
+      const { unmount } = renderHook(() => useAutoRecordInviteToResponse(shadowArgs))
+      flushRenderGateFrames()
+      jest.advanceTimersByTime(2000)
+      expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
+      expect(sessionStorage.getItem(`i2x-shadow-${baseArgs.appId}-${baseArgs.act}`)).toBe("true")
+      unmount()
+
+      renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, mode: "on" }))
+      flushRenderGateFrames()
+      jest.advanceTimersByTime(2000)
+      expect(recordResponse).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not fire when mode is "off"', () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, mode: "off" }))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
+  })
+
+  it("proceeds and fires when sessionStorage access throws (private mode)", () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked")
+    })
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked")
+    })
+
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(2000)
+
+    expect(recordResponse).toHaveBeenCalledTimes(1)
+    getItemSpy.mockRestore()
+  })
+
+  it("logs an error when the record request rejects", async () => {
+    ;(recordResponse as jest.Mock).mockRejectedValueOnce(new Error("api fail"))
+
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(2000)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Error auto-recording invite-to response:",
+      expect.any(Error)
+    )
+  })
+
+  it("resets the fire conditions when the page becomes hidden again before firing", () => {
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames() // arms while visible
+
+    setVisibility("hidden")
+    fireVisibilityChange() // else branch: clears the dwell timer + listeners
+
+    jest.advanceTimersByTime(5000)
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+
+  it("cleans up on unmount before dwell elapses with no call and no leaked listeners/timers", () => {
+    const { unmount } = renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+    flushRenderGateFrames()
+    unmount()
+
+    expect(() => {
+      jest.advanceTimersByTime(5000)
+      window.dispatchEvent(new Event("pointermove"))
+    }).not.toThrow()
+    expect(recordResponse).not.toHaveBeenCalled()
+  })
+})

--- a/app/javascript/__tests__/hooks/useAutoRecordInviteToResponse.test.tsx
+++ b/app/javascript/__tests__/hooks/useAutoRecordInviteToResponse.test.tsx
@@ -36,9 +36,7 @@ describe("useAutoRecordInviteToResponse", () => {
   beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
-    sessionStorage.clear()
     setVisibility("visible")
-    ;(recordResponse as jest.Mock).mockResolvedValue(undefined)
     ;(logHumanVerifiedClick as jest.Mock).mockResolvedValue(undefined)
     jest.spyOn(console, "error").mockImplementation(() => {})
   })
@@ -50,22 +48,32 @@ describe("useAutoRecordInviteToResponse", () => {
     jest.restoreAllMocks()
   })
 
-  it("fires recordResponse once after the dwell timer when visible", () => {
+  it("logs the human-verified click once after the dwell timer when visible", () => {
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
 
     flushRenderGateFrames()
     jest.advanceTimersByTime(2000)
 
-    expect(recordResponse).toHaveBeenCalledTimes(1)
-    expect(recordResponse).toHaveBeenCalledWith({
-      appId: "app-1",
-      applicationNumber: "app-1",
-      listingId: "listing-1",
-      deadline: "3000-01-01",
-      action: "yes",
-      response: "yes",
-      type: "I2A",
-    })
+    expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
+    expect(logHumanVerifiedClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "app-1",
+        listingId: "listing-1",
+        deadline: "3000-01-01",
+        act: "yes",
+        type: "I2A",
+        trigger: "dwell",
+      })
+    )
+  })
+
+  it("never records the response (recording stays server-side for now)", () => {
+    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
+
+    flushRenderGateFrames()
+    jest.advanceTimersByTime(5000)
+
+    expect(recordResponse).not.toHaveBeenCalled()
   })
 
   it("fires early on pointermove before the dwell timer elapses, only once", () => {
@@ -74,11 +82,14 @@ describe("useAutoRecordInviteToResponse", () => {
     flushRenderGateFrames()
     window.dispatchEvent(new Event("pointermove"))
 
-    expect(recordResponse).toHaveBeenCalledTimes(1)
+    expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
+    expect(logHumanVerifiedClick).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: "interaction" })
+    )
 
     // Advancing past the dwell time should not cause a second call.
     jest.advanceTimersByTime(2000)
-    expect(recordResponse).toHaveBeenCalledTimes(1)
+    expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
   })
 
   it("does not fire while hidden; fires after visibilitychange to visible + dwell", () => {
@@ -86,142 +97,59 @@ describe("useAutoRecordInviteToResponse", () => {
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
 
     jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
 
     setVisibility("visible")
     fireVisibilityChange()
     flushRenderGateFrames()
     jest.advanceTimersByTime(2000)
 
-    expect(recordResponse).toHaveBeenCalledTimes(1)
+    expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
   })
 
   it("does not fire when enabled is false", () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, enabled: false }))
     flushRenderGateFrames()
     jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it("does not fire when act is missing", () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, act: undefined }))
     flushRenderGateFrames()
     jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it('does not fire when act is "submit"', () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, act: "submit" }))
     flushRenderGateFrames()
     jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it("does not fire when deadline has passed", () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, deadline: "2000-01-01" }))
     flushRenderGateFrames()
     jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
-  it("does not fire when the sessionStorage guard is already set", () => {
-    sessionStorage.setItem(`i2x-recorded-${baseArgs.appId}-${baseArgs.act}`, "true")
-    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames()
-    jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
-  })
-
-  it("sets the sessionStorage guard so a remount does not fire again", () => {
+  it("logs again on a remount (no session guard, so repeat loads stay visible in logs)", () => {
     const { unmount } = renderHook(() => useAutoRecordInviteToResponse(baseArgs))
     flushRenderGateFrames()
     jest.advanceTimersByTime(2000)
-    expect(recordResponse).toHaveBeenCalledTimes(1)
-    expect(sessionStorage.getItem(`i2x-recorded-${baseArgs.appId}-${baseArgs.act}`)).toBe("true")
+    expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
     unmount()
 
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
     flushRenderGateFrames()
-    jest.advanceTimersByTime(5000)
-    expect(recordResponse).toHaveBeenCalledTimes(1)
-  })
-
-  describe("shadow mode", () => {
-    const shadowArgs = { ...baseArgs, mode: "shadow" as const }
-
-    it("fires logHumanVerifiedClick (not recordResponse) after dwell, with trigger and elapsed", () => {
-      renderHook(() => useAutoRecordInviteToResponse(shadowArgs))
-
-      flushRenderGateFrames()
-      jest.advanceTimersByTime(2000)
-
-      expect(recordResponse).not.toHaveBeenCalled()
-      expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
-      expect(logHumanVerifiedClick).toHaveBeenCalledWith(
-        expect.objectContaining({
-          appId: "app-1",
-          listingId: "listing-1",
-          deadline: "3000-01-01",
-          act: "yes",
-          type: "I2A",
-          trigger: "dwell",
-        })
-      )
-    })
-
-    it("reports trigger 'interaction' when fired by a user event", () => {
-      renderHook(() => useAutoRecordInviteToResponse(shadowArgs))
-
-      flushRenderGateFrames()
-      window.dispatchEvent(new Event("pointermove"))
-
-      expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
-      expect(logHumanVerifiedClick).toHaveBeenCalledWith(
-        expect.objectContaining({ trigger: "interaction" })
-      )
-    })
-
-    it("uses a shadow-specific guard so an on-mode remount can still record", () => {
-      const { unmount } = renderHook(() => useAutoRecordInviteToResponse(shadowArgs))
-      flushRenderGateFrames()
-      jest.advanceTimersByTime(2000)
-      expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
-      expect(sessionStorage.getItem(`i2x-shadow-${baseArgs.appId}-${baseArgs.act}`)).toBe("true")
-      unmount()
-
-      renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, mode: "on" }))
-      flushRenderGateFrames()
-      jest.advanceTimersByTime(2000)
-      expect(recordResponse).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  it('does not fire when mode is "off"', () => {
-    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, mode: "off" }))
-    flushRenderGateFrames()
-    jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
-    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
-  })
-
-  it("proceeds and fires when sessionStorage access throws (private mode)", () => {
-    const getItemSpy = jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("storage blocked")
-    })
-    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-      throw new Error("storage blocked")
-    })
-
-    renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames()
     jest.advanceTimersByTime(2000)
-
-    expect(recordResponse).toHaveBeenCalledTimes(1)
-    getItemSpy.mockRestore()
+    expect(logHumanVerifiedClick).toHaveBeenCalledTimes(2)
   })
 
-  it("logs an error when the record request rejects", async () => {
-    ;(recordResponse as jest.Mock).mockRejectedValueOnce(new Error("api fail"))
+  it("logs an error when the log request rejects", async () => {
+    ;(logHumanVerifiedClick as jest.Mock).mockRejectedValueOnce(new Error("api fail"))
 
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
     flushRenderGateFrames()
@@ -230,7 +158,7 @@ describe("useAutoRecordInviteToResponse", () => {
     await Promise.resolve()
 
     expect(console.error).toHaveBeenCalledWith(
-      "Error auto-recording invite-to response:",
+      "Error logging human-verified invite-to click:",
       expect.any(Error)
     )
   })
@@ -243,7 +171,7 @@ describe("useAutoRecordInviteToResponse", () => {
     fireVisibilityChange() // else branch: clears the dwell timer + listeners
 
     jest.advanceTimersByTime(5000)
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it("cleans up on unmount before dwell elapses with no call and no leaked listeners/timers", () => {
@@ -255,6 +183,6 @@ describe("useAutoRecordInviteToResponse", () => {
       jest.advanceTimersByTime(5000)
       window.dispatchEvent(new Event("pointermove"))
     }).not.toThrow()
-    expect(recordResponse).not.toHaveBeenCalled()
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 })

--- a/app/javascript/__tests__/hooks/useAutoRecordInviteToResponse.test.tsx
+++ b/app/javascript/__tests__/hooks/useAutoRecordInviteToResponse.test.tsx
@@ -18,13 +18,13 @@ const fireVisibilityChange = () => {
   document.dispatchEvent(new Event("visibilitychange"))
 }
 
-const flushRenderGateFrames = () => {
+const flushPaintFrames = () => {
   // Two nested requestAnimationFrame calls need to resolve.
   jest.advanceTimersByTime(100)
 }
 
 const baseArgs = {
-  enabled: true,
+  mode: "shadow" as const,
   act: "yes" as const,
   appId: "app-1",
   listingId: "listing-1",
@@ -51,7 +51,7 @@ describe("useAutoRecordInviteToResponse", () => {
   it("logs the human-verified click once after the dwell timer when visible", () => {
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
 
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(2000)
 
     expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
@@ -70,7 +70,7 @@ describe("useAutoRecordInviteToResponse", () => {
   it("never records the response (recording stays server-side for now)", () => {
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
 
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(5000)
 
     expect(recordResponse).not.toHaveBeenCalled()
@@ -79,7 +79,7 @@ describe("useAutoRecordInviteToResponse", () => {
   it("fires early on pointermove before the dwell timer elapses, only once", () => {
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
 
-    flushRenderGateFrames()
+    flushPaintFrames()
     window.dispatchEvent(new Event("pointermove"))
 
     expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
@@ -101,49 +101,70 @@ describe("useAutoRecordInviteToResponse", () => {
 
     setVisibility("visible")
     fireVisibilityChange()
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(2000)
 
     expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
   })
 
-  it("does not fire when enabled is false", () => {
-    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, enabled: false }))
-    flushRenderGateFrames()
+  it('does not fire when mode is "off"', () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, mode: "off" }))
+    flushPaintFrames()
+    jest.advanceTimersByTime(5000)
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
+  })
+
+  it("does not fire when the mode prop is absent", () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, mode: undefined }))
+    flushPaintFrames()
+    jest.advanceTimersByTime(5000)
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
+  })
+
+  it("does not fire for a test/preview link", () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, isTest: true }))
+    flushPaintFrames()
+    jest.advanceTimersByTime(5000)
+    expect(logHumanVerifiedClick).not.toHaveBeenCalled()
+  })
+
+  it("does not fire on the documents page", () => {
+    renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, documentsPath: true }))
+    flushPaintFrames()
     jest.advanceTimersByTime(5000)
     expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it("does not fire when act is missing", () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, act: undefined }))
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(5000)
     expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it('does not fire when act is "submit"', () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, act: "submit" }))
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(5000)
     expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it("does not fire when deadline has passed", () => {
     renderHook(() => useAutoRecordInviteToResponse({ ...baseArgs, deadline: "2000-01-01" }))
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(5000)
     expect(logHumanVerifiedClick).not.toHaveBeenCalled()
   })
 
   it("logs again on a remount (no session guard, so repeat loads stay visible in logs)", () => {
     const { unmount } = renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(2000)
     expect(logHumanVerifiedClick).toHaveBeenCalledTimes(1)
     unmount()
 
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(2000)
     expect(logHumanVerifiedClick).toHaveBeenCalledTimes(2)
   })
@@ -152,7 +173,7 @@ describe("useAutoRecordInviteToResponse", () => {
     ;(logHumanVerifiedClick as jest.Mock).mockRejectedValueOnce(new Error("api fail"))
 
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames()
+    flushPaintFrames()
     jest.advanceTimersByTime(2000)
     await Promise.resolve()
     await Promise.resolve()
@@ -165,7 +186,7 @@ describe("useAutoRecordInviteToResponse", () => {
 
   it("resets the fire conditions when the page becomes hidden again before firing", () => {
     renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames() // arms while visible
+    flushPaintFrames() // arms while visible
 
     setVisibility("hidden")
     fireVisibilityChange() // else branch: clears the dwell timer + listeners
@@ -176,7 +197,7 @@ describe("useAutoRecordInviteToResponse", () => {
 
   it("cleans up on unmount before dwell elapses with no call and no leaked listeners/timers", () => {
     const { unmount } = renderHook(() => useAutoRecordInviteToResponse(baseArgs))
-    flushRenderGateFrames()
+    flushPaintFrames()
     unmount()
 
     expect(() => {

--- a/app/javascript/__tests__/pages/invite-to-apply.test.tsx
+++ b/app/javascript/__tests__/pages/invite-to-apply.test.tsx
@@ -14,6 +14,7 @@ import { INVITE_TO_X } from "../../modules/constants"
 jest.mock("../../api/listingApiService")
 jest.mock("../../api/inviteToApiService", () => ({
   recordResponse: jest.fn(),
+  logHumanVerifiedClick: jest.fn(),
 }))
 jest.mock("../../hooks/useFeatureFlag", () => ({
   useFeatureFlag: () => ({
@@ -238,13 +239,13 @@ describe("Invite to Apply", () => {
       expect(recordResponse).toHaveBeenCalledTimes(1)
     })
 
-    it("arms client-side auto-recording when clientRecordingMode is not off", async () => {
+    it("arms client-side human detection when clientRecordingMode is not off", async () => {
       // Exercises the full `enabled` gate in invite-to.tsx (clientRecordingMode + type/deadline
       // checks) rather than short-circuiting at the default "off".
       await renderWithContext(
         <InviteToPage
           assetPaths={"/"}
-          clientRecordingMode="on"
+          clientRecordingMode="shadow"
           urlParams={{
             type: INVITE_TO_X.APPLY,
             deadline: mockFutureDeadline,

--- a/app/javascript/__tests__/pages/invite-to-apply.test.tsx
+++ b/app/javascript/__tests__/pages/invite-to-apply.test.tsx
@@ -238,6 +238,30 @@ describe("Invite to Apply", () => {
       expect(recordResponse).toHaveBeenCalledTimes(1)
     })
 
+    it("arms client-side auto-recording when clientRecordingMode is not off", async () => {
+      // Exercises the full `enabled` gate in invite-to.tsx (clientRecordingMode + type/deadline
+      // checks) rather than short-circuiting at the default "off".
+      await renderWithContext(
+        <InviteToPage
+          assetPaths={"/"}
+          clientRecordingMode="on"
+          urlParams={{
+            type: INVITE_TO_X.APPLY,
+            deadline: mockFutureDeadline,
+            act: "yes",
+            appId: "a0o123",
+          }}
+        />
+      )
+      expect(
+        screen.getByText(
+          t("inviteToApplyPage.submitYourInfo.deadline", {
+            day: localizedFormat(mockFutureDeadline, "ll"),
+          })
+        )
+      ).toBeInTheDocument()
+    })
+
     it("does not call recordResponse when submit is clicked and isTest is true", async () => {
       await renderWithContext(
         <InviteToPage

--- a/app/javascript/__tests__/pages/invite-to-apply.test.tsx
+++ b/app/javascript/__tests__/pages/invite-to-apply.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import "@testing-library/jest-dom"
 import { t } from "@bloom-housing/ui-components"
@@ -7,7 +7,7 @@ import InviteToPage from "../../pages/inviteTo/invite-to"
 import { renderAndLoadAsync } from "../__util__/renderUtils"
 import { localizedFormat } from "../../util/languageUtil"
 import { getListing } from "../../api/listingApiService"
-import { recordResponse } from "../../api/inviteToApiService"
+import { recordResponse, logHumanVerifiedClick } from "../../api/inviteToApiService"
 import { ConfigContext } from "../../lib/ConfigContext"
 import { INVITE_TO_X } from "../../modules/constants"
 
@@ -60,9 +60,11 @@ const mockConfigContext = {
   listingsAlertUrl: "/",
 }
 
-const renderWithContext = async (component: React.ReactElement) => {
+const renderWithContext = async (component: React.ReactElement, initialEntries?: string[]) => {
   return renderAndLoadAsync(
-    <ConfigContext.Provider value={mockConfigContext}>{component}</ConfigContext.Provider>
+    <ConfigContext.Provider value={mockConfigContext}>{component}</ConfigContext.Provider>,
+    undefined,
+    initialEntries
   )
 }
 
@@ -241,7 +243,10 @@ describe("Invite to Apply", () => {
 
     it("arms client-side human detection when clientRecordingMode is not off", async () => {
       // Exercises the full `enabled` gate in invite-to.tsx (clientRecordingMode + type/deadline
-      // checks) rather than short-circuiting at the default "off".
+      // checks) rather than short-circuiting at the default "off". Needs a listing id in the
+      // URL, or invite-to.tsx's listingId is undefined and the hook's enable gate never opens.
+      ;(logHumanVerifiedClick as jest.Mock).mockResolvedValue(undefined)
+
       await renderWithContext(
         <InviteToPage
           assetPaths={"/"}
@@ -252,15 +257,27 @@ describe("Invite to Apply", () => {
             act: "yes",
             appId: "a0o123",
           }}
-        />
+        />,
+        ["/en/listings/listing-id/next-steps"]
       )
-      expect(
-        screen.getByText(
-          t("inviteToApplyPage.submitYourInfo.deadline", {
-            day: localizedFormat(mockFutureDeadline, "ll"),
+
+      // The hook only registers its interaction listeners after two animation frames have
+      // elapsed (its paint gate), so wait for those before dispatching.
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+      window.dispatchEvent(new Event("pointermove"))
+
+      await waitFor(() => {
+        expect(logHumanVerifiedClick).toHaveBeenCalledWith(
+          expect.objectContaining({
+            appId: "a0o123",
+            listingId: "listing-id",
+            deadline: mockFutureDeadline,
+            act: "yes",
+            type: INVITE_TO_X.APPLY,
+            trigger: "interaction",
           })
         )
-      ).toBeInTheDocument()
+      })
     })
 
     it("does not call recordResponse when submit is clicked and isTest is true", async () => {

--- a/app/javascript/api/inviteToApiService.ts
+++ b/app/javascript/api/inviteToApiService.ts
@@ -11,3 +11,17 @@ export const recordResponse = async (record: {
 }) => {
   return post("/api/v1/next-steps/record-response", { record })
 }
+
+// Shadow-mode only: records nothing, just logs that client-side detection judged this a real
+// human click. Used to measure the detection against live traffic before enabling client recording.
+export const logHumanVerifiedClick = async (record: {
+  listingId: string
+  appId: string
+  deadline: string
+  act: string
+  type: string
+  trigger: string
+  elapsedMs: number
+}) => {
+  return post("/api/v1/next-steps/log-human-verified", { record })
+}

--- a/app/javascript/hooks/useAutoRecordInviteToResponse.ts
+++ b/app/javascript/hooks/useAutoRecordInviteToResponse.ts
@@ -1,0 +1,213 @@
+import { useEffect } from "react"
+import { recordResponse, logHumanVerifiedClick } from "../api/inviteToApiService"
+import { isDeadlinePassed } from "../util/listingUtil"
+
+const INTERACTION_EVENTS = [
+  "pointermove",
+  "pointerdown",
+  "touchstart",
+  "keydown",
+  "scroll",
+] as const
+
+export type ClientRecordingMode = "off" | "shadow" | "on"
+
+interface UseAutoRecordInviteToResponseArgs {
+  enabled: boolean
+  // "on" fires the real recordResponse; "shadow" fires a log-only call (server still records on GET).
+  mode?: ClientRecordingMode
+  act?: "yes" | "no" | "contact" | "submit" | "appointment"
+  appId?: string
+  listingId?: string
+  deadline?: string
+  type?: string
+  dwellMs?: number
+}
+
+const AUTO_RECORD_ACTS = new Set(["yes", "no", "contact"])
+
+// Shadow and on modes use distinct guard keys so a session that later flips from shadow to on
+// still records for real (the shadow call must not block the real one).
+const guardKey = (appId: string, act: string, mode: ClientRecordingMode) =>
+  mode === "shadow" ? `i2x-shadow-${appId}-${act}` : `i2x-recorded-${appId}-${act}`
+
+const isGuardSet = (key: string) => {
+  try {
+    return sessionStorage.getItem(key) === "true"
+  } catch {
+    return false
+  }
+}
+
+const setGuard = (key: string) => {
+  try {
+    sessionStorage.setItem(key, "true")
+  } catch {
+    // Ignore private-mode / storage-disabled failures; server-side dedup is the backstop.
+  }
+}
+
+/**
+ * Automatically records an applicant's response to an invite-to-apply/interview email link
+ * once the page has genuinely been seen by a human, gating out email-scanner-bot prefetches.
+ *
+ * In `mode: "on"` it fires the real `recordResponse`; in `mode: "shadow"` it fires a log-only
+ * `logHumanVerifiedClick` (the server still records on GET) so the detection can be measured
+ * against live traffic. Fires exactly once when all of the following hold:
+ *  - `enabled` is true (caller is responsible for computing this, including the
+ *    client-recording mode, `act`, `isTest`, `documentsPath`, and deadline checks)
+ *  - the document is visible
+ *  - two animation frames have elapsed while visible (a real paint happened)
+ *  - either a first user interaction occurs, or `dwellMs` of continuous visibility elapses
+ *    (whichever comes first)
+ */
+export const useAutoRecordInviteToResponse = ({
+  enabled,
+  mode = "on",
+  act,
+  appId,
+  listingId,
+  deadline,
+  type,
+  dwellMs = 2000,
+}: UseAutoRecordInviteToResponseArgs) => {
+  useEffect(() => {
+    if (
+      !enabled ||
+      mode === "off" ||
+      !act ||
+      !AUTO_RECORD_ACTS.has(act) ||
+      !appId ||
+      !listingId ||
+      !type ||
+      !deadline ||
+      isDeadlinePassed(deadline)
+    ) {
+      return undefined
+    }
+
+    const key = guardKey(appId, act, mode)
+    if (isGuardSet(key)) {
+      return undefined
+    }
+
+    // Set when the fire conditions actually arm (after the render gate, while visible), so
+    // elapsedMs reflects visible dwell/interaction time and excludes hidden/background-tab time.
+    let armedAt = 0
+    let fired = false
+    let dwellTimeoutId: ReturnType<typeof setTimeout> | null = null
+    let visibilityRafId1: number | null = null
+    let visibilityRafId2: number | null = null
+
+    const clearDwellTimer = () => {
+      if (dwellTimeoutId !== null) {
+        clearTimeout(dwellTimeoutId)
+        dwellTimeoutId = null
+      }
+    }
+
+    const clearRenderGateFrames = () => {
+      if (visibilityRafId1 !== null) {
+        cancelAnimationFrame(visibilityRafId1)
+        visibilityRafId1 = null
+      }
+      if (visibilityRafId2 !== null) {
+        cancelAnimationFrame(visibilityRafId2)
+        visibilityRafId2 = null
+      }
+    }
+
+    const removeInteractionListeners = () => {
+      INTERACTION_EVENTS.forEach((eventName) => {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive with fire()
+        window.removeEventListener(eventName, handleInteraction)
+      })
+    }
+
+    const cleanup = () => {
+      clearDwellTimer()
+      clearRenderGateFrames()
+      removeInteractionListeners()
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define -- registered further down
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+
+    const fire = (trigger: "interaction" | "dwell") => {
+      if (fired) return
+      fired = true
+      cleanup()
+      setGuard(key)
+      const elapsedMs = Date.now() - armedAt
+      const request =
+        mode === "shadow"
+          ? logHumanVerifiedClick({
+              appId,
+              listingId,
+              deadline,
+              act,
+              type,
+              trigger,
+              elapsedMs,
+            })
+          : recordResponse({
+              appId,
+              applicationNumber: appId,
+              listingId,
+              deadline,
+              action: act,
+              response: act,
+              type,
+            })
+      void request.catch((error) => {
+        console.error("Error auto-recording invite-to response:", error)
+      })
+    }
+
+    const handleInteraction = () => {
+      fire("interaction")
+    }
+
+    const armFireConditions = () => {
+      armedAt = Date.now()
+      INTERACTION_EVENTS.forEach((eventName) => {
+        window.addEventListener(eventName, handleInteraction, { passive: true, once: true })
+      })
+      dwellTimeoutId = setTimeout(() => {
+        fire("dwell")
+      }, dwellMs)
+    }
+
+    const startRenderGate = () => {
+      visibilityRafId1 = requestAnimationFrame(() => {
+        visibilityRafId2 = requestAnimationFrame(() => {
+          if (document.visibilityState === "visible") {
+            armFireConditions()
+          }
+        })
+      })
+    }
+
+    const handleVisibilityChange = () => {
+      if (fired) return
+      if (document.visibilityState === "visible") {
+        clearRenderGateFrames()
+        startRenderGate()
+      } else {
+        // Page hidden again before firing - pause/reset everything.
+        clearRenderGateFrames()
+        clearDwellTimer()
+        removeInteractionListeners()
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    if (document.visibilityState === "visible") {
+      startRenderGate()
+    }
+
+    return cleanup
+  }, [enabled, mode, act, appId, listingId, deadline, type, dwellMs])
+}
+
+export default useAutoRecordInviteToResponse

--- a/app/javascript/hooks/useAutoRecordInviteToResponse.ts
+++ b/app/javascript/hooks/useAutoRecordInviteToResponse.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { recordResponse, logHumanVerifiedClick } from "../api/inviteToApiService"
+import { logHumanVerifiedClick } from "../api/inviteToApiService"
 import { isDeadlinePassed } from "../util/listingUtil"
 
 const INTERACTION_EVENTS = [
@@ -10,12 +10,13 @@ const INTERACTION_EVENTS = [
   "scroll",
 ] as const
 
-export type ClientRecordingMode = "off" | "shadow" | "on"
+// 'shadow' is currently the only active mode: the server still records on GET and the client
+// only logs its human-detection result. A client-records ('on') mode is deferred until
+// https://github.com/SFDigitalServices/sf-dahlia-web/pull/2993 lands.
+export type ClientRecordingMode = "off" | "shadow"
 
 interface UseAutoRecordInviteToResponseArgs {
   enabled: boolean
-  // "on" fires the real recordResponse; "shadow" fires a log-only call (server still records on GET).
-  mode?: ClientRecordingMode
   act?: "yes" | "no" | "contact" | "submit" | "appointment"
   appId?: string
   listingId?: string
@@ -26,44 +27,24 @@ interface UseAutoRecordInviteToResponseArgs {
 
 const AUTO_RECORD_ACTS = new Set(["yes", "no", "contact"])
 
-// Shadow and on modes use distinct guard keys so a session that later flips from shadow to on
-// still records for real (the shadow call must not block the real one).
-const guardKey = (appId: string, act: string, mode: ClientRecordingMode) =>
-  mode === "shadow" ? `i2x-shadow-${appId}-${act}` : `i2x-recorded-${appId}-${act}`
-
-const isGuardSet = (key: string) => {
-  try {
-    return sessionStorage.getItem(key) === "true"
-  } catch {
-    return false
-  }
-}
-
-const setGuard = (key: string) => {
-  try {
-    sessionStorage.setItem(key, "true")
-  } catch {
-    // Ignore private-mode / storage-disabled failures; server-side dedup is the backstop.
-  }
-}
-
 /**
- * Automatically records an applicant's response to an invite-to-apply/interview email link
- * once the page has genuinely been seen by a human, gating out email-scanner-bot prefetches.
+ * Detects whether an invite-to-apply/interview email link was opened by a human rather than
+ * prefetched by an email-scanner bot, and logs the result (nothing is recorded to Salesforce -
+ * the server still records on GET).
  *
- * In `mode: "on"` it fires the real `recordResponse`; in `mode: "shadow"` it fires a log-only
- * `logHumanVerifiedClick` (the server still records on GET) so the detection can be measured
- * against live traffic. Fires exactly once when all of the following hold:
+ * Fires exactly once per mount when all of the following hold:
  *  - `enabled` is true (caller is responsible for computing this, including the
  *    client-recording mode, `act`, `isTest`, `documentsPath`, and deadline checks)
  *  - the document is visible
  *  - two animation frames have elapsed while visible (a real paint happened)
  *  - either a first user interaction occurs, or `dwellMs` of continuous visibility elapses
  *    (whichever comes first)
+ *
+ * There is deliberately no cross-mount/session dedup guard: this is log-only telemetry, and a
+ * guard would hide repeat loads we want to see in the logs.
  */
 export const useAutoRecordInviteToResponse = ({
   enabled,
-  mode = "on",
   act,
   appId,
   listingId,
@@ -74,7 +55,6 @@ export const useAutoRecordInviteToResponse = ({
   useEffect(() => {
     if (
       !enabled ||
-      mode === "off" ||
       !act ||
       !AUTO_RECORD_ACTS.has(act) ||
       !appId ||
@@ -83,11 +63,6 @@ export const useAutoRecordInviteToResponse = ({
       !deadline ||
       isDeadlinePassed(deadline)
     ) {
-      return undefined
-    }
-
-    const key = guardKey(appId, act, mode)
-    if (isGuardSet(key)) {
       return undefined
     }
 
@@ -136,30 +111,16 @@ export const useAutoRecordInviteToResponse = ({
       if (fired) return
       fired = true
       cleanup()
-      setGuard(key)
-      const elapsedMs = Date.now() - armedAt
-      const request =
-        mode === "shadow"
-          ? logHumanVerifiedClick({
-              appId,
-              listingId,
-              deadline,
-              act,
-              type,
-              trigger,
-              elapsedMs,
-            })
-          : recordResponse({
-              appId,
-              applicationNumber: appId,
-              listingId,
-              deadline,
-              action: act,
-              response: act,
-              type,
-            })
-      void request.catch((error) => {
-        console.error("Error auto-recording invite-to response:", error)
+      void logHumanVerifiedClick({
+        appId,
+        listingId,
+        deadline,
+        act,
+        type,
+        trigger,
+        elapsedMs: Date.now() - armedAt,
+      }).catch((error) => {
+        console.error("Error logging human-verified invite-to click:", error)
       })
     }
 
@@ -207,7 +168,7 @@ export const useAutoRecordInviteToResponse = ({
     }
 
     return cleanup
-  }, [enabled, mode, act, appId, listingId, deadline, type, dwellMs])
+  }, [enabled, act, appId, listingId, deadline, type, dwellMs])
 }
 
 export default useAutoRecordInviteToResponse

--- a/app/javascript/hooks/useAutoRecordInviteToResponse.ts
+++ b/app/javascript/hooks/useAutoRecordInviteToResponse.ts
@@ -2,13 +2,8 @@ import { useEffect } from "react"
 import { logHumanVerifiedClick } from "../api/inviteToApiService"
 import { isDeadlinePassed } from "../util/listingUtil"
 
-const INTERACTION_EVENTS = [
-  "pointermove",
-  "pointerdown",
-  "touchstart",
-  "keydown",
-  "scroll",
-] as const
+// `pointerdown`/`pointermove` cover touch input too, so there is no separate `touchstart` here.
+const INTERACTION_EVENTS = ["pointermove", "pointerdown", "keydown", "scroll"] as const
 
 // 'shadow' is currently the only active mode: the server still records on GET and the client
 // only logs its human-detection result. A client-records ('on') mode is deferred until
@@ -16,15 +11,20 @@ const INTERACTION_EVENTS = [
 export type ClientRecordingMode = "off" | "shadow"
 
 interface UseAutoRecordInviteToResponseArgs {
-  enabled: boolean
+  mode?: ClientRecordingMode
   act?: "yes" | "no" | "contact" | "submit" | "appointment"
   appId?: string
   listingId?: string
   deadline?: string
   type?: string
-  dwellMs?: number
+  // Preview/test links and the documents page are page states that must never log.
+  isTest?: boolean
+  documentsPath?: boolean
+  dwellTimeMs?: number
 }
 
+// Only these three arrive via the email links we're measuring; 'submit' and 'appointment' are
+// on-page actions, not email clicks.
 const AUTO_RECORD_ACTS = new Set(["yes", "no", "contact"])
 
 /**
@@ -33,28 +33,32 @@ const AUTO_RECORD_ACTS = new Set(["yes", "no", "contact"])
  * the server still records on GET).
  *
  * Fires exactly once per mount when all of the following hold:
- *  - `enabled` is true (caller is responsible for computing this, including the
- *    client-recording mode, `act`, `isTest`, `documentsPath`, and deadline checks)
+ *  - `mode` is not "off", the page is not a test/preview or documents view, and the params
+ *    make up a complete, unexpired payload
  *  - the document is visible
- *  - two animation frames have elapsed while visible (a real paint happened)
- *  - either a first user interaction occurs, or `dwellMs` of continuous visibility elapses
- *    (whichever comes first)
+ *  - a first paint has happened (see `afterFirstPaint`)
+ *  - either a first user interaction occurs, or `dwellTimeMs` of continuous visibility
+ *    elapses (whichever comes first)
  *
  * There is deliberately no cross-mount/session dedup guard: this is log-only telemetry, and a
  * guard would hide repeat loads we want to see in the logs.
  */
 export const useAutoRecordInviteToResponse = ({
-  enabled,
+  mode = "off",
   act,
   appId,
   listingId,
   deadline,
   type,
-  dwellMs = 2000,
+  isTest = false,
+  documentsPath = false,
+  dwellTimeMs = 2000,
 }: UseAutoRecordInviteToResponseArgs) => {
   useEffect(() => {
     if (
-      !enabled ||
+      mode === "off" ||
+      isTest ||
+      documentsPath ||
       !act ||
       !AUTO_RECORD_ACTS.has(act) ||
       !appId ||
@@ -66,7 +70,7 @@ export const useAutoRecordInviteToResponse = ({
       return undefined
     }
 
-    // Set when the fire conditions actually arm (after the render gate, while visible), so
+    // Set when the fire conditions actually arm (after the first paint, while visible), so
     // elapsedMs reflects visible dwell/interaction time and excludes hidden/background-tab time.
     let armedAt = 0
     let fired = false
@@ -81,7 +85,7 @@ export const useAutoRecordInviteToResponse = ({
       }
     }
 
-    const clearRenderGateFrames = () => {
+    const cancelPendingFrames = () => {
       if (visibilityRafId1 !== null) {
         cancelAnimationFrame(visibilityRafId1)
         visibilityRafId1 = null
@@ -101,7 +105,7 @@ export const useAutoRecordInviteToResponse = ({
 
     const cleanup = () => {
       clearDwellTimer()
-      clearRenderGateFrames()
+      cancelPendingFrames()
       removeInteractionListeners()
       // eslint-disable-next-line @typescript-eslint/no-use-before-define -- registered further down
       document.removeEventListener("visibilitychange", handleVisibilityChange)
@@ -135,10 +139,21 @@ export const useAutoRecordInviteToResponse = ({
       })
       dwellTimeoutId = setTimeout(() => {
         fire("dwell")
-      }, dwellMs)
+      }, dwellTimeMs)
     }
 
-    const startRenderGate = () => {
+    // Waits for evidence that the browser has actually painted this page, which headless and
+    // sandboxed scanners often never do.
+    //
+    // A requestAnimationFrame callback runs *before* the paint of the frame it was scheduled
+    // for, so a single frame proves nothing was drawn yet. Scheduling a second frame from
+    // inside the first means we resume after that first frame was handed off for rendering.
+    // Note this is a heuristic, not a guarantee: the spec's "update the rendering" steps
+    // (https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering) don't
+    // promise a commit to the screen between the two callbacks. It's fine that it may be a
+    // frame optimistic - it's one layer of the detection, and the visibility check and the
+    // interaction-or-dwell gate still have to pass before anything is logged.
+    const afterFirstPaint = () => {
       visibilityRafId1 = requestAnimationFrame(() => {
         visibilityRafId2 = requestAnimationFrame(() => {
           if (document.visibilityState === "visible") {
@@ -151,11 +166,11 @@ export const useAutoRecordInviteToResponse = ({
     const handleVisibilityChange = () => {
       if (fired) return
       if (document.visibilityState === "visible") {
-        clearRenderGateFrames()
-        startRenderGate()
+        cancelPendingFrames()
+        afterFirstPaint()
       } else {
         // Page hidden again before firing - pause/reset everything.
-        clearRenderGateFrames()
+        cancelPendingFrames()
         clearDwellTimer()
         removeInteractionListeners()
       }
@@ -164,11 +179,11 @@ export const useAutoRecordInviteToResponse = ({
     document.addEventListener("visibilitychange", handleVisibilityChange)
 
     if (document.visibilityState === "visible") {
-      startRenderGate()
+      afterFirstPaint()
     }
 
     return cleanup
-  }, [enabled, act, appId, listingId, deadline, type, dwellMs])
+  }, [mode, act, appId, listingId, deadline, type, isTest, documentsPath, dwellTimeMs])
 }
 
 export default useAutoRecordInviteToResponse

--- a/app/javascript/pages/inviteTo/invite-to.tsx
+++ b/app/javascript/pages/inviteTo/invite-to.tsx
@@ -15,6 +15,10 @@ import InviteToInterviewNextSteps from "./inviteToInterview/InviteToInterviewNex
 import RailsSaleListing from "../../api/types/rails/listings/RailsSaleListing"
 import { getPathWithoutLanguagePrefix } from "../../util/languageUtil"
 import { isDeadlinePassed } from "../../util/listingUtil"
+import {
+  useAutoRecordInviteToResponse,
+  ClientRecordingMode,
+} from "../../hooks/useAutoRecordInviteToResponse"
 
 interface UrlParams {
   type?: INVITE_TO_X
@@ -34,6 +38,7 @@ interface HomePageProps {
   documentsPath?: boolean
   uploadUrl?: string
   schedulingUrl?: string
+  clientRecordingMode?: ClientRecordingMode
 }
 
 const InviteToPage = ({
@@ -42,10 +47,35 @@ const InviteToPage = ({
   schedulingUrl,
   submitPreviewLinkTokenParam,
   documentsPath,
+  clientRecordingMode = "off",
 }: HomePageProps) => {
   const [listing, setListing] = useState<RailsSaleListing>(null)
   const { pathname } = useLocation()
   const navigate = useNavigate()
+  const isTestMode = isTest === true || isTest === "true"
+  const listingId = getPathWithoutLanguagePrefix(pathname).split("/")[2]
+
+  useAutoRecordInviteToResponse({
+    enabled:
+      clientRecordingMode !== "off" &&
+      !!act &&
+      act !== "submit" &&
+      act !== "appointment" &&
+      !isTestMode &&
+      !documentsPath &&
+      !!type &&
+      !!deadline &&
+      !isDeadlinePassed(deadline) &&
+      !!appId &&
+      !!listingId,
+    mode: clientRecordingMode,
+    act,
+    appId,
+    listingId,
+    deadline,
+    type,
+  })
+
   useEffect(() => {
     const path = getPathWithoutLanguagePrefix(pathname)
     void getListing(path.split("/")[2]).then((listing: RailsSaleListing) => {

--- a/app/javascript/pages/inviteTo/invite-to.tsx
+++ b/app/javascript/pages/inviteTo/invite-to.tsx
@@ -56,23 +56,14 @@ const InviteToPage = ({
   const listingId = getPathWithoutLanguagePrefix(pathname).split("/")[2]
 
   useAutoRecordInviteToResponse({
-    enabled:
-      clientRecordingMode !== "off" &&
-      !!act &&
-      act !== "submit" &&
-      act !== "appointment" &&
-      !isTestMode &&
-      !documentsPath &&
-      !!type &&
-      !!deadline &&
-      !isDeadlinePassed(deadline) &&
-      !!appId &&
-      !!listingId,
+    mode: clientRecordingMode,
     act,
     appId,
     listingId,
     deadline,
     type,
+    isTest: isTestMode,
+    documentsPath,
   })
 
   useEffect(() => {

--- a/app/javascript/pages/inviteTo/invite-to.tsx
+++ b/app/javascript/pages/inviteTo/invite-to.tsx
@@ -53,6 +53,8 @@ const InviteToPage = ({
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const isTestMode = isTest === true || isTest === "true"
+  // Single source of truth for the listing id parsed from the URL, so the hook and the
+  // getListing() fetch below can't diverge if the path parsing ever changes.
   const listingId = getPathWithoutLanguagePrefix(pathname).split("/")[2]
 
   useAutoRecordInviteToResponse({
@@ -67,14 +69,13 @@ const InviteToPage = ({
   })
 
   useEffect(() => {
-    const path = getPathWithoutLanguagePrefix(pathname)
-    void getListing(path.split("/")[2]).then((listing: RailsSaleListing) => {
+    void getListing(listingId).then((listing: RailsSaleListing) => {
       if (!listing) {
         void navigate("/")
       }
       setListing(listing)
     })
-  }, [navigate, pathname])
+  }, [navigate, listingId])
 
   const { unleashFlag: isI2AEnabled } = useFeatureFlag("partners.inviteToApply", false)
   const { unleashFlag: isI2IEnabledFlag } = useVariantFlag("all.i2i", false)

--- a/app/javascript/pages/inviteTo/invite-to.tsx
+++ b/app/javascript/pages/inviteTo/invite-to.tsx
@@ -68,7 +68,6 @@ const InviteToPage = ({
       !isDeadlinePassed(deadline) &&
       !!appId &&
       !!listingId,
-    mode: clientRecordingMode,
     act,
     appId,
     listingId,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       # Deprecated I2A pilot - remove in DAH-4045
       post 'invite-to-apply/record-response' => 'invite_to_response#record_response'
       post 'next-steps/record-response' => 'invite_to_response#record_response'
+      post 'next-steps/log-human-verified' => 'invite_to_response#log_human_verified'
       scope '/short-form' do
         post 'validate-household' => 'short_form#validate_household'
         get 'listing-application/:listing_id' => 'short_form#show_listing_application_for_user'

--- a/spec/controllers/api/v1/invite_to_response_controller_spec.rb
+++ b/spec/controllers/api/v1/invite_to_response_controller_spec.rb
@@ -14,15 +14,15 @@ describe Api::V1::InviteToResponseController do
 
     it 'passes params to messaging service for valid params' do
       post :record_response, params: {
-      record: {
-        deadline: deadline,
-        appId: application_id,
-        applicationNumber: application_id,
-        response: response_type,
-        action: response_type,
-        listingId: listing_id,
-      },
-    }
+        record: {
+          deadline: deadline,
+          appId: application_id,
+          applicationNumber: application_id,
+          response: response_type,
+          action: response_type,
+          listingId: listing_id,
+        },
+      }
       expect(DahliaBackend::MessageService)
         .to have_received(:send_invite_to_response).with(
           deadline,
@@ -37,15 +37,15 @@ describe Api::V1::InviteToResponseController do
 
     it 'does not pass params to messaging service for expired deadline' do
       post :record_response, params: {
-      record: {
-        deadline: '1999-01-01',
-        appId: application_id,
-        applicationNumber: application_id,
-        response: response_type,
-        action: response_type,
-        listingId: listing_id,
-      },
-    }
+        record: {
+          deadline: '1999-01-01',
+          appId: application_id,
+          applicationNumber: application_id,
+          response: response_type,
+          action: response_type,
+          listingId: listing_id,
+        },
+      }
       expect(DahliaBackend::MessageService)
         .not_to have_received(:send_invite_to_response)
       expect(response).to be_ok
@@ -53,18 +53,66 @@ describe Api::V1::InviteToResponseController do
 
     it 'returns an error for invalid params' do
       post :record_response, params: {
-      record: {
-        deadline: '',
-        appId: application_id,
-        applicationNumber: application_id,
-        response: response_type,
-        action: response_type,
-        listingId: listing_id,
-      },
-    }
+        record: {
+          deadline: '',
+          appId: application_id,
+          applicationNumber: application_id,
+          response: response_type,
+          action: response_type,
+          listingId: listing_id,
+        },
+      }
       expect(DahliaBackend::MessageService)
         .not_to have_received(:send_invite_to_response)
       expect(response).not_to be_ok
+    end
+  end
+
+  describe '#log_human_verified' do
+    let(:valid_record) do
+      {
+        type: 'I2A',
+        deadline: deadline,
+        appId: application_id,
+        listingId: listing_id,
+        act: 'yes',
+        trigger: 'interaction',
+        elapsedMs: 1234,
+      }
+    end
+
+    before do
+      allow(DahliaBackend::MessageService).to receive(:send_invite_to_response)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it 'logs the human-verified click and records nothing' do
+      post :log_human_verified, params: { record: valid_record }
+
+      expect(response).to be_ok
+      expect(DahliaBackend::MessageService).not_to have_received(:send_invite_to_response)
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_including(
+          'InviteToResponseController#log_human_verified:',
+          'human-verified click (shadow, not recorded)',
+          "appId=#{application_id.inspect}",
+          'act="yes"',
+          'trigger="interaction"',
+          'elapsedMs="1234"',
+        ),
+      )
+    end
+
+    it 'returns 400 when the record param is missing' do
+      post :log_human_verified, params: { notRecord: {} }
+      expect(response).to have_http_status(:bad_request)
+      expect(DahliaBackend::MessageService).not_to have_received(:send_invite_to_response)
+    end
+
+    it 'returns 500 on an unexpected error' do
+      allow(Rails.logger).to receive(:info).and_raise(StandardError, 'boom')
+      post :log_human_verified, params: { record: valid_record }
+      expect(response).to have_http_status(:internal_server_error)
     end
   end
 end

--- a/spec/controllers/invite_to_controller_spec.rb
+++ b/spec/controllers/invite_to_controller_spec.rb
@@ -67,12 +67,18 @@ RSpec.describe InviteToController do
     allow(DahliaBackend::MessageService).to receive(:send_invite_to_response)
     allow(Rails.logger).to receive(:info)
     allow(controller).to receive(:encode_token).and_return(fixed_token)
+    allow(Rails.configuration.unleash).to receive(:is_enabled?)
+      .with('temp.webapp.inviteToClientRecording').and_return(false)
+    allow(Rails.configuration.unleash).to receive(:get_variant)
+      .with('temp.webapp.inviteToClientRecording').and_return(nil)
   end
 
   describe '#index' do
     context 'with valid parameters' do
       before do
-        allow(Force::ShortFormService).to receive(:get).with(application_number).and_return({ 'uploadURL' => 'test-upload-url', 'leaseupAppointmentSchedulingURL' => 'test-scheduling-url' })
+        allow(Force::ShortFormService).to receive(:get).with(application_number).and_return({
+                                                                                              'uploadURL' => 'test-upload-url', 'leaseupAppointmentSchedulingURL' => 'test-scheduling-url'
+                                                                                            })
 
         get :index, params: {
           id: listing_id,
@@ -94,18 +100,19 @@ RSpec.describe InviteToController do
 
       it 'sets the invite_to_props instance variable' do
         expect(assigns(:invite_to_props)).to eq({
-                                                        assetPaths: { logo: 'logo.png' },
-                                                        urlParams: {
-                                                          type: 'I2A',
-                                                          deadline: deadline,
-                                                          act: response_value,
-                                                          appId: application_number,
-                                                          isTest: false,
-                                                        },
-                                                        uploadUrl: 'test-upload-url',
-                                                        schedulingUrl: 'test-scheduling-url',
-                                                        submitPreviewLinkTokenParam: fixed_token,
-                                                      })
+                                                  assetPaths: { logo: 'logo.png' },
+                                                  urlParams: {
+                                                    type: 'I2A',
+                                                    deadline: deadline,
+                                                    act: response_value,
+                                                    appId: application_number,
+                                                    isTest: false,
+                                                  },
+                                                  clientRecordingMode: 'off',
+                                                  uploadUrl: 'test-upload-url',
+                                                  schedulingUrl: 'test-scheduling-url',
+                                                  submitPreviewLinkTokenParam: fixed_token,
+                                                })
       end
 
       # TODO: update deprecated I2A pilot
@@ -123,7 +130,9 @@ RSpec.describe InviteToController do
 
     context 'when DahliaBackend::MessageService raises an error' do
       before do
-        allow(Force::ShortFormService).to receive(:get).with(application_number).and_return({ 'uploadURL' => 'test-upload-url', 'leaseupAppointmentSchedulingURL' => 'test-scheduling-url' })
+        allow(Force::ShortFormService).to receive(:get).with(application_number).and_return({
+                                                                                              'uploadURL' => 'test-upload-url', 'leaseupAppointmentSchedulingURL' => 'test-scheduling-url'
+                                                                                            })
         allow(DahliaBackend::MessageService).to receive(:send_invite_to_response).and_raise(
           StandardError, 'API Error'
         )
@@ -187,6 +196,94 @@ RSpec.describe InviteToController do
 
       it 'returns a successful response' do
         expect(response).to be_ok
+      end
+    end
+  end
+
+  describe 'client recording feature flag' do
+    let(:variant_double) { instance_double(Unleash::Variant, name: variant_name) }
+    let(:variant_name) { 'on' }
+
+    before do
+      allow(Force::ShortFormService).to receive(:get).with(application_number).and_return(
+        { 'uploadURL' => 'test-upload-url',
+          'leaseupAppointmentSchedulingURL' => 'test-scheduling-url' },
+      )
+    end
+
+    def request_index
+      get :index, params: {
+        id: listing_id,
+        t: fixed_token,
+        type: 'I2A',
+        deadline: deadline,
+        act: response_value,
+        appId: application_number,
+      }
+    end
+
+    context "when the flag is enabled with the 'on' variant" do
+      before do
+        allow(Rails.configuration.unleash).to receive(:is_enabled?)
+          .with('temp.webapp.inviteToClientRecording').and_return(true)
+        allow(Rails.configuration.unleash).to receive(:get_variant)
+          .with('temp.webapp.inviteToClientRecording').and_return(variant_double)
+        request_index
+      end
+
+      it 'does not call record_response server-side' do
+        expect(DahliaBackend::MessageService).not_to have_received(:send_invite_to_response)
+      end
+
+      it "includes clientRecordingMode: 'on' in the props" do
+        expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'on')
+      end
+    end
+
+    context 'when the flag is enabled with no configured variant' do
+      before do
+        allow(Rails.configuration.unleash).to receive(:is_enabled?)
+          .with('temp.webapp.inviteToClientRecording').and_return(true)
+        allow(Rails.configuration.unleash).to receive(:get_variant)
+          .with('temp.webapp.inviteToClientRecording').and_return(nil)
+        request_index
+      end
+
+      it "defaults to 'on' (skips server-side recording)" do
+        expect(DahliaBackend::MessageService).not_to have_received(:send_invite_to_response)
+        expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'on')
+      end
+    end
+
+    context "when the flag is enabled with the 'shadow' variant" do
+      let(:variant_name) { 'shadow' }
+
+      before do
+        allow(Rails.configuration.unleash).to receive(:is_enabled?)
+          .with('temp.webapp.inviteToClientRecording').and_return(true)
+        allow(Rails.configuration.unleash).to receive(:get_variant)
+          .with('temp.webapp.inviteToClientRecording').and_return(variant_double)
+        request_index
+      end
+
+      it 'still records server-side on GET (unchanged applicant behavior)' do
+        expect(DahliaBackend::MessageService).to have_received(:send_invite_to_response)
+      end
+
+      it "includes clientRecordingMode: 'shadow' in the props" do
+        expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'shadow')
+      end
+    end
+
+    context 'when the flag is disabled' do
+      before { request_index }
+
+      it 'still records server-side on GET with act present' do
+        expect(DahliaBackend::MessageService).to have_received(:send_invite_to_response)
+      end
+
+      it "includes clientRecordingMode: 'off' in the props" do
+        expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'off')
       end
     end
   end

--- a/spec/controllers/invite_to_controller_spec.rb
+++ b/spec/controllers/invite_to_controller_spec.rb
@@ -69,8 +69,6 @@ RSpec.describe InviteToController do
     allow(controller).to receive(:encode_token).and_return(fixed_token)
     allow(Rails.configuration.unleash).to receive(:is_enabled?)
       .with('temp.webapp.inviteToClientRecording').and_return(false)
-    allow(Rails.configuration.unleash).to receive(:get_variant)
-      .with('temp.webapp.inviteToClientRecording').and_return(nil)
   end
 
   describe '#index' do
@@ -201,9 +199,6 @@ RSpec.describe InviteToController do
   end
 
   describe 'client recording feature flag' do
-    let(:variant_double) { instance_double(Unleash::Variant, name: variant_name) }
-    let(:variant_name) { 'on' }
-
     before do
       allow(Force::ShortFormService).to receive(:get).with(application_number).and_return(
         { 'uploadURL' => 'test-upload-url',
@@ -222,47 +217,11 @@ RSpec.describe InviteToController do
       }
     end
 
-    context "when the flag is enabled with the 'on' variant" do
+    context 'when the flag is enabled' do
       before do
         allow(Rails.configuration.unleash).to receive(:is_enabled?)
           .with('temp.webapp.inviteToClientRecording').and_return(true)
         allow(Rails.configuration.unleash).to receive(:get_variant)
-          .with('temp.webapp.inviteToClientRecording').and_return(variant_double)
-        request_index
-      end
-
-      it 'does not call record_response server-side' do
-        expect(DahliaBackend::MessageService).not_to have_received(:send_invite_to_response)
-      end
-
-      it "includes clientRecordingMode: 'on' in the props" do
-        expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'on')
-      end
-    end
-
-    context 'when the flag is enabled with no configured variant' do
-      before do
-        allow(Rails.configuration.unleash).to receive(:is_enabled?)
-          .with('temp.webapp.inviteToClientRecording').and_return(true)
-        allow(Rails.configuration.unleash).to receive(:get_variant)
-          .with('temp.webapp.inviteToClientRecording').and_return(nil)
-        request_index
-      end
-
-      it "defaults to 'on' (skips server-side recording)" do
-        expect(DahliaBackend::MessageService).not_to have_received(:send_invite_to_response)
-        expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'on')
-      end
-    end
-
-    context "when the flag is enabled with the 'shadow' variant" do
-      let(:variant_name) { 'shadow' }
-
-      before do
-        allow(Rails.configuration.unleash).to receive(:is_enabled?)
-          .with('temp.webapp.inviteToClientRecording').and_return(true)
-        allow(Rails.configuration.unleash).to receive(:get_variant)
-          .with('temp.webapp.inviteToClientRecording').and_return(variant_double)
         request_index
       end
 
@@ -272,6 +231,10 @@ RSpec.describe InviteToController do
 
       it "includes clientRecordingMode: 'shadow' in the props" do
         expect(assigns(:invite_to_props)).to include(clientRecordingMode: 'shadow')
+      end
+
+      it 'ignores any configured variant (there is no client-records mode yet)' do
+        expect(Rails.configuration.unleash).not_to have_received(:get_variant)
       end
     end
 


### PR DESCRIPTION
## Summary

Email-security scanners (SafeLinks, Proofpoint, etc.) **prefetch every link in an email with a GET**. Our invite-to "Yes / No / Waitlist" links record the applicant's response *on that GET*, so scanner prefetches silently corrupt Salesforce state and send spurious confirmation emails.

Before changing any of that, we need to know how big the problem is. **This PR only measures it.** The page now runs a client-side check for whether a human is actually looking at it — JS ran, the page is genuinely visible, and either a real interaction happened or the page was foregrounded for ~2s — and reports the result to a **log-only** endpoint that records nothing.

Server-side recording on the GET is unchanged in every mode, so turning this on in production carries no behavior risk for applicants or leasing agents. Diffing "GETs that recorded" against "GETs that also logged a human-verified line" tells us, on live traffic, what share of clicks are bots and whether any real humans fail detection.

Gated behind Unleash flag `temp.webapp.inviteToClientRecording`. Flag off = byte-identical to today.

<details>
<summary>Why the detection filters bots, the two modes, and changes</summary>

### Why this distinguishes humans from scanners

Stop treating a bare GET as evidence of a human. The log call fires only after clearing, in order:

1. **JavaScript must run.** The GET renders inert HTML; React fires the call on mount. Most scanners issue a plain GET and never execute page JS, so they never reach it.
2. **The page must be genuinely visible.** We wait for `document.visibilityState === "visible"` plus evidence of a paint (two nested `requestAnimationFrame` callbacks). Headless/sandbox scanners that *do* run JS usually render hidden or backgrounded and fail here. The two-frame trick is a heuristic, not a spec guarantee — that's written into the code comment, and it's why the gates are layered rather than relied on individually.
3. **A human signal must occur.** We fire on the first real interaction (`pointermove` / `pointerdown` / `keydown` / `scroll`) **or** after ~2s of continuous foreground visibility (dwell). A person trips this immediately; an automated fetch that closes on DOM load does not.

Each gate is something a scanner is unlikely to satisfy but a human satisfies without noticing.

### Modes (Unleash flag `temp.webapp.inviteToClientRecording`)

Resolved **server-side** in the controller and passed to React as `clientRecordingMode`. The flag is read as a plain boolean; no variant is consulted.

| Mode | Flag | Server records on GET? | Client behavior |
|------|------|------------------------|-----------------|
| `off` | disabled | **Yes** (legacy) | inert |
| `shadow` | enabled | **Yes** (unchanged) | runs the detection and calls the **log-only** endpoint `POST /api/v1/next-steps/log-human-verified` — records nothing, logs `act` / `trigger` / `elapsedMs` |

There is deliberately **no `on` (client-records) mode**. Recording from the client has to be reworked once #2993 lands, since that PR changes how `record-response` authorizes callers (a signed token rather than trusting the request body). Adding it back is tracked in **DAH-4275**.

There is also deliberately **no `sessionStorage` dedup guard**: the log call writes nothing, so there's nothing to double-record, and a guard would suppress the repeat loads and refreshes we want to see in the logs. Durable duplicate handling belongs in the backend service and is tracked in **DAH-4276**.

### Changes

- `InviteToController#index` resolves `clientRecordingMode` from the flag and passes it to the React page. It still calls `record_response` on the GET in both modes.
- New `useAutoRecordInviteToResponse` hook implements the visibility + paint + interaction-or-dwell gating. It owns its own enable checks (`mode`, `isTest`, `documentsPath`, and a complete unexpired payload) rather than taking a precomputed `enabled` flag.
- New `POST /api/v1/next-steps/log-human-verified` endpoint for the telemetry: logs only, 400 on malformed input, values `.inspect`'d to prevent log forging from an unauthenticated endpoint.
- RSpec + Jest coverage for both modes and every detection gate.

Verified end-to-end on a review app (scanner `curl` vs. real browser click). See [`docs/plans/defer-invite-response-recording.md`](docs/plans/defer-invite-response-recording.md) for design and rollout notes.

### Rollout

`shadow` on staging → `shadow` on production for ~1–2 weeks → review the bot/human ratio → then decide whether to move recording to the client (after #2993) or keep it server-side. Since recording behavior is identical in both modes, the flag is safe to leave on and instantly revertible.

</details>
