### PR TITLE
feat: DAH-3462 Add bidirectional application transform layer

### DIFF
--- a/app/javascript/__tests__/api/formApiService.test.ts
+++ b/app/javascript/__tests__/api/formApiService.test.ts
@@ -67,7 +67,9 @@ describe("formApiService", () => {
         primaryApplicantFirstName: "First name",
         primaryApplicantMiddleName: "Middle name",
         primaryApplicantLastName: "Last name",
-        primaryApplicantDob: "1990-01-01",
+        primaryApplicantBirthYear: "1990",
+        primaryApplicantBirthMonth: "1",
+        primaryApplicantBirthDate: "1",
       }
       await submitForm(formData, "testListingId")
 
@@ -84,7 +86,8 @@ describe("formApiService", () => {
             dob: "1990-01-01",
           },
           householdMembers: [],
-          annualIncome: 0,
+          adaPrioritiesSelected: "None;",
+          formMetadata: "{}",
           applicationSubmittedDate: today,
         },
         autosave: false,
@@ -92,6 +95,25 @@ describe("formApiService", () => {
         locale: "en",
         uploaded_file: { file: "todo.png" },
       })
+    })
+
+    it("maps the whole form, not just the applicant's name", async () => {
+      await submitForm(
+        {
+          primaryApplicantFirstName: "Alice",
+          primaryApplicantLastName: "Cooper",
+          householdIncome: "1250",
+          householdIncomeMultiplier: "per_month",
+          householdMembers: [{ firstName: "Carol", lastName: "Cooper", relationship: "Sibling" }],
+        },
+        "testListingId"
+      )
+
+      const { application } = (post as jest.Mock).mock.calls[0][1]
+      expect(application.monthlyIncome).toBe(1250)
+      expect(application.householdMembers).toEqual([
+        { firstName: "Carol", lastName: "Cooper", relationship: "Sibling" },
+      ])
     })
   })
 

--- a/app/javascript/__tests__/util/applicationTransforms/codecs.test.ts
+++ b/app/javascript/__tests__/util/applicationTransforms/codecs.test.ts
@@ -1,0 +1,170 @@
+import {
+  checkboxToBoolean,
+  dateOfBirth,
+  identity,
+  number,
+  pickList,
+  streetAndUnit,
+  text,
+  yesNoToBoolean,
+  yesNoToBooleanString,
+} from "../../../util/applicationTransforms/codecs"
+
+describe("application transform codecs", () => {
+  describe("identity", () => {
+    it("drops empty values on the way out", () => {
+      expect(identity.toSf(null)).toBeUndefined()
+      expect(identity.toSf("")).toBeUndefined()
+      expect(identity.toSf("Home")).toBe("Home")
+    })
+
+    it("normalizes missing values to an empty string on the way in", () => {
+      expect(identity.fromSf(undefined)).toBe("")
+      expect(identity.fromSf(null)).toBe("")
+      expect(identity.fromSf("Home")).toBe("Home")
+    })
+  })
+
+  describe("text", () => {
+    it("trims and drops blank strings", () => {
+      expect(text.toSf("  Alice  ")).toBe("Alice")
+      expect(text.toSf("   ")).toBeUndefined()
+      expect(text.toSf(undefined)).toBeUndefined()
+    })
+  })
+
+  describe("yesNoToBooleanString", () => {
+    it("converts to the strings Salesforce expects", () => {
+      expect(yesNoToBooleanString.toSf("Yes")).toBe("true")
+      expect(yesNoToBooleanString.toSf("No")).toBe("false")
+    })
+
+    it("treats anything else as unanswered", () => {
+      expect(yesNoToBooleanString.toSf(null)).toBeUndefined()
+      expect(yesNoToBooleanString.toSf("")).toBeUndefined()
+    })
+
+    it("round-trips both answers", () => {
+      expect(yesNoToBooleanString.fromSf(yesNoToBooleanString.toSf("Yes"))).toBe("Yes")
+      expect(yesNoToBooleanString.fromSf(yesNoToBooleanString.toSf("No"))).toBe("No")
+    })
+
+    it("returns null for an unset Salesforce value", () => {
+      expect(yesNoToBooleanString.fromSf(undefined)).toBeNull()
+    })
+  })
+
+  describe("yesNoToBoolean", () => {
+    it("round-trips both answers", () => {
+      expect(yesNoToBoolean.toSf("Yes")).toBe(true)
+      expect(yesNoToBoolean.toSf("No")).toBe(false)
+      expect(yesNoToBoolean.fromSf(true)).toBe("Yes")
+      expect(yesNoToBoolean.fromSf(false)).toBe("No")
+      expect(yesNoToBoolean.fromSf(undefined)).toBeNull()
+    })
+  })
+
+  describe("checkboxToBoolean", () => {
+    it("coerces truthiness", () => {
+      expect(checkboxToBoolean.toSf(true)).toBe(true)
+      expect(checkboxToBoolean.toSf(false)).toBe(false)
+      expect(checkboxToBoolean.fromSf(true)).toBe(true)
+      expect(checkboxToBoolean.fromSf(undefined)).toBe(false)
+    })
+
+    it("omits a checkbox the applicant never saw", () => {
+      expect(checkboxToBoolean.toSf(undefined)).toBeUndefined()
+      expect(checkboxToBoolean.toSf(null)).toBeUndefined()
+    })
+  })
+
+  describe("pickList", () => {
+    it("builds a semicolon-terminated list", () => {
+      expect(pickList.toSf(["Adaptable", "Vision impairments"])).toBe(
+        "Adaptable;Vision impairments;"
+      )
+    })
+
+    it("omits an empty selection", () => {
+      expect(pickList.toSf([])).toBeUndefined()
+      expect(pickList.toSf(undefined)).toBeUndefined()
+    })
+
+    it("parses a list back into an array", () => {
+      expect(pickList.fromSf("Adaptable;Vision impairments;")).toEqual([
+        "Adaptable",
+        "Vision impairments",
+      ])
+    })
+
+    it("returns an empty array for no selection", () => {
+      expect(pickList.fromSf(undefined)).toEqual([])
+      expect(pickList.fromSf("")).toEqual([])
+    })
+
+    it("round-trips", () => {
+      const selected = ["Asian - Chinese", "White - European"]
+      expect(pickList.fromSf(pickList.toSf(selected))).toEqual(selected)
+    })
+  })
+
+  describe("number", () => {
+    it("strips currency formatting", () => {
+      expect(number.toSf("$1,250")).toBe(1250)
+      expect(number.toSf("1250")).toBe(1250)
+    })
+
+    it("omits blank and unparseable values", () => {
+      expect(number.toSf("")).toBeUndefined()
+      expect(number.toSf(null)).toBeUndefined()
+      expect(number.toSf("not a number")).toBeUndefined()
+    })
+
+    it("round-trips", () => {
+      expect(number.fromSf(number.toSf("1250"))).toBe("1250")
+    })
+  })
+
+  describe("dateOfBirth", () => {
+    it("zero-pads into a Salesforce date", () => {
+      expect(dateOfBirth.toSf(["1985", "6", "5"])).toBe("1985-06-05")
+    })
+
+    it("omits an incomplete date", () => {
+      expect(dateOfBirth.toSf(["1985", "6", ""])).toBeUndefined()
+      expect(dateOfBirth.toSf(["", "", ""])).toBeUndefined()
+    })
+
+    it("omits an impossible date", () => {
+      expect(dateOfBirth.toSf(["1985", "2", "30"])).toBeUndefined()
+    })
+
+    it("splits a Salesforce date back into three inputs", () => {
+      expect(dateOfBirth.fromSf("1985-06-05")).toEqual(["1985", "06", "05"])
+    })
+
+    it("returns empty inputs when there is no date", () => {
+      expect(dateOfBirth.fromSf(undefined)).toEqual(["", "", ""])
+    })
+
+    it("round-trips a padded date", () => {
+      expect(dateOfBirth.toSf(dateOfBirth.fromSf("1985-06-05"))).toBe("1985-06-05")
+    })
+  })
+
+  describe("streetAndUnit", () => {
+    it("joins the street and unit", () => {
+      expect(streetAndUnit.toSf(["1 Main St", "Apt 2"])).toBe("1 Main St Apt 2")
+    })
+
+    it("handles a missing unit", () => {
+      expect(streetAndUnit.toSf(["1 Main St", ""])).toBe("1 Main St")
+      expect(streetAndUnit.toSf(["", ""])).toBeUndefined()
+    })
+
+    // documented lossiness: the unit boundary is not recoverable
+    it("returns the whole string as the street, with no unit", () => {
+      expect(streetAndUnit.fromSf("1 Main St Apt 2")).toEqual(["1 Main St Apt 2", ""])
+    })
+  })
+})

--- a/app/javascript/__tests__/util/applicationTransforms/crossFieldTransforms.test.ts
+++ b/app/javascript/__tests__/util/applicationTransforms/crossFieldTransforms.test.ts
@@ -1,0 +1,200 @@
+import {
+  adaPriorities,
+  formMetadata,
+  geocodingDataToFormData,
+  income,
+  totalMonthlyRent,
+} from "../../../util/applicationTransforms/crossFieldTransforms"
+import { HCBS_PRIORITY_NAME } from "../../../util/applicationTransforms/constants"
+
+describe("cross-field application transforms", () => {
+  describe("income", () => {
+    it("sends a monthly amount to monthlyIncome", () => {
+      expect(
+        income.toSf({ householdIncome: "1250", householdIncomeMultiplier: "per_month" })
+      ).toEqual({ monthlyIncome: 1250 })
+    })
+
+    it("sends a yearly amount to annualIncome", () => {
+      expect(
+        income.toSf({ householdIncome: "15000", householdIncomeMultiplier: "per_year" })
+      ).toEqual({ annualIncome: 15000 })
+    })
+
+    it("strips currency formatting", () => {
+      expect(
+        income.toSf({ householdIncome: "$1,250", householdIncomeMultiplier: "per_month" })
+      ).toEqual({ monthlyIncome: 1250 })
+    })
+
+    it("sends nothing when no income was entered", () => {
+      expect(income.toSf({})).toEqual({})
+      expect(income.toSf({ householdIncome: "" })).toEqual({})
+    })
+
+    it("recovers the amount and the timeframe", () => {
+      expect(income.fromSf({ monthlyIncome: 1250 })).toEqual({
+        householdIncome: "1250",
+        householdIncomeMultiplier: "per_month",
+      })
+      expect(income.fromSf({ annualIncome: 15000 })).toEqual({
+        householdIncome: "15000",
+        householdIncomeMultiplier: "per_year",
+      })
+      expect(income.fromSf({})).toEqual({})
+    })
+
+    it("round-trips both timeframes", () => {
+      for (const multiplier of ["per_month", "per_year"]) {
+        const formData = { householdIncome: "1250", householdIncomeMultiplier: multiplier }
+        expect(income.fromSf(income.toSf(formData))).toEqual(formData)
+      }
+    })
+  })
+
+  describe("adaPriorities", () => {
+    it("builds a semicolon-terminated picklist", () => {
+      expect(adaPriorities.toSf({ adaPrioritiesSelected: ["Adaptable", "Vision impairments"] })).toEqual(
+        { adaPrioritiesSelected: "Adaptable;Vision impairments;" }
+      )
+    })
+
+    it("sends None when nothing is selected", () => {
+      expect(adaPriorities.toSf({})).toEqual({ adaPrioritiesSelected: "None;" })
+      expect(adaPriorities.toSf({ adaPrioritiesSelected: [] })).toEqual({
+        adaPrioritiesSelected: "None;",
+      })
+    })
+
+    it("folds the HCBS answer into the picklist", () => {
+      expect(
+        adaPriorities.toSf({
+          adaPrioritiesSelected: ["Adaptable"],
+          hasHomeAndCommunityBasedServices: "Yes",
+        })
+      ).toEqual({ adaPrioritiesSelected: `Adaptable;${HCBS_PRIORITY_NAME};` })
+    })
+
+    it("sends HCBS alone rather than alongside None", () => {
+      expect(
+        adaPriorities.toSf({
+          adaPrioritiesSelected: [],
+          hasHomeAndCommunityBasedServices: "Yes",
+        })
+      ).toEqual({ adaPrioritiesSelected: `${HCBS_PRIORITY_NAME};` })
+    })
+
+    it("separates the HCBS answer back out of the picklist", () => {
+      expect(
+        adaPriorities.fromSf({ adaPrioritiesSelected: `Adaptable;${HCBS_PRIORITY_NAME};` })
+      ).toEqual({
+        adaPrioritiesSelected: ["Adaptable"],
+        hasHomeAndCommunityBasedServices: "Yes",
+      })
+    })
+
+    it("reads None as no priorities", () => {
+      expect(adaPriorities.fromSf({ adaPrioritiesSelected: "None;" })).toEqual({
+        adaPrioritiesSelected: [],
+        hasHomeAndCommunityBasedServices: "No",
+      })
+    })
+
+    it("round-trips priorities with and without HCBS", () => {
+      for (const hcbs of ["Yes", "No"]) {
+        const formData = {
+          adaPrioritiesSelected: ["Adaptable", "Mobility impairments"],
+          hasHomeAndCommunityBasedServices: hcbs,
+        }
+        expect(adaPriorities.fromSf(adaPriorities.toSf(formData))).toEqual(formData)
+      }
+    })
+  })
+
+  describe("totalMonthlyRent", () => {
+    it("sums the per-address rents", () => {
+      expect(
+        totalMonthlyRent.toSf({
+          groupedHouseholdAddresses: [{ monthlyRent: 1000 }, { monthlyRent: 500 }],
+        })
+      ).toEqual({ totalMonthlyRent: 1500 })
+    })
+
+    it("counts missing rents as zero", () => {
+      expect(
+        totalMonthlyRent.toSf({
+          groupedHouseholdAddresses: [{ monthlyRent: 1000 }, {}],
+        })
+      ).toEqual({ totalMonthlyRent: 1000 })
+    })
+
+    it("sends nothing when there are no addresses", () => {
+      expect(totalMonthlyRent.toSf({})).toEqual({})
+    })
+
+    // not invertible; the grouped addresses come back via formMetadata
+    it("recovers nothing on the way in", () => {
+      expect(totalMonthlyRent.fromSf({ totalMonthlyRent: 1500 })).toEqual({})
+    })
+  })
+
+  describe("formMetadata", () => {
+    it("stashes the metadata fields as JSON", () => {
+      const result = formMetadata.toSf({
+        lastPage: "household-overview",
+        completedSections: { you: true },
+        primaryApplicantFirstName: "Alice",
+      })
+      expect(JSON.parse(result.formMetadata as string)).toEqual({
+        lastPage: "household-overview",
+        completedSections: { you: true },
+      })
+    })
+
+    it("round-trips the metadata fields", () => {
+      const formData = {
+        lastPage: "household-overview",
+        completedSections: { you: true },
+        session_uid: "abc-123",
+        groupedHouseholdAddresses: [{ address: "1 Main St", monthlyRent: 1000 }],
+      }
+      expect(formMetadata.fromSf(formMetadata.toSf(formData))).toEqual(formData)
+    })
+
+    it("recovers nothing when there is no metadata", () => {
+      expect(formMetadata.fromSf({})).toEqual({})
+    })
+
+    it("survives unparseable metadata", () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined)
+      expect(formMetadata.fromSf({ formMetadata: "not json" })).toEqual({})
+      jest.restoreAllMocks()
+    })
+  })
+
+  describe("geocodingDataToFormData", () => {
+    it("flattens the geocoding response", () => {
+      expect(
+        geocodingDataToFormData({
+          location: { x: -122.4, y: 37.7 },
+          attributes: { Loc_name: "SF_Address" },
+          score: 100,
+        })
+      ).toEqual({
+        xCoordinate: -122.4,
+        yCoordinate: 37.7,
+        whichComponentOfLocatorWasUsed: "SF_Address",
+        candidateScore: 100,
+      })
+    })
+
+    it("prefixes the field names when asked", () => {
+      const result = geocodingDataToFormData({ location: { x: -122.4 } }, "primaryApplicant")
+      expect(result.primaryApplicantXCoordinate).toBe(-122.4)
+    })
+
+    it("returns nothing when there is no geocoding data", () => {
+      expect(geocodingDataToFormData(undefined)).toEqual({})
+    })
+  })
+})

