### PR TITLE
feat: DAH-4247 Add angular form link to form engine debug overlay

### DIFF
--- a/app/javascript/__tests__/formEngine/FormEngineDebug.test.tsx
+++ b/app/javascript/__tests__/formEngine/FormEngineDebug.test.tsx
@@ -109,4 +109,23 @@ describe("FormEngineDebug", () => {
     await user.click(screen.getByRole("button", { name: /hide prefs data/i }))
     expect(screen.queryByText(/"preferenceName": "Test Preference Name"/)).toBeNull()
   })
+
+  it("links to the equivalent legacy Angular form for the listing", () => {
+    render(<FormEngineDebug {...props} />)
+
+    expect(screen.getByRole("link", { name: /angular form/i })).toHaveAttribute(
+      "href",
+      `/listings/${openRentalListing.listingID}/apply-welcome/intro`
+    )
+  })
+
+  it("includes the current language prefix in the Angular form link", () => {
+    window.history.pushState({}, "", "/es/listings/test-listing/apply/intro")
+    render(<FormEngineDebug {...props} />)
+
+    expect(screen.getByRole("link", { name: /angular form/i })).toHaveAttribute(
+      "href",
+      `/es/listings/${openRentalListing.listingID}/apply-welcome/intro`
+    )
+  })
 })

--- a/app/javascript/formEngine/FormEngineDebug.scss
+++ b/app/javascript/formEngine/FormEngineDebug.scss
@@ -62,6 +62,12 @@
     padding: 8px;
   }
 
+  a.button {
+    border: 1px solid transparent;
+    padding: 8px;
+    display: block;
+  }
+
   ul {
     list-style-type: numeric;
     list-style-position: inside;

--- a/app/javascript/formEngine/FormEngineDebug.tsx
+++ b/app/javascript/formEngine/FormEngineDebug.tsx
@@ -95,7 +95,7 @@ const FormEngineDebug = ({
           {showStepInfo && <ViewJson data={stepInfoMap[currentStepIndex]} />}
         </div>
         <div>
-          <button onClick={() => window.location.href = getAngularFormUrl(staticData)}>
+          <button onClick={() => (window.location.href = getAngularFormUrl(staticData))}>
             angular form
           </button>
         </div>

--- a/app/javascript/formEngine/FormEngineDebug.tsx
+++ b/app/javascript/formEngine/FormEngineDebug.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import { type StepInfoSchema } from "./formSchemas"
 import "./FormEngineDebug.scss"
 import { updateFormPath } from "../util/formEngineUtil"
-import { getCurrentLanguage, LanguagePrefix } from "../util/languageUtil"
+import { localizedPath } from "../util/routeUtil"
 
 interface FormEngineDebugProps {
   currentStepIndex: number
@@ -12,18 +12,10 @@ interface FormEngineDebugProps {
   formData: Record<string, unknown>
 }
 
-// Builds a link to the equivalent listing in the legacy Angular short-form
-// application ("apply-welcome" flow), so devs can quickly compare behavior
-// against the old form while debugging the new react form engine. The
-// Angular flow is served by the same Rails app (via the catch-all
-// angular#index route) on every environment - prod, full/staging, and PR
-// review apps alike - so this just swaps the path on the current origin
-// rather than pointing at a fixed host.
+// Link to the equivalent legacy Angular form for the current listing.
 const getAngularFormUrl = (staticData: Record<string, unknown>): string => {
   const listing = staticData.listing as { listingID?: string } | undefined
-  const lang = getCurrentLanguage(window.location.pathname)
-  const langPrefix = lang && lang !== LanguagePrefix.English ? `/${lang}` : ""
-  return `${window.location.origin}${langPrefix}/listings/${listing?.listingID ?? ""}/apply-welcome/intro`
+  return localizedPath(`listings/${listing?.listingID ?? ""}/apply-welcome/intro`)
 }
 
 const Steps = ({
@@ -95,9 +87,7 @@ const FormEngineDebug = ({
           {showStepInfo && <ViewJson data={stepInfoMap[currentStepIndex]} />}
         </div>
         <div>
-          <button onClick={() => (window.location.href = getAngularFormUrl(staticData))}>
-            angular form
-          </button>
+          <a href={getAngularFormUrl(staticData)}>angular form</a>
         </div>
       </div>
       <div>

--- a/app/javascript/formEngine/FormEngineDebug.tsx
+++ b/app/javascript/formEngine/FormEngineDebug.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 import { type StepInfoSchema } from "./formSchemas"
 import "./FormEngineDebug.scss"
 import { updateFormPath } from "../util/formEngineUtil"
+import { getCurrentLanguage, LanguagePrefix } from "../util/languageUtil"
 
 interface FormEngineDebugProps {
   currentStepIndex: number
@@ -9,6 +10,20 @@ interface FormEngineDebugProps {
   setCurrentStepIndex: (step: number) => void
   staticData: Record<string, unknown>
   formData: Record<string, unknown>
+}
+
+// Builds a link to the equivalent listing in the legacy Angular short-form
+// application ("apply-welcome" flow), so devs can quickly compare behavior
+// against the old form while debugging the new react form engine. The
+// Angular flow is served by the same Rails app (via the catch-all
+// angular#index route) on every environment - prod, full/staging, and PR
+// review apps alike - so this just swaps the path on the current origin
+// rather than pointing at a fixed host.
+const getAngularFormUrl = (staticData: Record<string, unknown>): string => {
+  const listing = staticData.listing as { listingID?: string } | undefined
+  const lang = getCurrentLanguage(window.location.pathname)
+  const langPrefix = lang && lang !== LanguagePrefix.English ? `/${lang}` : ""
+  return `${window.location.origin}${langPrefix}/listings/${listing?.listingID ?? ""}/apply-welcome/intro`
 }
 
 const Steps = ({
@@ -78,6 +93,11 @@ const FormEngineDebug = ({
             {showStepInfo ? "hide" : "show"} step info
           </button>
           {showStepInfo && <ViewJson data={stepInfoMap[currentStepIndex]} />}
+        </div>
+        <div>
+          <button onClick={() => window.location.href = getAngularFormUrl(staticData)}>
+            angular form
+          </button>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Description

I always forget what the route to the start of the Angular form is, so added a button for it.

<img width="590" height="273" alt="image" src="https://github.com/user-attachments/assets/0bf9236a-e306-4f83-b391-4d9a0c47f415" />

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4247

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag