### PR TITLE
chore: add translation key parity check to CI

### DIFF
--- a/.github/workflows/translations-check.yml
+++ b/.github/workflows/translations-check.yml
@@ -8,6 +8,10 @@ on:
       - "scripts/known-translation-gaps.json"
       - ".github/workflows/translations-check.yml"
 
+# Both jobs only read the checked-out tree; nothing writes back to the repo.
+permissions:
+  contents: read
+
 jobs:
   check-sorting:
     runs-on: ubuntu-latest

--- a/.github/workflows/translations-check.yml
+++ b/.github/workflows/translations-check.yml
@@ -1,9 +1,12 @@
-name: Check Translation Files Sorting
+name: Check Translation Files
 
 on:
   pull_request:
     paths:
       - "app/assets/json/translations/react/*.json"
+      - "scripts/check-translation-parity.js"
+      - "scripts/known-translation-gaps.json"
+      - ".github/workflows/translations-check.yml"
 
 jobs:
   check-sorting:
@@ -47,3 +50,21 @@ jobs:
               rm sorted.json
             fi
           done
+
+  check-key-parity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      # loadTranslations() overlays each locale on top of en.json, so a key that is
+      # missing from es/tl/zh renders the English string with no error anywhere.
+      # This is the only thing in CI that catches that.
+      - name: Check translation key parity
+        run: node scripts/check-translation-parity.js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig(
       "*.config.js",
       "config/webpack/**/*",
       "lighthouserc.js",
+      "scripts/**", // Standalone Node/shell tooling, outside the TS project
       "public/**",
       "node_modules/**",
       "spec/e2e/**", // Legacy E2E tests

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "lint:config": "eslint --insepct-config",
     "lint:benchmark": "cross-env TIMING=all eslint --stats",
     "format": "prettier --write .",
+    "check:translations": "node scripts/check-translation-parity.js",
     "webpack:analyze": "yarn webpack:build_json && yarn webpack:analyze_json",
     "webpack:build_json": "cross-env RAILS_ENV=${RAILS_ENV:-production} NODE_ENV=${NODE_ENV:-production} bin/webpack --profile --json > tmp/webpack-stats.json",
     "webpack:analyze_json": "webpack-bundle-analyzer tmp/webpack-stats.json public/packs",

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/*
+ * Verifies that every key in the English translation file exists in each of the
+ * other locale files.
+ *
+ * Why this matters: loadTranslations() in app/javascript/util/languageUtil.tsx
+ * loads en.json first and then overlays the target locale on top of it. A key
+ * that is missing from es.json therefore renders the *English* string silently —
+ * no raw key, no empty box, no console warning. Nothing in the app surfaces it,
+ * and visual regression tooling can't either, because the English fallback is
+ * simply what the page has always looked like.
+ *
+ * Keys that are intentionally identical across locales (proper nouns, acronyms)
+ * do not need listing here — this checks key presence, not value difference.
+ * Keys that are intentionally English-only go in known-translation-gaps.json.
+ *
+ * Usage:
+ *   node scripts/check-translation-parity.js
+ *   node scripts/check-translation-parity.js --json   # machine-readable output
+ */
+
+const fs = require("fs")
+const path = require("path")
+
+const TRANSLATIONS_DIR = path.join(__dirname, "..", "app", "assets", "json", "translations", "react")
+const GAPS_FILE = path.join(__dirname, "known-translation-gaps.json")
+const BASE_LOCALE = "en"
+
+const flatten = (obj, prefix = "") =>
+  Object.entries(obj).reduce((acc, [key, value]) => {
+    const name = prefix ? `${prefix}.${key}` : key
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? { ...acc, ...flatten(value, name) }
+      : { ...acc, [name]: value }
+  }, {})
+
+const readLocale = (locale) => {
+  const file = path.join(TRANSLATIONS_DIR, `${locale}.json`)
+  try {
+    return flatten(JSON.parse(fs.readFileSync(file, "utf8")))
+  } catch (error) {
+    console.error(`Could not read or parse ${file}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+/*
+ * known-translation-gaps.json groups exempted keys under a reason, so the
+ * allowlist documents itself:
+ *   { "gaps": { "es": [ { "reason": "...", "keys": ["a.b"] } ] } }
+ * Returns a flat Set of exempted keys per locale.
+ */
+const readKnownGaps = () => {
+  if (!fs.existsSync(GAPS_FILE)) return {}
+  try {
+    const { gaps = {} } = JSON.parse(fs.readFileSync(GAPS_FILE, "utf8"))
+    return Object.fromEntries(
+      Object.entries(gaps).map(([locale, groups]) => [
+        locale,
+        new Set(groups.flatMap((group) => group.keys)),
+      ])
+    )
+  } catch (error) {
+    console.error(`Could not parse ${GAPS_FILE}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+const main = () => {
+  const asJson = process.argv.includes("--json")
+
+  const locales = fs
+    .readdirSync(TRANSLATIONS_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.basename(file, ".json"))
+
+  if (!locales.includes(BASE_LOCALE)) {
+    console.error(`No ${BASE_LOCALE}.json found in ${TRANSLATIONS_DIR}`)
+    process.exit(1)
+  }
+
+  const base = readLocale(BASE_LOCALE)
+  const baseKeys = Object.keys(base).sort()
+  const knownGaps = readKnownGaps()
+
+  const results = {}
+  let failed = false
+  let totalAllowed = 0
+
+  for (const locale of locales.filter((l) => l !== BASE_LOCALE)) {
+    const target = readLocale(locale)
+    const allowed = knownGaps[locale] || new Set()
+
+    const missing = baseKeys.filter((key) => !(key in target) && !allowed.has(key))
+    const allowedStillMissing = baseKeys.filter((key) => !(key in target) && allowed.has(key))
+    // A key that is present but empty renders as blank text, which is worse than
+    // the English fallback — flag it alongside genuinely missing keys.
+    const empty = baseKeys.filter(
+      (key) => key in target && typeof target[key] === "string" && target[key].trim() === ""
+    )
+    const extra = Object.keys(target).filter((key) => !(key in base))
+    // A stale allowlist entry means someone translated the key but left the
+    // exemption behind; clearing these keeps the ratchet tightening.
+    const staleAllowlist = [...allowed].filter((key) => key in target)
+
+    results[locale] = { missing, empty, extra, allowedStillMissing, staleAllowlist }
+    totalAllowed += allowedStillMissing.length
+
+    if (missing.length > 0 || empty.length > 0) failed = true
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ baseKeyCount: baseKeys.length, results }, null, 2))
+    process.exit(failed ? 1 : 0)
+  }
+
+  console.log(`Base locale ${BASE_LOCALE}.json: ${baseKeys.length} keys\n`)
+
+  for (const [locale, result] of Object.entries(results)) {
+    const { missing, empty, extra, allowedStillMissing, staleAllowlist } = result
+    const status = missing.length === 0 && empty.length === 0 ? "PASS" : "FAIL"
+    console.log(`${status}  ${locale}.json`)
+
+    if (missing.length > 0) {
+      console.log(`  ${missing.length} key(s) missing (will silently render in English):`)
+      missing.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (empty.length > 0) {
+      console.log(`  ${empty.length} key(s) present but empty (will render blank):`)
+      empty.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (extra.length > 0) {
+      console.log(`  note: ${extra.length} key(s) not present in ${BASE_LOCALE}.json (dead weight):`)
+      extra.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (staleAllowlist.length > 0) {
+      console.log(
+        `  note: ${staleAllowlist.length} allowlist entr(ies) now translated — remove from known-translation-gaps.json:`
+      )
+      staleAllowlist.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (allowedStillMissing.length > 0) {
+      console.log(`  ${allowedStillMissing.length} known gap(s) allowlisted`)
+    }
+    console.log("")
+  }
+
+  if (failed) {
+    console.log("Translation parity check failed.")
+    console.log(
+      `Add the missing keys to the locale files, or — if a key is intentionally English-only —\n` +
+        `add it to scripts/known-translation-gaps.json with a reason.`
+    )
+    process.exit(1)
+  }
+
+  console.log("Translation parity check passed.")
+  if (totalAllowed > 0) {
+    console.log(
+      `${totalAllowed} allowlisted gap(s) remain in scripts/known-translation-gaps.json — these are\n` +
+        `untranslated strings rendering in English today, not resolved issues.`
+    )
+  }
+}
+
+main()

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -35,6 +35,13 @@ const flatten = (obj, prefix = "") =>
   }, {})
 
 const readLocale = (locale) => {
+  // Locale names only ever come from readdirSync on TRANSLATIONS_DIR or from
+  // BASE_LOCALE, so they can't contain traversal sequences. Validated anyway so
+  // that stays true if a caller is ever added, and to keep SAST scanners quiet.
+  if (!/^[a-z]{2}(-[A-Za-z]{2,4})?$/.test(locale)) {
+    console.error(`Refusing to read unexpected locale name: ${locale}`)
+    process.exit(1)
+  }
   const file = path.join(TRANSLATIONS_DIR, `${locale}.json`)
   try {
     return flatten(JSON.parse(fs.readFileSync(file, "utf8")))
@@ -94,16 +101,31 @@ const main = () => {
     const missing = baseKeys.filter((key) => !(key in target) && !allowed.has(key))
     const allowedStillMissing = baseKeys.filter((key) => !(key in target) && allowed.has(key))
     // A key that is present but empty renders as blank text, which is worse than
-    // the English fallback — flag it alongside genuinely missing keys.
+    // the English fallback — flag it alongside genuinely missing keys. Skipped
+    // when en.json is itself empty for that key (e.g. an unused placeholder),
+    // since mirroring an empty base value loses nothing.
     const empty = baseKeys.filter(
-      (key) => key in target && typeof target[key] === "string" && target[key].trim() === ""
+      (key) =>
+        key in target &&
+        typeof target[key] === "string" &&
+        target[key].trim() === "" &&
+        !(typeof base[key] === "string" && base[key].trim() === "")
     )
     const extra = Object.keys(target).filter((key) => !(key in base))
-    // A stale allowlist entry means someone translated the key but left the
-    // exemption behind; clearing these keeps the ratchet tightening.
+    // Two ways an allowlist entry goes stale: the key finally got translated, or
+    // it was dropped from en.json entirely. Reporting both keeps the ratchet
+    // tightening instead of letting dead exemptions pile up.
     const staleAllowlist = [...allowed].filter((key) => key in target)
+    const orphanedAllowlist = [...allowed].filter((key) => !(key in base))
 
-    results[locale] = { missing, empty, extra, allowedStillMissing, staleAllowlist }
+    results[locale] = {
+      missing,
+      empty,
+      extra,
+      allowedStillMissing,
+      staleAllowlist,
+      orphanedAllowlist,
+    }
     totalAllowed += allowedStillMissing.length
 
     if (missing.length > 0 || empty.length > 0) failed = true
@@ -117,7 +139,7 @@ const main = () => {
   console.log(`Base locale ${BASE_LOCALE}.json: ${baseKeys.length} keys\n`)
 
   for (const [locale, result] of Object.entries(results)) {
-    const { missing, empty, extra, allowedStillMissing, staleAllowlist } = result
+    const { missing, empty, extra, allowedStillMissing, staleAllowlist, orphanedAllowlist } = result
     const status = missing.length === 0 && empty.length === 0 ? "PASS" : "FAIL"
     console.log(`${status}  ${locale}.json`)
 
@@ -138,6 +160,12 @@ const main = () => {
         `  note: ${staleAllowlist.length} allowlist entr(ies) now translated — remove from known-translation-gaps.json:`
       )
       staleAllowlist.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (orphanedAllowlist.length > 0) {
+      console.log(
+        `  note: ${orphanedAllowlist.length} allowlist entr(ies) no longer in ${BASE_LOCALE}.json — remove from known-translation-gaps.json:`
+      )
+      orphanedAllowlist.forEach((key) => console.log(`    - ${key}`))
     }
     if (allowedStillMissing.length > 0) {
       console.log(`  ${allowedStillMissing.length} known gap(s) allowlisted`)

--- a/scripts/known-translation-gaps.json
+++ b/scripts/known-translation-gaps.json
@@ -1,0 +1,133 @@
+{
+  "README": [
+    "Keys exempted from scripts/check-translation-parity.js.",
+    "",
+    "This is a ratchet, not a resolution. Every key listed here is rendering the",
+    "ENGLISH string to speakers of that language right now, because loadTranslations()",
+    "in app/javascript/util/languageUtil.tsx overlays the locale file on top of",
+    "en.json — a missing key silently falls back rather than erroring.",
+    "",
+    "The list was seeded from the state of main on 2026-07-25 so the check could be",
+    "turned on without blocking unrelated PRs. It should only ever get shorter.",
+    "Do not add to it to make a build pass; add the translated strings instead."
+  ],
+  "gaps": {
+    "es": [
+      {
+        "reason": "Language switcher labels are deliberately shown in their own language ('Español', '中文'), so the en.json values are correct for every locale and the fallback is intended.",
+        "keys": ["languages.en", "languages.es", "languages.tl", "languages.zh"]
+      },
+      {
+        "reason": "Key-name mismatch, not a missing translation: en.json defines 'label.Other' while the locale files define 'label.Other.other'. The locale value is also the untranslated string 'Other'. Needs reconciling in a follow-up — see PR description.",
+        "keys": ["label.Other"]
+      },
+      {
+        "reason": "The en.json value is an empty string, so there is nothing to translate. Candidate for deletion.",
+        "keys": ["listings.occupancyDescriptionAllSroPlural"]
+      },
+      {
+        "reason": "DAH-4213 housing counselor agency access shipped ahead of its translations. These 20 strings render in English today and are the reason this check was written.",
+        "keys": [
+          "accountSettings.housingCounselor.agencyCan",
+          "accountSettings.housingCounselor.banner.shortError",
+          "accountSettings.housingCounselor.banner.title",
+          "accountSettings.housingCounselor.checkbox",
+          "accountSettings.housingCounselor.checkboxError",
+          "accountSettings.housingCounselor.description",
+          "accountSettings.housingCounselor.fieldError",
+          "accountSettings.housingCounselor.heading",
+          "accountSettings.housingCounselor.label",
+          "accountSettings.housingCounselor.p1",
+          "accountSettings.housingCounselor.p2",
+          "accountSettings.housingCounselor.p3",
+          "accountSettings.housingCounselor.p4",
+          "accountSettings.housingCounselor.placeholder",
+          "accountSettings.housingCounselor.revokeButton",
+          "accountSettings.housingCounselor.shareButton",
+          "accountSettings.housingCounselor.sharedOn",
+          "accountSettings.housingCounselor.sharedWith",
+          "accountSettings.housingCounselor.toastShared",
+          "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      }
+    ],
+    "tl": [
+      {
+        "reason": "Language switcher labels are deliberately shown in their own language ('Español', '中文'), so the en.json values are correct for every locale and the fallback is intended.",
+        "keys": ["languages.en", "languages.es", "languages.tl", "languages.zh"]
+      },
+      {
+        "reason": "Key-name mismatch, not a missing translation: en.json defines 'label.Other' while the locale files define 'label.Other.other'. The locale value is also the untranslated string 'Other'. Needs reconciling in a follow-up — see PR description.",
+        "keys": ["label.Other"]
+      },
+      {
+        "reason": "The en.json value is an empty string, so there is nothing to translate. Candidate for deletion.",
+        "keys": ["listings.occupancyDescriptionAllSroPlural"]
+      },
+      {
+        "reason": "DAH-4213 housing counselor agency access shipped ahead of its translations. These 20 strings render in English today and are the reason this check was written.",
+        "keys": [
+          "accountSettings.housingCounselor.agencyCan",
+          "accountSettings.housingCounselor.banner.shortError",
+          "accountSettings.housingCounselor.banner.title",
+          "accountSettings.housingCounselor.checkbox",
+          "accountSettings.housingCounselor.checkboxError",
+          "accountSettings.housingCounselor.description",
+          "accountSettings.housingCounselor.fieldError",
+          "accountSettings.housingCounselor.heading",
+          "accountSettings.housingCounselor.label",
+          "accountSettings.housingCounselor.p1",
+          "accountSettings.housingCounselor.p2",
+          "accountSettings.housingCounselor.p3",
+          "accountSettings.housingCounselor.p4",
+          "accountSettings.housingCounselor.placeholder",
+          "accountSettings.housingCounselor.revokeButton",
+          "accountSettings.housingCounselor.shareButton",
+          "accountSettings.housingCounselor.sharedOn",
+          "accountSettings.housingCounselor.sharedWith",
+          "accountSettings.housingCounselor.toastShared",
+          "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      }
+    ],
+    "zh": [
+      {
+        "reason": "Language switcher labels are deliberately shown in their own language ('Español', '中文'), so the en.json values are correct for every locale and the fallback is intended.",
+        "keys": ["languages.en", "languages.es", "languages.tl", "languages.zh"]
+      },
+      {
+        "reason": "Key-name mismatch, not a missing translation: en.json defines 'label.Other' while the locale files define 'label.Other.other'. The locale value is also the untranslated string 'Other'. Needs reconciling in a follow-up — see PR description.",
+        "keys": ["label.Other"]
+      },
+      {
+        "reason": "The en.json value is an empty string, so there is nothing to translate. Candidate for deletion.",
+        "keys": ["listings.occupancyDescriptionAllSroPlural"]
+      },
+      {
+        "reason": "DAH-4213 housing counselor agency access shipped ahead of its translations. These 20 strings render in English today and are the reason this check was written.",
+        "keys": [
+          "accountSettings.housingCounselor.agencyCan",
+          "accountSettings.housingCounselor.banner.shortError",
+          "accountSettings.housingCounselor.banner.title",
+          "accountSettings.housingCounselor.checkbox",
+          "accountSettings.housingCounselor.checkboxError",
+          "accountSettings.housingCounselor.description",
+          "accountSettings.housingCounselor.fieldError",
+          "accountSettings.housingCounselor.heading",
+          "accountSettings.housingCounselor.label",
+          "accountSettings.housingCounselor.p1",
+          "accountSettings.housingCounselor.p2",
+          "accountSettings.housingCounselor.p3",
+          "accountSettings.housingCounselor.p4",
+          "accountSettings.housingCounselor.placeholder",
+          "accountSettings.housingCounselor.revokeButton",
+          "accountSettings.housingCounselor.shareButton",
+          "accountSettings.housingCounselor.sharedOn",
+          "accountSettings.housingCounselor.sharedWith",
+          "accountSettings.housingCounselor.toastShared",
+          "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

`loadTranslations()` in [`app/javascript/util/languageUtil.tsx`](https://github.com/SFDigitalServices/sf-dahlia-web/blob/main/app/javascript/util/languageUtil.tsx) loads English first and then overlays the target locale:

```ts
addTranslation(await loadDefaultTranslation())
const config = LANGUAGE_CONFIGS[prefix]
if (!config.isDefault) {
  addTranslation(await config.load())
}
```

A key that is absent from `es.json` therefore renders **the English string** — no raw key, no empty box, no console warning. Nothing in the app surfaces it, and nothing in CI does either: the existing `translations-check` workflow only runs `jsonlint` and verifies each file is `jq -S` sorted. It never compares key sets between locales.

This is not hypothetical. On `main` today, `es.json`, `tl.json`, and `zh.json` are each missing **26 keys** relative to `en.json`'s 2,097 — 20 of them the `accountSettings.housingCounselor.*` strings from DAH-4213. Those are being shown in English to Spanish, Chinese, and Tagalog speakers right now.

## What this adds

`scripts/check-translation-parity.js` flattens each locale file and diffs its key set against `en.json`. It fails the build on:

- **keys missing** from a locale (silently render in English)
- **keys present but empty** (render blank, which is worse than the fallback)

It reports, without failing, keys present in a locale but not in `en.json` — currently 10 per locale, all dead weight from removed features.

Runs as a second job in the existing `translations-check` workflow, and locally via `yarn check:translations`.

## The allowlist is a ratchet, not a resolution

`scripts/known-translation-gaps.json` is seeded with the 26 already-missing keys per locale so this can merge without blocking unrelated PRs. Entries are grouped under a written reason. It should only ever get shorter — the script also flags stale entries once a key gets translated.

Of the 26, three groups are worth separate attention:

| Keys | Finding |
|---|---|
| `accountSettings.housingCounselor.*` (20) | Genuinely awaiting translation — DAH-4213 shipped ahead of its strings. **These need a follow-up ticket.** |
| `languages.en/es/tl/zh` (4) | Working as intended. The switcher shows each language in its own name (`Español`, `中文`), so the English values are correct everywhere and the fallback is deliberate. |
| `label.Other` (1) | **Pre-existing bug.** `en.json` defines `label.Other`; the locale files define `label.Other.other`. The key names don't match, so every locale falls back — and the locale value is the untranslated string `"Other"` anyway. Needs reconciling. |
| `listings.occupancyDescriptionAllSroPlural` (1) | The `en.json` value is an empty string. Candidate for deletion. |

## Testing

- Against `main` as-is: **passes**, reporting 78 allowlisted gaps (26 × 3 locales).
- Negative test — deleted one key and blanked another in `es.json`: **fails** with exit 1, naming both. `es.json` restored, `git diff` clean.
- `yarn lint` and `npx prettier --check` both pass.

## Note on `eslint.config.mjs`

`scripts/**` is added to the ignore list. The flat config applies `parserOptions.project: ["tsconfig.lint.json"]` globally rather than scoping it to the `files` blocks, so any plain Node script outside the TS project fails `yarn lint` with a parsing error. This matches how `Gruntfile.js`, `lighthouserc.js`, and `config/webpack/**` are already handled. Verified `yarn lint` exits 0 with the change and 1 without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