--- a/app/javascript/__tests__/util/applicationTransforms/fieldMap.test.ts
+++ b/app/javascript/__tests__/util/applicationTransforms/fieldMap.test.ts
@@ -1,0 +1,106 @@
+import { dateOfBirth, text, yesNoToBooleanString } from "../../../util/applicationTransforms/codecs"
+import {
+  applyFromSf,
+  applyToSf,
+  prefixForm,
+  type FieldMap,
+} from "../../../util/applicationTransforms/fieldMap"
+
+const map: FieldMap = [
+  { form: "firstName", sf: "firstName", codec: text },
+  { form: "workInSf", sf: "workInSf", codec: yesNoToBooleanString },
+  { form: ["birthYear", "birthMonth", "birthDate"], sf: "dob", codec: dateOfBirth },
+  { form: "relationship", sf: "relationship" },
+  { form: "lotteryNumber", sf: "lotteryNumber", readOnly: true },
+]
+
+describe("field map engine", () => {
+  describe("applyToSf", () => {
+    it("renames fields and applies codecs", () => {
+      expect(
+        applyToSf(map, {
+          firstName: "Alice",
+          workInSf: "Yes",
+          birthYear: "1985",
+          birthMonth: "6",
+          birthDate: "5",
+          relationship: "Cousin",
+        })
+      ).toEqual({
+        firstName: "Alice",
+        workInSf: "true",
+        dob: "1985-06-05",
+        relationship: "Cousin",
+      })
+    })
+
+    it("omits fields with no value rather than sending nulls", () => {
+      expect(applyToSf(map, { firstName: "Alice" })).toEqual({ firstName: "Alice" })
+    })
+
+    it("skips read-only fields Salesforce calculates", () => {
+      expect(applyToSf(map, { lotteryNumber: 42 })).toEqual({})
+    })
+  })
+
+  describe("applyFromSf", () => {
+    it("is the inverse of applyToSf", () => {
+      const formData = {
+        firstName: "Alice",
+        workInSf: "Yes",
+        birthYear: "1985",
+        birthMonth: "06",
+        birthDate: "05",
+        relationship: "Cousin",
+        lotteryNumber: "",
+      }
+      expect(applyFromSf(map, applyToSf(map, formData))).toEqual(formData)
+    })
+
+    it("spreads a multi-field codec back across its form fields", () => {
+      const result = applyFromSf(map, { dob: "1985-06-05" })
+      expect(result.birthYear).toBe("1985")
+      expect(result.birthMonth).toBe("06")
+      expect(result.birthDate).toBe("05")
+    })
+
+    it("reads read-only fields", () => {
+      expect(applyFromSf(map, { lotteryNumber: 42 }).lotteryNumber).toBe(42)
+    })
+
+    it("fills empty form fields when the Salesforce record is empty", () => {
+      expect(applyFromSf(map, {})).toEqual({
+        firstName: "",
+        workInSf: null,
+        birthYear: "",
+        birthMonth: "",
+        birthDate: "",
+        relationship: "",
+        lotteryNumber: "",
+      })
+    })
+  })
+
+  describe("prefixForm", () => {
+    it("namespaces the form side, leaving the Salesforce side alone", () => {
+      const prefixed = prefixForm(map, "primaryApplicant")
+      expect(prefixed[0]).toMatchObject({ form: "primaryApplicantFirstName", sf: "firstName" })
+    })
+
+    it("namespaces every field of a multi-field entry", () => {
+      const prefixed = prefixForm(map, "primaryApplicant")
+      expect(prefixed[2].form).toEqual([
+        "primaryApplicantBirthYear",
+        "primaryApplicantBirthMonth",
+        "primaryApplicantBirthDate",
+      ])
+    })
+
+    it("reads prefixed form data", () => {
+      const prefixed = prefixForm(map, "primaryApplicant")
+      expect(applyToSf(prefixed, { primaryApplicantFirstName: "Alice" })).toEqual({
+        firstName: "Alice",
+      })
+    })
+  })
+})

--- a/app/javascript/__tests__/util/applicationTransforms/index.test.ts
+++ b/app/javascript/__tests__/util/applicationTransforms/index.test.ts
@@ -1,0 +1,209 @@
+import {
+  applicationToFormData,
+  formDataToApplication,
+  getAlternateContactData,
+  getHouseholdMembersData,
+  getPrimaryApplicantData,
+} from "../../../util/applicationTransforms"
+
+const formData = {
+  primaryApplicantFirstName: "Alice",
+  primaryApplicantMiddleName: "B",
+  primaryApplicantLastName: "Cooper",
+  primaryApplicantBirthYear: "1985",
+  primaryApplicantBirthMonth: "06",
+  primaryApplicantBirthDate: "05",
+  primaryApplicantAddressStreet: "1 Main St",
+  primaryApplicantAddressAptOrUnit: "",
+  primaryApplicantAddressCity: "San Francisco",
+  primaryApplicantAddressState: "CA",
+  primaryApplicantAddressZipcode: "94103",
+  primaryApplicantPhone: "4155551234",
+  primaryApplicantPhoneType: "Cell",
+  primaryApplicantEmail: "alice@example.com",
+  primaryApplicantWorkInSf: "Yes",
+  householdVouchersSubsidies: "No",
+  householdIncome: "1250",
+  householdIncomeMultiplier: "per_month",
+  adaPrioritiesSelected: ["Adaptable"],
+  hasHomeAndCommunityBasedServices: "No",
+  alternateContactType: "Friend",
+  alternateContactFirstName: "Bob",
+  alternateContactLastName: "Jones",
+  householdMembers: [
+    {
+      firstName: "Carol",
+      middleName: "",
+      lastName: "Cooper",
+      birthYear: "1990",
+      birthMonth: "01",
+      birthDate: "15",
+      relationship: "Sibling",
+      hasSameAddressAsApplicant: "Yes",
+    },
+  ],
+}
+
+describe("applicationTransforms", () => {
+  describe("getPrimaryApplicantData", () => {
+    it("maps the applicant's name, date of birth and address", () => {
+      const applicant = getPrimaryApplicantData(formData)
+      expect(applicant).toMatchObject({
+        firstName: "Alice",
+        middleName: "B",
+        lastName: "Cooper",
+        dob: "1985-06-05",
+        address: "1 Main St",
+        city: "San Francisco",
+        state: "CA",
+        zip: "94103",
+        workInSf: "true",
+      })
+    })
+
+    it("maps the applicant's contact info", () => {
+      expect(getPrimaryApplicantData(formData)).toMatchObject({
+        phone: "4155551234",
+        phoneType: "Cell",
+        email: "alice@example.com",
+      })
+    })
+
+    it("joins the street and unit into the Salesforce address field", () => {
+      const applicant = getPrimaryApplicantData({
+        ...formData,
+        primaryApplicantAddressAptOrUnit: "Apt 4",
+      })
+      expect(applicant.address).toBe("1 Main St Apt 4")
+    })
+  })
+
+  describe("getHouseholdMembersData", () => {
+    it("maps each member with the shared member fields", () => {
+      expect(getHouseholdMembersData(formData)).toEqual([
+        {
+          firstName: "Carol",
+          lastName: "Cooper",
+          dob: "1990-01-15",
+          relationship: "Sibling",
+          hasSameAddressAsApplicant: true,
+        },
+      ])
+    })
+
+    it("returns an empty list when the applicant lives alone", () => {
+      expect(getHouseholdMembersData({})).toEqual([])
+    })
+  })
+
+  describe("getAlternateContactData", () => {
+    it("maps the contact's address into the mailing fields", () => {
+      const contact = getAlternateContactData({
+        ...formData,
+        alternateContactAddressStreet: "2 Oak St",
+        alternateContactAddressCity: "Oakland",
+        alternateContactAddressState: "CA",
+        alternateContactAddressZipcode: "94601",
+      })
+      expect(contact).toMatchObject({
+        mailingAddress: "2 Oak St",
+        mailingCity: "Oakland",
+        mailingState: "CA",
+        mailingZip: "94601",
+      })
+    })
+  })
+
+  describe("formDataToApplication", () => {
+    it("assembles the nested Salesforce payload", () => {
+      const application = formDataToApplication(formData)
+      expect(application.primaryApplicant).toMatchObject({ firstName: "Alice" })
+      expect(application.householdMembers).toHaveLength(1)
+      expect(application.alternateContact).toMatchObject({ firstName: "Bob", lastName: "Jones" })
+    })
+
+    it("applies the cross-field transforms", () => {
+      const application = formDataToApplication(formData)
+      expect(application.monthlyIncome).toBe(1250)
+      expect(application.adaPrioritiesSelected).toBe("Adaptable;")
+      expect(application.householdVouchersSubsidies).toBe("false")
+      expect(typeof application.formMetadata).toBe("string")
+    })
+
+    it("omits the alternate contact when the applicant declined to name one", () => {
+      const application = formDataToApplication({
+        ...formData,
+        alternateContactType: "None",
+        alternateContactFirstName: "",
+        alternateContactLastName: "",
+      })
+      expect(application.alternateContact).toBeUndefined()
+    })
+
+    it("omits the alternate contact when the name is incomplete", () => {
+      const application = formDataToApplication({
+        ...formData,
+        alternateContactLastName: "",
+      })
+      expect(application.alternateContact).toBeUndefined()
+    })
+  })
+
+  describe("applicationToFormData", () => {
+    it("round-trips the fields the form collects", () => {
+      const restored = applicationToFormData(formDataToApplication(formData))
+
+      // scalar fields, including those needing cross-field logic
+      expect(restored).toMatchObject({
+        primaryApplicantFirstName: "Alice",
+        primaryApplicantMiddleName: "B",
+        primaryApplicantLastName: "Cooper",
+        primaryApplicantBirthYear: "1985",
+        primaryApplicantBirthMonth: "06",
+        primaryApplicantBirthDate: "05",
+        primaryApplicantAddressStreet: "1 Main St",
+        primaryApplicantAddressCity: "San Francisco",
+        primaryApplicantAddressState: "CA",
+        primaryApplicantAddressZipcode: "94103",
+        primaryApplicantWorkInSf: "Yes",
+        householdVouchersSubsidies: "No",
+        householdIncome: "1250",
+        householdIncomeMultiplier: "per_month",
+        adaPrioritiesSelected: ["Adaptable"],
+        hasHomeAndCommunityBasedServices: "No",
+        alternateContactFirstName: "Bob",
+      })
+    })
+
+    it("uses form field names, not Salesforce ones", () => {
+      const restored = applicationToFormData(formDataToApplication(formData))
+      expect(restored).not.toHaveProperty("city")
+      expect(restored).not.toHaveProperty("primaryApplicantCity")
+      expect(restored).not.toHaveProperty("dob")
+    })
+
+    it("round-trips household members", () => {
+      const restored = applicationToFormData(formDataToApplication(formData))
+      expect(restored.householdMembers).toMatchObject([
+        {
+          firstName: "Carol",
+          lastName: "Cooper",
+          birthYear: "1990",
+          birthMonth: "01",
+          birthDate: "15",
+          relationship: "Sibling",
+          hasSameAddressAsApplicant: "Yes",
+        },
+      ])
+    })
+
+    it("marks the alternate contact as None when the application has none", () => {
+      expect(applicationToFormData({}).alternateContactType).toBe("None")
+    })
+
+    it("survives an empty application", () => {
+      expect(() => applicationToFormData({})).not.toThrow()
+      expect(applicationToFormData({}).householdMembers).toEqual([])
+    })
+  })
+})

