### PR TITLE
fix: DAH-4002 DAH-4076 housing counselor page: Balance link/email, add rental agencies

### DIFF
--- a/app/assets/json/housing_counselors.json
+++ b/app/assets/json/housing_counselors.json
@@ -13,7 +13,7 @@
       "address": "3543 18th Street",
       "citystate": "San Francisco, CA 94110",
       "phone": "(800) 777-7526",
-      "website": "https://www.balancepro.org"
+      "website": "https://www.bebalanced.org/"
     },
     {
       "name": "Bill Sorro Housing Program (BiSHoP)",

--- a/app/assets/json/housing_counselors_react.json
+++ b/app/assets/json/housing_counselors_react.json
@@ -44,8 +44,8 @@
                     "cityState": "San Francisco, CA 94134"
                 }
             ],
-            "website": "https://www.balancepro.org/workshops/",
-            "email": "sfhousing@balancepro.org",
+            "website": "https://www.bebalanced.org/",
+            "email": "sfhousing@bebalanced.org",
             "phone": "(800) 777-7526"
         },
         {
@@ -192,6 +192,69 @@
             "website": "http://www.seaccusa.org/",
             "email": "info@seaccusa.org",
             "phone": "(415) 885-2743"
+        },
+        {
+            "fullName": "Young Community Developers",
+            "shortName": "YCD",
+            "services": [
+                "rental"
+            ],
+            "languages": [
+                "english",
+                "spanish"
+            ],
+            "address": [
+                {
+                    "street": "150 Executive Park Blvd. #4000",
+                    "cityState": "San Francisco, CA 94134"
+                }
+            ],
+            "website": "https://ycdjobs.org/",
+            "email": "housing@ycdjobs.org",
+            "phone": "(415) 822-3491"
+        },
+        {
+            "fullName": "Compass Family Services",
+            "services": [
+                "rental"
+            ],
+            "languages": [
+                "english",
+                "spanish"
+            ],
+            "address": [
+                {
+                    "street": "37 Grove Street",
+                    "cityState": "San Francisco, CA 94102"
+                }
+            ],
+            "website": "https://compass-sf.org/",
+            "email": "chls-ns@compass-sf.org",
+            "phone": "(415) 644-0504"
+        },
+        {
+            "fullName": "Bayview Senior Services",
+            "services": [
+                "rental",
+                "seniorOnly"
+            ],
+            "languages": [
+                "english",
+                "spanish",
+                "cantonese",
+                "mandarin",
+                "filipino",
+                "samoan"
+            ],
+            "address": [
+                {
+                    "street": "5600 3rd Street, Suite A",
+                    "cityState": "San Francisco, CA 94124"
+                }
+            ],
+            "website": "https://bhpmss.org/",
+            "email": "info@bhpmss.org",
+            "phone": "(415) 762-2167"
         }
     ]
 }

--- a/app/assets/json/translations/react/en.json
+++ b/app/assets/json/translations/react/en.json
@@ -174,6 +174,7 @@
   "assistance.housingCounselors.services.languages.french": "French",
   "assistance.housingCounselors.services.languages.mandarin": "Mandarin",
   "assistance.housingCounselors.services.languages.russian": "Russian",
+  "assistance.housingCounselors.services.languages.samoan": "Samoan",
   "assistance.housingCounselors.services.languages.spanish": "Spanish",
   "assistance.housingCounselors.services.languages.taiwanese": "Taiwanese",
   "assistance.housingCounselors.services.languages.vietnamese": "Vietnamese",

--- a/app/assets/json/translations/react/es.json
+++ b/app/assets/json/translations/react/es.json
@@ -154,6 +154,7 @@
   "assistance.housingCounselors.services.languages.french": "Francés",
   "assistance.housingCounselors.services.languages.mandarin": "Mandarín",
   "assistance.housingCounselors.services.languages.russian": "Ruso",
+  "assistance.housingCounselors.services.languages.samoan": "Samoano",
   "assistance.housingCounselors.services.languages.spanish": "Español",
   "assistance.housingCounselors.services.languages.taiwanese": "Taiwanés",
   "assistance.housingCounselors.services.languages.vietnamese": "Vietnamita",

--- a/app/assets/json/translations/react/tl.json
+++ b/app/assets/json/translations/react/tl.json
@@ -154,6 +154,7 @@
   "assistance.housingCounselors.services.languages.french": "French",
   "assistance.housingCounselors.services.languages.mandarin": "Mandarin",
   "assistance.housingCounselors.services.languages.russian": "Russian",
+  "assistance.housingCounselors.services.languages.samoan": "Samoan",
   "assistance.housingCounselors.services.languages.spanish": "Espanyol",
   "assistance.housingCounselors.services.languages.taiwanese": "Taiwanese",
   "assistance.housingCounselors.services.languages.vietnamese": "Vietnamese",

--- a/app/assets/json/translations/react/zh.json
+++ b/app/assets/json/translations/react/zh.json
@@ -154,6 +154,7 @@
   "assistance.housingCounselors.services.languages.french": "法語",
   "assistance.housingCounselors.services.languages.mandarin": "華語",
   "assistance.housingCounselors.services.languages.russian": "俄羅斯語",
+  "assistance.housingCounselors.services.languages.samoan": "薩摩亞語",
   "assistance.housingCounselors.services.languages.spanish": "西班牙語",
   "assistance.housingCounselors.services.languages.taiwanese": "臺語",
   "assistance.housingCounselors.services.languages.vietnamese": "越南語",

--- a/app/javascript/pages/getAssistance/counselor-filter.tsx
+++ b/app/javascript/pages/getAssistance/counselor-filter.tsx
@@ -42,6 +42,7 @@ const CounselorFilter = ({ handleFilterData, clearClick }: CounselorFilterProps)
     { label: t("assistance.housingCounselors.services.languages.french"), value: "french" },
     { label: t("assistance.housingCounselors.services.languages.mandarin"), value: "mandarin" },
     { label: t("assistance.housingCounselors.services.languages.russian"), value: "russian" },
+    { label: t("assistance.housingCounselors.services.languages.samoan"), value: "samoan" },
     { label: t("assistance.housingCounselors.services.languages.spanish"), value: "spanish" },
     { label: t("assistance.housingCounselors.services.languages.taiwanese"), value: "taiwanese" },
     { label: t("assistance.housingCounselors.services.languages.vietnamese"), value: "vietnamese" },

--- a/app/javascript/pages/getAssistance/counselor-filter.tsx
+++ b/app/javascript/pages/getAssistance/counselor-filter.tsx
@@ -39,6 +39,7 @@ const CounselorFilter = ({ handleFilterData, clearClick }: CounselorFilterProps)
     { label: t("assistance.housingCounselors.services.languages.arabic"), value: "arabic" },
     { label: t("assistance.housingCounselors.services.languages.cantonese"), value: "cantonese" },
     { label: t("assistance.housingCounselors.services.languages.english"), value: "english" },
+    { label: t("assistance.housingCounselors.services.languages.filipino"), value: "filipino" },
     { label: t("assistance.housingCounselors.services.languages.french"), value: "french" },
     { label: t("assistance.housingCounselors.services.languages.mandarin"), value: "mandarin" },
     { label: t("assistance.housingCounselors.services.languages.russian"), value: "russian" },

--- a/app/javascript/pages/getAssistance/housing-counselors.tsx
+++ b/app/javascript/pages/getAssistance/housing-counselors.tsx
@@ -204,7 +204,7 @@ const HousingCounselors = () => {
       }
       case 0: {
         return (
-          <div>
+          <div className="mb-8 md:mb-16">
             {t("assistance.housingCounselors.findACounselor.filter.zero.part1")}
             <br /> <br />
             {renderInlineMarkup(t("assistance.housingCounselors.findACounselor.filter.zero.part2"))}

--- a/app/javascript/pages/getAssistance/housing-counselors.tsx
+++ b/app/javascript/pages/getAssistance/housing-counselors.tsx
@@ -233,7 +233,9 @@ const HousingCounselors = () => {
         return counselor.services.some((service) => filterData.services.includes(service))
       })
     }
-    return filteredList
+    return [...filteredList].sort((a, b) =>
+      a.fullName.localeCompare(b.fullName, undefined, { sensitivity: "base" })
+    )
   }, [filterData])
 
   return (


### PR DESCRIPTION
## Summary

- **DAH-4002**: Update BALANCE website and email to the `bebalanced.org` domain (both the react and legacy JSON data files).
- **DAH-4076**: Add three rental housing counselor agencies to the Housing Counselor page and enable filtering by their offered services:
  - Young Community Developers
  - Compass Family Services
  - Bayview Senior Services (also adds Senior-only service and Samoan as a filterable language)
- Add Samoan and missing Filipino items to the language filter list
- Sort the list alphabetically

## Testing

- Verified all modified JSON files parse correctly.
- Verified translation files (`en`, `es`, `tl`, `zh`) remain alphabetically sorted (matches the `jq -S` check used by the translations-check CI workflow).
- Confirmed addresses/zip codes for the new agencies against their official sites.
- No existing Jest tests reference this page, so none needed updating.
- IDE diagnostics on the touched TSX files are clean.

## Links

- https://sfgovdt.jira.com/browse/DAH-4002
- https://sfgovdt.jira.com/browse/DAH-4076