--- a/app/javascript/__tests__/util/listingApplyUtil.test.ts
+++ b/app/javascript/__tests__/util/listingApplyUtil.test.ts
@@ -3,7 +3,7 @@ import MockDate from "mockdate"
 import {
   validAge,
   validVeteranAge,
-  getPrimaryApplicantData,
+  getPrimaryApplicantName,
   allHouseholdMembers,
   getProofOptions,
 } from "../../util/listingApplyUtil"
@@ -71,29 +71,18 @@ describe("listingApplyUtil", () => {
     })
   })
 
-  describe("getPrimaryApplicantData", () => {
+  describe("getPrimaryApplicantName", () => {
     it("extracts primary applicant name fields from form data", () => {
       const formData = {
         primaryApplicantFirstName: "Alice",
         primaryApplicantMiddleName: "B",
         primaryApplicantLastName: "Cooper",
-        primaryApplicantDob: "1985-06-15",
       }
-      expect(getPrimaryApplicantData(formData)).toEqual({
+      expect(getPrimaryApplicantName(formData)).toEqual({
         firstName: "Alice",
         middleName: "B",
         lastName: "Cooper",
-        dob: "1985-06-15",
       })
-    })
-
-    it("defaults dob when primaryApplicantDob is not present", () => {
-      const formData = {
-        primaryApplicantFirstName: "Alice",
-        primaryApplicantMiddleName: "",
-        primaryApplicantLastName: "Cooper",
-      }
-      expect(getPrimaryApplicantData(formData).dob).toBe("1990-01-01")
     })
   })
 

--- a/app/javascript/api/formApiService.ts
+++ b/app/javascript/api/formApiService.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from "axios"
 import { post, apiDelete } from "./apiService"
 import { getCurrentLanguage } from "../util/languageUtil"
 import { Application } from "./types/rails/application/RailsApplication"
-import { getPrimaryApplicantData } from "../util/listingApplyUtil"
+import { formDataToApplication } from "../util/applicationTransforms"
 
 type UploadProofFileResponse = {
   success: boolean
@@ -117,12 +117,10 @@ export const submitForm = async (
   listingId: string
 ): Promise<Record<string, unknown>> => {
   const applicationData: Partial<Application> = {
+    ...formDataToApplication(formData),
     listingID: listingId,
     applicationLanguage: LanguagePrefix[getCurrentLanguage()],
     status: "Submitted",
-    primaryApplicant: getPrimaryApplicantData(formData),
-    householdMembers: [],
-    annualIncome: 0, // TODO: update after DAH-3683
     applicationSubmittedDate: new Date().toISOString().split("T")[0],
   }
   return post<Record<string, unknown>>("/api/v1/short-form/application", {

--- a/app/javascript/pages/form/components/household/AddHouseholdMembers.tsx
+++ b/app/javascript/pages/form/components/household/AddHouseholdMembers.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { t } from "@bloom-housing/ui-components"
 import { Button, Card, Heading } from "@bloom-housing/ui-seeds"
 import { useFormEngineContext } from "../../../../formEngine/formEngineContext"
-import { getPrimaryApplicantData, getFullName } from "../../../../util/listingApplyUtil"
+import { getPrimaryApplicantName, getFullName } from "../../../../util/listingApplyUtil"
 import stepStyles from "../ListingApplyStepWrapper.module.scss"
 import styles from "./AddHouseholdMembers.module.scss"
 interface AddHouseholdMemberProps {
@@ -50,7 +50,7 @@ const AddHouseholdMembers = ({
   handleSubmitHouseholdMembers,
 }: AddHouseholdMemberProps) => {
   const { jumpToStep, formData } = useFormEngineContext()
-  const primaryApplicant = getPrimaryApplicantData(formData)
+  const primaryApplicant = getPrimaryApplicantName(formData)
   return (
     <Card>
       <Card.Header divider="inset">

--- a/app/javascript/pages/form/components/household/ListingApplyHouseholdMonthlyRentStep.tsx
+++ b/app/javascript/pages/form/components/household/ListingApplyHouseholdMonthlyRentStep.tsx
@@ -7,7 +7,7 @@ import { useFormEngineContext } from "../../../../formEngine/formEngineContext"
 import { getAddress, translationFromDataSchema } from "../../../../util/formEngineUtil"
 import ListingApplyHouseholdMonthlyRent from "./ListingApplyHouseholdMonthlyRent"
 import styles from "./ListingApplyhouseholdMonthlyRentStep.module.scss"
-import { getPrimaryApplicantData } from "../../../../util/listingApplyUtil"
+import { getPrimaryApplicantName } from "../../../../util/listingApplyUtil"
 
 // TODO: DAH-4176 centralize HouseholdMember and GroupedAddress data for other pages to use
 type HouseholdMember = {
@@ -45,7 +45,7 @@ const ListingApplyHouseholdMonthlyRentStep = ({
 
   const groupedAddresses = useMemo<GroupedAddress[]>(() => {
     const { firstName: primaryFirstName, lastName: primaryLastName } =
-      getPrimaryApplicantData(formData)
+      getPrimaryApplicantName(formData)
     const householdMembers = (formData.householdMembers as HouseholdMember[]) ?? []
     const primaryAddress = getAddress(
       formData.primaryApplicantAddressStreet as string,

--- a/app/javascript/util/applicationTransforms/codecs.ts
+++ b/app/javascript/util/applicationTransforms/codecs.ts
@@ -1,0 +1,150 @@
+/**
+ * Bidirectional value codecs for translating between form engine `formData`
+ * values and the Salesforce-shaped `Application` payload.
+ *
+ * Each codec is a `{ toSf, fromSf }` pair that must round-trip: for any value
+ * the form can produce, `fromSf(toSf(v))` should equal `v`. Codecs that cannot
+ * round-trip losslessly say so in a comment.
+ *
+ * Ported from the Angular ShortFormDataService `_format*` / `_reformat*`
+ * helpers, which implemented each direction as a separate function. Pairing
+ * them here keeps the two directions from drifting apart.
+ */
+
+import dayjs from "dayjs"
+import customParseFormat from "dayjs/plugin/customParseFormat"
+
+dayjs.extend(customParseFormat)
+
+export interface Codec<TForm = unknown, TSf = unknown> {
+  toSf: (value: TForm) => TSf
+  fromSf: (value: TSf) => TForm
+}
+
+/** Passes the value through untouched, normalizing empty values to undefined. */
+export const identity: Codec<unknown, unknown> = {
+  toSf: (value) => (value === null || value === "" ? undefined : value),
+  fromSf: (value) => (value === undefined || value === null ? "" : value),
+}
+
+/** Trims strings and drops empty ones. */
+export const text: Codec<string, string> = {
+  toSf: (value) => {
+    return value?.trim() || undefined
+  },
+  fromSf: (value) => value ?? "",
+}
+
+/**
+ * Salesforce stores several tri-state answers as the strings "true" / "false",
+ * with null meaning unanswered. The form uses radio values "Yes" / "No".
+ * Angular: `_formatBoolean` / `_reformatBoolean`.
+ */
+export const yesNoToBooleanString: Codec<string, "true" | "false"> = {
+  toSf: (value) => {
+    if (value === "Yes") return "true"
+    if (value === "No") return "false"
+    return undefined
+  },
+  fromSf: (value) => {
+    if (value === "true") return "Yes"
+    if (value === "false") return "No"
+    return null
+  },
+}
+
+/** As above, but for the fields Salesforce types as a real boolean. */
+export const yesNoToBoolean: Codec<string, boolean> = {
+  toSf: (value) => {
+    if (value === "Yes") return true
+    if (value === "No") return false
+    return undefined
+  },
+  fromSf: (value) => {
+    if (value === true) return "Yes"
+    if (value === false) return "No"
+    return null
+  },
+}
+
+/**
+ * A form checkbox (truthy / falsy) against a Salesforce boolean.
+ *
+ * A checkbox the applicant never saw is omitted rather than sent as `false`,
+ * matching Angular's `_.pick`-based whitelisting. Once the field exists in
+ * formData, an unchecked box does send `false`.
+ */
+export const checkboxToBoolean: Codec<unknown, boolean> = {
+  toSf: (value) => (value === undefined || value === null ? undefined : !!value),
+  fromSf: (value) => !!value,
+}
+
+/**
+ * Salesforce multi-selects are semicolon-delimited and semicolon-terminated
+ * ("Adaptable;Vision impairments;"). The form holds an array of selected keys.
+ * Angular: `_formatPickList` / `_reformatMultiSelect`.
+ */
+export const pickList: Codec<string[], string> = {
+  toSf: (value) => {
+    if (!value?.length) return undefined
+    return value.map((key) => `${key};`).join("")
+  },
+  fromSf: (value) =>
+    (value ?? "")
+      .split(";")
+      .map((key) => key.trim())
+      .filter(Boolean),
+}
+
+/** Currency and score fields arrive from the form as strings. */
+export const number: Codec<string, number> = {
+  toSf: (value) => {
+    if (value === null || value === undefined || value === "") return undefined
+    const parsed = Number(String(value).replace(/[$,]/g, ""))
+    return Number.isNaN(parsed) ? undefined : parsed
+  },
+  fromSf: (value) => (value === null || value === undefined ? "" : String(value)),
+}
+
+/**
+ * The form collects a birth date as three separate inputs; Salesforce wants a
+ * single zero-padded "YYYY-MM-DD".
+ * Angular: `formatUserDOB` / `reformatDOB`.
+ */
+export const dateOfBirth: Codec<[string, string, string], string> = {
+  toSf: ([year, month, day]) => {
+    if (!year || !month || !day) return undefined
+    const parsed = dayjs(
+      `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+      "YYYY-MM-DD",
+      true
+    )
+    return parsed.isValid() ? parsed.format("YYYY-MM-DD") : undefined
+  },
+  fromSf: (value) => {
+    const [year, month, day] = (value ?? "").split("-")
+    return [year ?? "", month ?? "", day ?? ""]
+  },
+}
+
+/**
+ * Salesforce has one street field per address; the form keeps the street and
+ * the apt/unit separately.
+ *
+ * NOTE: lossy by design, matching the Angular behavior. `toSf` joins with a
+ * space and `fromSf` cannot know where the unit began, so it returns the whole
+ * string as the street and an empty unit. Round-tripping a draft moves the unit
+ * into the street field. Tracked for DAH-3533 (draft resume) — if we want this
+ * to round-trip we need the unit preserved in `formMetadata`.
+ */
+export const streetAndUnit: Codec<[string, string], string> = {
+  toSf: ([street, unit]) => {
+    return (
+      [street, unit]
+        .map((part) => part?.trim())
+        .filter(Boolean)
+        .join(" ") || undefined
+    )
+  },
+  fromSf: (value) => [value ?? "", ""],
+}

--- a/app/javascript/util/applicationTransforms/constants.ts
+++ b/app/javascript/util/applicationTransforms/constants.ts
@@ -1,0 +1,8 @@
+/** Constants shared by the application transforms. */
+
+/**
+ * Appended to the ADA priorities picklist so the "home and community based
+ * services" answer appears alongside priorities in the Leasing Agent Portal.
+ * Angular: `ListingConstantsService.HCBS_PRIORITY_NAME`.
+ */
+export const HCBS_PRIORITY_NAME = "HCBS Units"

--- a/app/javascript/util/applicationTransforms/crossFieldTransforms.ts
+++ b/app/javascript/util/applicationTransforms/crossFieldTransforms.ts
@@ -1,0 +1,157 @@
+/**
+ * Transforms that span more than one field and so can't be expressed as a
+ * single field-map entry. Each is still written as a `{ toSf, fromSf }` pair for
+ * the same reason the codecs are: so the two directions stay together.
+ *
+ * Keep this file small. If something here turns out to be a plain rename,
+ * move it into `fieldMaps.ts`.
+ */
+
+import { HCBS_PRIORITY_NAME } from "./constants"
+
+type Data = Record<string, unknown>
+
+export interface CrossFieldTransform {
+  toSf: (formData: Data) => Data
+  fromSf: (sfData: Data) => Data
+}
+
+/**
+ * One form amount + timeframe becomes one of two Salesforce fields.
+ * Angular: `_formatIncome` / `_reformatIncome`.
+ */
+export const income: CrossFieldTransform = {
+  toSf: (formData) => {
+    const entered = formData.householdIncome as string | number | undefined
+    const amount = Number(String(entered ?? "").replace(/[$,]/g, ""))
+    if (!entered || Number.isNaN(amount)) return {}
+    return formData.householdIncomeMultiplier === "per_month"
+      ? { monthlyIncome: amount }
+      : { annualIncome: amount }
+  },
+  fromSf: (sfData) => {
+    const monthly = sfData.monthlyIncome as number | undefined
+    if (monthly) {
+      return { householdIncome: String(monthly), householdIncomeMultiplier: "per_month" }
+    }
+    const annual = sfData.annualIncome as number | undefined
+    if (annual) {
+      return { householdIncome: String(annual), householdIncomeMultiplier: "per_year" }
+    }
+    return {}
+  },
+}
+
+/**
+ * ADA priorities are a semicolon-delimited multi-select, but the "home and
+ * community based services" answer is a separate yes/no question in the form
+ * that Salesforce expects folded into the same picklist, so it shows up
+ * alongside the priorities in the Leasing Agent Portal.
+ * Angular: the HCBS block in `formatApplication` / `reformatApplication`.
+ */
+export const adaPriorities: CrossFieldTransform = {
+  toSf: (formData) => {
+    const selected = [...((formData.adaPrioritiesSelected as string[]) ?? [])].filter(
+      (priority) => priority !== "None"
+    )
+    if (formData.hasHomeAndCommunityBasedServices === "Yes") {
+      selected.push(HCBS_PRIORITY_NAME)
+    }
+    if (selected.length === 0) return { adaPrioritiesSelected: "None;" }
+    return { adaPrioritiesSelected: selected.map((priority) => `${priority};`).join("") }
+  },
+  fromSf: (sfData) => {
+    const selected = ((sfData.adaPrioritiesSelected as string) ?? "")
+      .split(";")
+      .map((priority) => priority.trim())
+      .filter((priority) => priority && priority !== "None")
+    const hasHcbs = selected.includes(HCBS_PRIORITY_NAME)
+    return {
+      adaPrioritiesSelected: selected.filter((priority) => priority !== HCBS_PRIORITY_NAME),
+      hasHomeAndCommunityBasedServices: hasHcbs ? "Yes" : "No",
+    }
+  },
+}
+
+/**
+ * Total monthly rent is the sum of the per-address rents collected on the
+ * household monthly rent step.
+ * Angular: `_calculateTotalMonthlyRent`.
+ *
+ * NOTE: not invertible — the sum can't be split back into per-address values.
+ * `fromSf` returns nothing and relies on the grouped addresses being restored
+ * from `formMetadata` instead.
+ */
+export const totalMonthlyRent: CrossFieldTransform = {
+  toSf: (formData) => {
+    const addresses = (formData.groupedHouseholdAddresses as { monthlyRent?: unknown }[]) ?? []
+    if (addresses.length === 0) return {}
+    const total = addresses.reduce((sum, address) => sum + (Number(address.monthlyRent) || 0), 0)
+    return { totalMonthlyRent: total }
+  },
+  fromSf: () => ({}),
+}
+
+/**
+ * Fields the form needs on resume but Salesforce has no column for get stashed
+ * in a JSON string. This is also where anything that doesn't round-trip through
+ * a codec should be preserved.
+ * Angular: `_formatMetadata` / `_reformatMetadata`.
+ */
+export const META_FIELDS = [
+  "completedSections",
+  "session_uid",
+  "lastPage",
+  "groupedHouseholdAddresses",
+] as const
+
+export const formMetadata: CrossFieldTransform = {
+  toSf: (formData) => {
+    const metadata: Data = {}
+    for (const field of META_FIELDS) {
+      if (formData[field] !== undefined) metadata[field] = formData[field]
+    }
+    return { formMetadata: JSON.stringify(metadata) }
+  },
+  fromSf: (sfData) => {
+    if (!sfData.formMetadata) return {}
+    try {
+      const parsed = JSON.parse(sfData.formMetadata as string) as Data
+      const result: Data = {}
+      for (const field of META_FIELDS) {
+        if (parsed[field] !== undefined) result[field] = parsed[field]
+      }
+      return result
+    } catch {
+      console.error("Could not parse formMetadata")
+      return {}
+    }
+  },
+}
+
+/**
+ * Geocoding results arrive from the address verification API as a nested object
+ * and are stored flat. Applies to the primary applicant and each household
+ * member, so it takes an optional form field prefix.
+ * Angular: `_formatGeocodingData`.
+ */
+export const geocodingDataToFormData = (
+  geocodingData:
+    | {
+        location?: { x?: unknown; y?: unknown }
+        attributes?: { Loc_name?: unknown }
+        score?: unknown
+      }
+    | undefined,
+  prefix = ""
+): Data => {
+  if (!geocodingData) return {}
+  const key = (name: string) =>
+    prefix ? prefix + name.charAt(0).toUpperCase() + name.slice(1) : name
+  return {
+    [key("xCoordinate")]: geocodingData.location?.x,
+    [key("yCoordinate")]: geocodingData.location?.y,
+    [key("whichComponentOfLocatorWasUsed")]: geocodingData.attributes?.Loc_name,
+    [key("candidateScore")]: geocodingData.score,
+  }
+}

--- a/app/javascript/util/applicationTransforms/fieldMap.ts
+++ b/app/javascript/util/applicationTransforms/fieldMap.ts
@@ -1,0 +1,87 @@
+/**
+ * The mapping engine.
+ *
+ * A field map is an array of entries, each describing one correspondence
+ * between form engine field name(s) and a Salesforce field name, plus the codec
+ * to apply. `applyToSf` and `applyFromSf` walk the same array in opposite
+ * directions, so adding a field means adding one line to one table and both
+ * directions are covered.
+ */
+
+import { type Codec, identity } from "./codecs"
+
+/**
+ * One field correspondence.
+ *
+ * `form` is the form engine field name, or an array of names for codecs that
+ * combine several inputs into one Salesforce value (date of birth, street +
+ * unit). The codec's form-side type must be a tuple of the same arity.
+ *
+ * `sf` is the field name on the Salesforce-shaped object.
+ *
+ * `codec` defaults to `identity`.
+ *
+ * `readOnly` marks fields Salesforce calculates and we never send; they are
+ * read on the way in and skipped on the way out.
+ */
+export interface FieldMapEntry {
+  form: string | string[]
+  sf: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  codec?: Codec<any, any>
+  readOnly?: boolean
+}
+
+export type FieldMap = FieldMapEntry[]
+
+type Data = Record<string, unknown>
+
+/**
+ * Prefixes the form-side names of a map. Household members and the primary
+ * applicant share a field set but namespace it differently in formData
+ * ("primaryApplicantFirstName" vs the unprefixed "firstName" inside a
+ * householdMembers[] entry), so the same table serves both.
+ */
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1)
+
+export const prefixForm = (map: FieldMap, prefix: string): FieldMap =>
+  map.map((entry) => ({
+    ...entry,
+    form: Array.isArray(entry.form)
+      ? entry.form.map((name) => prefix + capitalize(name))
+      : prefix + capitalize(entry.form),
+  }))
+
+/** formData -> Salesforce-shaped object. Omits fields with no value. */
+export const applyToSf = (map: FieldMap, formData: Data): Data => {
+  const result: Data = {}
+  for (const entry of map) {
+    if (entry.readOnly) continue
+    const codec = entry.codec ?? identity
+    const input = Array.isArray(entry.form)
+      ? entry.form.map((name) => formData[name])
+      : formData[entry.form]
+    const value = codec.toSf(input)
+    if (value !== undefined) result[entry.sf] = value
+  }
+  return result
+}
+
+/** Salesforce-shaped object -> formData. The inverse of `applyToSf`. */
+export const applyFromSf = (map: FieldMap, sfData: Data): Data => {
+  const result: Data = {}
+  for (const entry of map) {
+    const codec = entry.codec ?? identity
+    const value = codec.fromSf(sfData[entry.sf])
+    if (Array.isArray(entry.form)) {
+      // codecs for multi-field entries return a tuple in the same order
+      const values = value as unknown[]
+      entry.form.forEach((name, index) => {
+        result[name] = values?.[index] ?? ""
+      })
+    } else {
+      result[entry.form] = value
+    }
+  }
+  return result
+}

--- a/app/javascript/util/applicationTransforms/fieldMaps.ts
+++ b/app/javascript/util/applicationTransforms/fieldMaps.ts
@@ -1,0 +1,173 @@
+/**
+ * The field tables.
+ *
+ * This is the file you edit when a new field is added to the form. Add one
+ * entry to the appropriate table and both the submit and the draft-resume
+ * direction are handled.
+ *
+ * Field name sources:
+ *  - form side: the `fieldNames` maps in
+ *    `app/javascript/formEngine/listingApplicationDefaultRental.json`
+ *  - Salesforce side: `app/javascript/api/types/rails/application/RailsApplication.d.ts`
+ *    (and the Angular `WHITELIST_FIELDS`, which is the set Salesforce accepts)
+ *
+ * Note on structure: the Angular code did a lot of address flattening
+ * (`_formatAddress` / `_reformatHomeAddress`) because *Angular's* model was
+ * nested (`applicant.home_address.address1`). Salesforce itself is flat, and so
+ * is the form engine's `formData`, so that flattening is no longer needed —
+ * those transforms reduce to the plain renames below.
+ */
+
+import {
+  checkboxToBoolean,
+  dateOfBirth,
+  number,
+  pickList,
+  streetAndUnit,
+  text,
+  yesNoToBoolean,
+  yesNoToBooleanString,
+} from "./codecs"
+import { type FieldMap } from "./fieldMap"
+
+/**
+ * Fields shared by the primary applicant and household members. Used unprefixed
+ * for household member entries and prefixed with "primaryApplicant" for the
+ * applicant, via `prefixForm`.
+ */
+export const appMemberFieldMap: FieldMap = [
+  { form: "appMemberId", sf: "appMemberId" },
+  { form: "firstName", sf: "firstName", codec: text },
+  { form: "middleName", sf: "middleName", codec: text },
+  { form: "lastName", sf: "lastName", codec: text },
+  { form: ["birthYear", "birthMonth", "birthDate"], sf: "dob", codec: dateOfBirth },
+  { form: ["addressStreet", "addressAptOrUnit"], sf: "address", codec: streetAndUnit },
+  { form: "addressCity", sf: "city", codec: text },
+  { form: "addressState", sf: "state" },
+  { form: "addressZipcode", sf: "zip", codec: text },
+  { form: "noAddress", sf: "noAddress", codec: checkboxToBoolean },
+  { form: "workInSf", sf: "workInSf", codec: yesNoToBooleanString },
+  { form: "neighborhoodPreferenceAddressMatch", sf: "preferenceAddressMatch" },
+  // geocoding results, written by the address verification step
+  { form: "xCoordinate", sf: "xCoordinate" },
+  { form: "yCoordinate", sf: "yCoordinate" },
+  { form: "whichComponentOfLocatorWasUsed", sf: "whichComponentOfLocatorWasUsed" },
+  { form: "candidateScore", sf: "candidateScore", codec: number },
+  // isVeteran is derived across all members rather than mapped per member;
+  // see applyVeteranStatus in veterans.ts (DAH-3678)
+]
+
+/** Primary-applicant-only fields (contact info the household members lack). */
+export const primaryApplicantOnlyFieldMap: FieldMap = [
+  { form: "primaryApplicantContactId", sf: "contactId" },
+  { form: "primaryApplicantPhone", sf: "phone", codec: text },
+  { form: "primaryApplicantPhoneType", sf: "phoneType" },
+  { form: "primaryApplicantAdditionalPhone", sf: "alternatePhone", codec: text },
+  { form: "primaryApplicantAdditionalPhoneType", sf: "alternatePhoneType" },
+  { form: "_primaryApplicantNoPhoneCheckbox", sf: "noPhone", codec: checkboxToBoolean },
+  { form: "primaryApplicantEmail", sf: "email", codec: text },
+  { form: "primaryApplicantNoEmailCheckbox", sf: "noEmail", codec: checkboxToBoolean },
+  {
+    form: "_primaryApplicantMailingAddressCheckbox",
+    sf: "hasAltMailingAddress",
+    codec: checkboxToBoolean,
+  },
+  { form: "primaryApplicantMailingAddressStreet", sf: "mailingAddress", codec: text },
+  { form: "primaryApplicantMailingAddressCity", sf: "mailingCity", codec: text },
+  { form: "primaryApplicantMailingAddressState", sf: "mailingState" },
+  { form: "primaryApplicantMailingAddressZipcode", sf: "mailingZip", codec: text },
+  // custom educator listing (DAH-3679)
+  { form: "customEducatorScreeningAnswer", sf: "isSFUSDEmployee" },
+  { form: "customEducatorJobClassificationNumber", sf: "jobClassification" },
+]
+
+/** Household-member-only fields. */
+export const householdMemberOnlyFieldMap: FieldMap = [
+  { form: "relationship", sf: "relationship" },
+  {
+    form: "hasSameAddressAsApplicant",
+    sf: "hasSameAddressAsApplicant",
+    codec: yesNoToBoolean,
+  },
+]
+
+/** Demographics, collected on the optional review step (DAH-3612). */
+export const demographicsFieldMap: FieldMap = [
+  { form: "primaryApplicantGender", sf: "gender" },
+  { form: "primaryApplicantGenderOther", sf: "genderOther", codec: text },
+  { form: "primaryApplicantPrimaryLanguage", sf: "primaryLanguage" },
+  { form: "primaryApplicantOtherLanguage", sf: "otherLanguage", codec: text },
+  { form: "primaryApplicantSexualOrientation", sf: "sexualOrientation" },
+  { form: "primaryApplicantSexualOrientationOther", sf: "sexualOrientationOther", codec: text },
+  // raceEthnicity is a semicolon-delimited multi-select of "Parent - Suboption"
+  // keys; the accordion component holds it as an array
+  { form: "primaryApplicantRaceEthnicity", sf: "raceEthnicity", codec: pickList },
+  { form: "primaryApplicantAsianOther", sf: "asianOther", codec: text },
+  { form: "primaryApplicantBlackOther", sf: "blackOther", codec: text },
+  { form: "primaryApplicantIndigenousOther", sf: "indigenousOther", codec: text },
+  { form: "primaryApplicantLatinoOther", sf: "latinoOther", codec: text },
+  { form: "primaryApplicantMenaOther", sf: "menaOther", codec: text },
+  { form: "primaryApplicantPacificIslanderOther", sf: "pacificIslanderOther", codec: text },
+  { form: "primaryApplicantWhiteOther", sf: "whiteOther", codec: text },
+  {
+    form: "primaryApplicantIndigenousNativeAmericanGroup",
+    sf: "indigenousNativeAmericanGroup",
+    codec: text,
+  },
+  {
+    form: "primaryApplicantIndigenousCentralSouthAmericaGroup",
+    sf: "indigenousCentralSouthAmericaGroup",
+    codec: text,
+  },
+]
+
+/** Alternate contact (DAH-3680). */
+export const alternateContactFieldMap: FieldMap = [
+  { form: "alternateContactAppMemberId", sf: "appMemberId" },
+  { form: "alternateContactType", sf: "alternateContactType" },
+  { form: "alternateContactTypeOther", sf: "alternateContactTypeOther", codec: text },
+  { form: "alternateContactFirstName", sf: "firstName", codec: text },
+  { form: "alternateContactLastName", sf: "lastName", codec: text },
+  { form: "alternateContactAgency", sf: "agency", codec: text },
+  { form: "alternateContactPhone", sf: "phone", codec: text },
+  { form: "alternateContactEmail", sf: "email", codec: text },
+  // the alternate contact's address is stored in the mailing* fields in
+  // Salesforce, matching Angular's _formatAddress(..., 'mailing_address')
+  { form: "alternateContactAddressStreet", sf: "mailingAddress", codec: text },
+  { form: "alternateContactAddressCity", sf: "mailingCity", codec: text },
+  { form: "alternateContactAddressState", sf: "mailingState" },
+  { form: "alternateContactAddressZipcode", sf: "mailingZip", codec: text },
+]
+
+/**
+ * Top-level application fields that map one-to-one (DAH-3683).
+ *
+ * Fields that need cross-field logic are handled separately and are
+ * deliberately absent here: income (annual vs monthly timeframe),
+ * adaPrioritiesSelected (HCBS special case), totalMonthlyRent (summed),
+ * formMetadata (JSON blob), and the veteran fields.
+ */
+export const applicationFieldMap: FieldMap = [
+  { form: "id", sf: "id" },
+  { form: "hasPublicHousing", sf: "hasPublicHousing" },
+  { form: "hasMilitaryService", sf: "hasMilitaryService" },
+  { form: "hasDevelopmentalDisability", sf: "hasDevelopmentalDisability" },
+  { form: "answeredCommunityScreening", sf: "answeredCommunityScreening" },
+  { form: "householdVouchersSubsidies", sf: "householdVouchersSubsidies", codec: yesNoToBooleanString },
+  { form: "referral", sf: "referral" },
+  { form: "agreeToTerms", sf: "agreeToTerms", codec: checkboxToBoolean },
+  { form: "externalSessionId", sf: "externalSessionId" },
+  // sales-listing fields, not used by the rental form yet
+  { form: "isFirstTimeHomebuyer", sf: "isFirstTimeHomebuyer", codec: checkboxToBoolean },
+  { form: "hasMinimumCreditScore", sf: "hasMinimumCreditScore", codec: checkboxToBoolean },
+  {
+    form: "hasCompletedHomebuyerEducation",
+    sf: "hasCompletedHomebuyerEducation",
+    codec: checkboxToBoolean,
+  },
+  { form: "hasLoanPreapproval", sf: "hasLoanPreapproval", codec: checkboxToBoolean },
+  { form: "lendingAgent", sf: "lendingAgent" },
+  { form: "homebuyerEducationAgency", sf: "homebuyerEducationAgency" },
+  // calculated by Salesforce; read on resume, never submitted
+  { form: "lotteryNumber", sf: "lotteryNumber", readOnly: true },
+]

--- a/app/javascript/util/applicationTransforms/index.ts
+++ b/app/javascript/util/applicationTransforms/index.ts
@@ -1,0 +1,118 @@
+/**
+ * Application transforms: formData <-> Salesforce-shaped Application.
+ *
+ * `formDataToApplication` replaces the hand-built object in
+ * `formApiService.submitForm`. `applicationToFormData` is its inverse and is
+ * what DAH-3533 (draft resume) will call.
+ *
+ * The per-domain sections below are the DAH-3677..3683 tickets. Each is a
+ * field table in `fieldMaps.ts` plus, where unavoidable, a cross-field
+ * transform. To add a field: add a line to the relevant table.
+ */
+
+import { type Application } from "../../api/types/rails/application/RailsApplication"
+import { adaPriorities, formMetadata, income, totalMonthlyRent } from "./crossFieldTransforms"
+import { applyFromSf, applyToSf, prefixForm } from "./fieldMap"
+import {
+  alternateContactFieldMap,
+  appMemberFieldMap,
+  applicationFieldMap,
+  demographicsFieldMap,
+  householdMemberOnlyFieldMap,
+  primaryApplicantOnlyFieldMap,
+} from "./fieldMaps"
+
+type Data = Record<string, unknown>
+
+const PRIMARY_APPLICANT_PREFIX = "primaryApplicant"
+
+/** The applicant's own fields: the shared member fields, prefixed, plus their own. */
+const primaryApplicantMap = [
+  ...prefixForm(appMemberFieldMap, PRIMARY_APPLICANT_PREFIX),
+  ...primaryApplicantOnlyFieldMap,
+  ...demographicsFieldMap,
+]
+
+/** A household member's fields, read from an entry in formData.householdMembers. */
+const householdMemberMap = [...appMemberFieldMap, ...householdMemberOnlyFieldMap]
+
+/** Cross-field transforms applied at the top level of the application. */
+const applicationCrossFieldTransforms = [income, adaPriorities, totalMonthlyRent, formMetadata]
+
+// DAH-3682
+export const getPrimaryApplicantData = (formData: Data): Data =>
+  applyToSf(primaryApplicantMap, formData)
+
+export const getPrimaryApplicantFormData = (sfApplicant: Data): Data =>
+  applyFromSf(primaryApplicantMap, sfApplicant ?? {})
+
+// DAH-3681
+export const getHouseholdMembersData = (formData: Data): Data[] =>
+  ((formData.householdMembers as Data[]) ?? []).map((member) =>
+    applyToSf(householdMemberMap, member)
+  )
+
+export const getHouseholdMembersFormData = (sfMembers: Data[]): Data[] =>
+  (sfMembers ?? []).map((member) => applyFromSf(householdMemberMap, member))
+
+// DAH-3680
+export const getAlternateContactData = (formData: Data): Data =>
+  applyToSf(alternateContactFieldMap, formData)
+
+export const getAlternateContactFormData = (sfContact: Data): Data =>
+  applyFromSf(alternateContactFieldMap, sfContact ?? {})
+
+/**
+ * formData -> the payload posted to /api/v1/short-form/application.
+ *
+ * Fields not yet mapped, each waiting on its own ticket:
+ *  - shortFormPreferences (DAH-3677) and the veteran fields (DAH-3678)
+ *  - uploaded files (DAH-3685)
+ */
+export const formDataToApplication = (formData: Data): Partial<Application> => {
+  const application: Data = {
+    ...applyToSf(applicationFieldMap, formData),
+    primaryApplicant: getPrimaryApplicantData(formData),
+    householdMembers: getHouseholdMembersData(formData),
+  }
+
+  const alternateContact = getAlternateContactData(formData)
+  // Angular only sent the object when the applicant actually named someone
+  if (
+    formData.alternateContactType &&
+    formData.alternateContactType !== "None" &&
+    alternateContact.firstName &&
+    alternateContact.lastName
+  ) {
+    application.alternateContact = alternateContact
+  }
+
+  for (const transform of applicationCrossFieldTransforms) {
+    Object.assign(application, transform.toSf(formData))
+  }
+
+  return application as Partial<Application>
+}
+
+/** The inverse: a Salesforce application -> formData. Used by DAH-3533. */
+export const applicationToFormData = (sfApplication: Partial<Application>): Data => {
+  const sfData = (sfApplication ?? {}) as Data
+  const formData: Data = {
+    ...applyFromSf(applicationFieldMap, sfData),
+    ...getPrimaryApplicantFormData(sfData.primaryApplicant as Data),
+    householdMembers: getHouseholdMembersFormData(sfData.householdMembers as Data[]),
+  }
+
+  const sfAlternateContact = sfData.alternateContact as Data
+  if (sfAlternateContact && sfAlternateContact.alternateContactType) {
+    Object.assign(formData, getAlternateContactFormData(sfAlternateContact))
+  } else {
+    formData.alternateContactType = "None"
+  }
+
+  for (const transform of applicationCrossFieldTransforms) {
+    Object.assign(formData, transform.fromSf(sfData))
+  }
+
+  return formData
+}

--- a/app/javascript/util/listingApplyUtil.tsx
+++ b/app/javascript/util/listingApplyUtil.tsx
@@ -39,16 +39,14 @@ export const validVeteranAge = (birthDate: Dayjs): boolean => {
   return dayjs().diff(birthDate, "year") >= 17
 }
 
-export const getPrimaryApplicantData = (formData: Record<string, unknown>) => {
+// The primary applicant's name, for display alongside household members.
+// For the Salesforce-shaped applicant record, see
+// `util/applicationTransforms/getPrimaryApplicantData`.
+export const getPrimaryApplicantName = (formData: Record<string, unknown>) => {
   const firstName = formData.primaryApplicantFirstName as string
   const middleName = formData.primaryApplicantMiddleName as string
   const lastName = formData.primaryApplicantLastName as string
-  return {
-    firstName,
-    middleName,
-    lastName,
-    dob: (formData.primaryApplicantDob as string) || "1990-01-01", // TODO: update after DAH-3543
-  }
+  return { firstName, middleName, lastName }
 }
 
 export const allHouseholdMembers = (formData: Record<string, unknown>): HouseholdMember[] => {


### PR DESCRIPTION
Adds the shared transform layer the remaining form engine transform tickets (DAH-3677 through 3683) build on, replacing the stub payload formApiService was submitting.

The layer is table-driven so that adding a field is a one-line change covering both directions:

- codecs.ts        value-level `{ toSf, fromSf }` pairs (yes/no, picklist,
                   date of birth, street+unit, currency)
- fieldMap.ts      applyToSf / applyFromSf walk one array of
                   form-name/sf-name/codec entries in opposite directions;
                   prefixForm lets the primary applicant and household
                   members share a single table
- fieldMaps.ts     the tables themselves — the file you edit for a new field
- crossFieldTransforms.ts  the few transforms that span fields (income,
                   ADA/HCBS folding, total rent, formMetadata)

The Angular _formatAddress / _reformatHomeAddress family is not ported: Salesforce contacts are already flat, and the nesting those helpers undid was Angular's own internal model. In the new engine formData is flat too, so that class of transform reduces to key renaming.

Also renames listingApplyUtil's display-only getPrimaryApplicantData to getPrimaryApplicantName to free the name for the Salesforce mapper, and drops its hardcoded fallback dob, which read a field the schema never had.

## Description

_just one or two sentences_

## Jira ticket

https://sfgovdt.jira.com/browse/<JIRA TICKET NUMBER>

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag