### PR TITLE
chore: DAH-3291 translation key parity and value checks in CI

### DIFF
--- a/.github/workflows/translations-check.yml
+++ b/.github/workflows/translations-check.yml
@@ -8,6 +8,10 @@ on:
       - "scripts/known-translation-gaps.json"
       - ".github/workflows/translations-check.yml"
 
+# Both jobs only read the checked-out tree; nothing writes back to the repo.
+permissions:
+  contents: read
+
 jobs:
   check-sorting:
     runs-on: ubuntu-latest

--- a/.github/workflows/translations-check.yml
+++ b/.github/workflows/translations-check.yml
@@ -1,9 +1,12 @@
-name: Check Translation Files Sorting
+name: Check Translation Files
 
 on:
   pull_request:
     paths:
       - "app/assets/json/translations/react/*.json"
+      - "scripts/check-translation-parity.js"
+      - "scripts/known-translation-gaps.json"
+      - ".github/workflows/translations-check.yml"
 
 jobs:
   check-sorting:
@@ -47,3 +50,21 @@ jobs:
               rm sorted.json
             fi
           done
+
+  check-key-parity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      # loadTranslations() overlays each locale on top of en.json, so a key that is
+      # missing from es/tl/zh renders the English string with no error anywhere.
+      # This is the only thing in CI that catches that.
+      - name: Check translation key parity
+        run: node scripts/check-translation-parity.js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig(
       "*.config.js",
       "config/webpack/**/*",
       "lighthouserc.js",
+      "scripts/**", // Standalone Node/shell tooling, outside the TS project
       "public/**",
       "node_modules/**",
       "spec/e2e/**", // Legacy E2E tests

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "lint:config": "eslint --insepct-config",
     "lint:benchmark": "cross-env TIMING=all eslint --stats",
     "format": "prettier --write .",
+    "check:translations": "node scripts/check-translation-parity.js",
     "webpack:analyze": "yarn webpack:build_json && yarn webpack:analyze_json",
     "webpack:build_json": "cross-env RAILS_ENV=${RAILS_ENV:-production} NODE_ENV=${NODE_ENV:-production} bin/webpack --profile --json > tmp/webpack-stats.json",
     "webpack:analyze_json": "webpack-bundle-analyzer tmp/webpack-stats.json public/packs",

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/*
+ * Verifies that every key in the English translation file exists in each of the
+ * other locale files.
+ *
+ * Why this matters: loadTranslations() in app/javascript/util/languageUtil.tsx
+ * loads en.json first and then overlays the target locale on top of it. A key
+ * that is missing from es.json therefore renders the *English* string silently —
+ * no raw key, no empty box, no console warning. Nothing in the app surfaces it,
+ * and visual regression tooling can't either, because the English fallback is
+ * simply what the page has always looked like.
+ *
+ * Keys that are intentionally identical across locales (proper nouns, acronyms)
+ * do not need listing here — this checks key presence, not value difference.
+ * Keys that are intentionally English-only go in known-translation-gaps.json.
+ *
+ * Usage:
+ *   node scripts/check-translation-parity.js
+ *   node scripts/check-translation-parity.js --json   # machine-readable output
+ */
+
+const fs = require("fs")
+const path = require("path")
+
+const TRANSLATIONS_DIR = path.join(__dirname, "..", "app", "assets", "json", "translations", "react")
+const GAPS_FILE = path.join(__dirname, "known-translation-gaps.json")
+const BASE_LOCALE = "en"
+
+const flatten = (obj, prefix = "") =>
+  Object.entries(obj).reduce((acc, [key, value]) => {
+    const name = prefix ? `${prefix}.${key}` : key
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? { ...acc, ...flatten(value, name) }
+      : { ...acc, [name]: value }
+  }, {})
+
+const readLocale = (locale) => {
+  const file = path.join(TRANSLATIONS_DIR, `${locale}.json`)
+  try {
+    return flatten(JSON.parse(fs.readFileSync(file, "utf8")))
+  } catch (error) {
+    console.error(`Could not read or parse ${file}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+/*
+ * known-translation-gaps.json groups exempted keys under a reason, so the
+ * allowlist documents itself:
+ *   { "gaps": { "es": [ { "reason": "...", "keys": ["a.b"] } ] } }
+ * Returns a flat Set of exempted keys per locale.
+ */
+const readKnownGaps = () => {
+  if (!fs.existsSync(GAPS_FILE)) return {}
+  try {
+    const { gaps = {} } = JSON.parse(fs.readFileSync(GAPS_FILE, "utf8"))
+    return Object.fromEntries(
+      Object.entries(gaps).map(([locale, groups]) => [
+        locale,
+        new Set(groups.flatMap((group) => group.keys)),
+      ])
+    )
+  } catch (error) {
+    console.error(`Could not parse ${GAPS_FILE}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+const main = () => {
+  const asJson = process.argv.includes("--json")
+
+  const locales = fs
+    .readdirSync(TRANSLATIONS_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.basename(file, ".json"))
+
+  if (!locales.includes(BASE_LOCALE)) {
+    console.error(`No ${BASE_LOCALE}.json found in ${TRANSLATIONS_DIR}`)
+    process.exit(1)
+  }
+
+  const base = readLocale(BASE_LOCALE)
+  const baseKeys = Object.keys(base).sort()
+  const knownGaps = readKnownGaps()
+
+  const results = {}
+  let failed = false
+  let totalAllowed = 0
+
+  for (const locale of locales.filter((l) => l !== BASE_LOCALE)) {
+    const target = readLocale(locale)
+    const allowed = knownGaps[locale] || new Set()
+
+    const missing = baseKeys.filter((key) => !(key in target) && !allowed.has(key))
+    const allowedStillMissing = baseKeys.filter((key) => !(key in target) && allowed.has(key))
+    // A key that is present but empty renders as blank text, which is worse than
+    // the English fallback — flag it alongside genuinely missing keys.
+    const empty = baseKeys.filter(
+      (key) => key in target && typeof target[key] === "string" && target[key].trim() === ""
+    )
+    const extra = Object.keys(target).filter((key) => !(key in base))
+    // A stale allowlist entry means someone translated the key but left the
+    // exemption behind; clearing these keeps the ratchet tightening.
+    const staleAllowlist = [...allowed].filter((key) => key in target)
+
+    results[locale] = { missing, empty, extra, allowedStillMissing, staleAllowlist }
+    totalAllowed += allowedStillMissing.length
+
+    if (missing.length > 0 || empty.length > 0) failed = true
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ baseKeyCount: baseKeys.length, results }, null, 2))
+    process.exit(failed ? 1 : 0)
+  }
+
+  console.log(`Base locale ${BASE_LOCALE}.json: ${baseKeys.length} keys\n`)
+
+  for (const [locale, result] of Object.entries(results)) {
+    const { missing, empty, extra, allowedStillMissing, staleAllowlist } = result
+    const status = missing.length === 0 && empty.length === 0 ? "PASS" : "FAIL"
+    console.log(`${status}  ${locale}.json`)
+
+    if (missing.length > 0) {
+      console.log(`  ${missing.length} key(s) missing (will silently render in English):`)
+      missing.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (empty.length > 0) {
+      console.log(`  ${empty.length} key(s) present but empty (will render blank):`)
+      empty.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (extra.length > 0) {
+      console.log(`  note: ${extra.length} key(s) not present in ${BASE_LOCALE}.json (dead weight):`)
+      extra.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (staleAllowlist.length > 0) {
+      console.log(
+        `  note: ${staleAllowlist.length} allowlist entr(ies) now translated — remove from known-translation-gaps.json:`
+      )
+      staleAllowlist.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (allowedStillMissing.length > 0) {
+      console.log(`  ${allowedStillMissing.length} known gap(s) allowlisted`)
+    }
+    console.log("")
+  }
+
+  if (failed) {
+    console.log("Translation parity check failed.")
+    console.log(
+      `Add the missing keys to the locale files, or — if a key is intentionally English-only —\n` +
+        `add it to scripts/known-translation-gaps.json with a reason.`
+    )
+    process.exit(1)
+  }
+
+  console.log("Translation parity check passed.")
+  if (totalAllowed > 0) {
+    console.log(
+      `${totalAllowed} allowlisted gap(s) remain in scripts/known-translation-gaps.json — these are\n` +
+        `untranslated strings rendering in English today, not resolved issues.`
+    )
+  }
+}
+
+main()

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -35,6 +35,13 @@ const flatten = (obj, prefix = "") =>
   }, {})
 
 const readLocale = (locale) => {
+  // Locale names only ever come from readdirSync on TRANSLATIONS_DIR or from
+  // BASE_LOCALE, so they can't contain traversal sequences. Validated anyway so
+  // that stays true if a caller is ever added, and to keep SAST scanners quiet.
+  if (!/^[a-z]{2}(-[A-Za-z]{2,4})?$/.test(locale)) {
+    console.error(`Refusing to read unexpected locale name: ${locale}`)
+    process.exit(1)
+  }
   const file = path.join(TRANSLATIONS_DIR, `${locale}.json`)
   try {
     return flatten(JSON.parse(fs.readFileSync(file, "utf8")))
@@ -94,16 +101,31 @@ const main = () => {
     const missing = baseKeys.filter((key) => !(key in target) && !allowed.has(key))
     const allowedStillMissing = baseKeys.filter((key) => !(key in target) && allowed.has(key))
     // A key that is present but empty renders as blank text, which is worse than
-    // the English fallback — flag it alongside genuinely missing keys.
+    // the English fallback — flag it alongside genuinely missing keys. Skipped
+    // when en.json is itself empty for that key (e.g. an unused placeholder),
+    // since mirroring an empty base value loses nothing.
     const empty = baseKeys.filter(
-      (key) => key in target && typeof target[key] === "string" && target[key].trim() === ""
+      (key) =>
+        key in target &&
+        typeof target[key] === "string" &&
+        target[key].trim() === "" &&
+        !(typeof base[key] === "string" && base[key].trim() === "")
     )
     const extra = Object.keys(target).filter((key) => !(key in base))
-    // A stale allowlist entry means someone translated the key but left the
-    // exemption behind; clearing these keeps the ratchet tightening.
+    // Two ways an allowlist entry goes stale: the key finally got translated, or
+    // it was dropped from en.json entirely. Reporting both keeps the ratchet
+    // tightening instead of letting dead exemptions pile up.
     const staleAllowlist = [...allowed].filter((key) => key in target)
+    const orphanedAllowlist = [...allowed].filter((key) => !(key in base))
 
-    results[locale] = { missing, empty, extra, allowedStillMissing, staleAllowlist }
+    results[locale] = {
+      missing,
+      empty,
+      extra,
+      allowedStillMissing,
+      staleAllowlist,
+      orphanedAllowlist,
+    }
     totalAllowed += allowedStillMissing.length
 
     if (missing.length > 0 || empty.length > 0) failed = true
@@ -117,7 +139,7 @@ const main = () => {
   console.log(`Base locale ${BASE_LOCALE}.json: ${baseKeys.length} keys\n`)
 
   for (const [locale, result] of Object.entries(results)) {
-    const { missing, empty, extra, allowedStillMissing, staleAllowlist } = result
+    const { missing, empty, extra, allowedStillMissing, staleAllowlist, orphanedAllowlist } = result
     const status = missing.length === 0 && empty.length === 0 ? "PASS" : "FAIL"
     console.log(`${status}  ${locale}.json`)
 
@@ -138,6 +160,12 @@ const main = () => {
         `  note: ${staleAllowlist.length} allowlist entr(ies) now translated — remove from known-translation-gaps.json:`
       )
       staleAllowlist.forEach((key) => console.log(`    - ${key}`))
+    }
+    if (orphanedAllowlist.length > 0) {
+      console.log(
+        `  note: ${orphanedAllowlist.length} allowlist entr(ies) no longer in ${BASE_LOCALE}.json — remove from known-translation-gaps.json:`
+      )
+      orphanedAllowlist.forEach((key) => console.log(`    - ${key}`))
     }
     if (allowedStillMissing.length > 0) {
       console.log(`  ${allowedStillMissing.length} known gap(s) allowlisted`)

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * Verifies that every key in the English translation file exists in each of the
- * other locale files.
+ * other locale files, and that the translated values themselves are well formed.
  *
  * Why this matters: loadTranslations() in app/javascript/util/languageUtil.tsx
  * loads en.json first and then overlays the target locale on top of it. A key
@@ -13,6 +13,12 @@
  * Keys that are intentionally identical across locales (proper nouns, acronyms)
  * do not need listing here — this checks key presence, not value difference.
  * Keys that are intentionally English-only go in known-translation-gaps.json.
+ *
+ * The value checks (CONTENT_CHECKS below) are ported from the Translation-Checker
+ * tool devs have been running by hand — https://github.com/chadbrokaw/Translation-Checker
+ * — which validates XLIFF pasted into a browser. The rules are the valuable part:
+ * they catch the ways strings get mangled in the Phrase round trip. Two of them
+ * are deliberately adapted rather than copied; see the notes on each.
  *
  * Usage:
  *   node scripts/check-translation-parity.js
@@ -73,6 +79,90 @@ const readKnownGaps = () => {
   }
 }
 
+const PLURAL_SEPARATOR = "||||"
+// Number of plural forms each locale needs once a string is pluralized. Chinese
+// uses a single form for all counts.
+const EXPECTED_PLURAL_FORMS = { zh: 1 }
+const DEFAULT_EXPECTED_PLURAL_FORMS = 2
+
+const MALFORMED_BARS = [/(?<!\|)\|{1,3}(?!\|)/, /\|{5,}/]
+const hasMalformedBars = (value) => MALFORMED_BARS.some((pattern) => pattern.test(value))
+
+const variablesIn = (value) => value.match(/%\{.*?\}/g) || []
+
+const CONTENT_CHECKS = [
+  {
+    id: "encoding",
+    label: "encoding error (e.g. &nbsp;, &amp;)",
+    // A literal "&amp;" or "nbsp;" in the JSON means the string was double-encoded
+    // somewhere between Phrase and the repo.
+    failed: (target) => /nbsp;/.test(target) || /&amp;/.test(target),
+  },
+  {
+    id: "variablePrefix",
+    label: "variable missing its % prefix",
+    failed: (target) => /(?<!%)\{.*?\}/.test(target),
+  },
+  {
+    id: "variableMismatch",
+    label: "variables differ from en.json",
+    // Compares the *set* of variable names, not the number of occurrences: a
+    // pluralized translation repeats each variable once per form, so counting
+    // occurrences (as the XLF tool does) false-positives on every plural.
+    needsBase: true,
+    failed: (target, base) => {
+      const names = (value) => [...new Set(variablesIn(value))].sort().join(",")
+      return names(target) !== names(base)
+    },
+  },
+  {
+    id: "pluralBars",
+    label: `plural separator is not exactly four bars (${PLURAL_SEPARATOR})`,
+    failed: (target) => hasMalformedBars(target),
+  },
+  {
+    id: "pluralForms",
+    label: "pluralized string has the wrong number of forms",
+    // Only pluralized translations are checked, and against what the *locale*
+    // needs rather than against en.json's form count. English often has one form
+    // where Spanish legitimately needs two, so comparing to the base locale (as
+    // the XLF tool does) flags correct translations.
+    //
+    // Malformed separators are skipped: already reported above, and the split
+    // would produce meaningless counts.
+    skip: (target) => !target.includes(PLURAL_SEPARATOR) || hasMalformedBars(target),
+    failed: (target, base, locale) => {
+      const expected = EXPECTED_PLURAL_FORMS[locale] ?? DEFAULT_EXPECTED_PLURAL_FORMS
+      return target.split(PLURAL_SEPARATOR).filter((form) => form.trim() !== "").length !== expected
+    },
+  },
+]
+
+/*
+ * Runs the value-level checks over one locale. Returns { [checkId]: [keys] },
+ * omitting checks that found nothing.
+ */
+const runContentChecks = (target, base, locale) => {
+  const problems = {}
+
+  for (const key of Object.keys(target)) {
+    const value = target[key]
+    if (typeof value !== "string" || value.trim() === "") continue
+    const baseValue = base[key]
+
+    for (const check of CONTENT_CHECKS) {
+      if (check.needsBase && typeof baseValue !== "string") continue
+      if (check.skip && check.skip(value, baseValue, locale)) continue
+      if (check.failed(value, baseValue, locale)) {
+        problems[check.id] = problems[check.id] || []
+        problems[check.id].push(key)
+      }
+    }
+  }
+
+  return problems
+}
+
 const main = () => {
   const asJson = process.argv.includes("--json")
 
@@ -118,6 +208,8 @@ const main = () => {
     const staleAllowlist = [...allowed].filter((key) => key in target)
     const orphanedAllowlist = [...allowed].filter((key) => !(key in base))
 
+    const contentProblems = runContentChecks(target, base, locale)
+
     results[locale] = {
       missing,
       empty,
@@ -125,10 +217,13 @@ const main = () => {
       allowedStillMissing,
       staleAllowlist,
       orphanedAllowlist,
+      contentProblems,
     }
     totalAllowed += allowedStillMissing.length
 
-    if (missing.length > 0 || empty.length > 0) failed = true
+    if (missing.length > 0 || empty.length > 0 || Object.keys(contentProblems).length > 0) {
+      failed = true
+    }
   }
 
   if (asJson) {
@@ -140,7 +235,11 @@ const main = () => {
 
   for (const [locale, result] of Object.entries(results)) {
     const { missing, empty, extra, allowedStillMissing, staleAllowlist, orphanedAllowlist } = result
-    const status = missing.length === 0 && empty.length === 0 ? "PASS" : "FAIL"
+    const { contentProblems } = result
+    const status =
+      missing.length === 0 && empty.length === 0 && Object.keys(contentProblems).length === 0
+        ? "PASS"
+        : "FAIL"
     console.log(`${status}  ${locale}.json`)
 
     if (missing.length > 0) {
@@ -150,6 +249,12 @@ const main = () => {
     if (empty.length > 0) {
       console.log(`  ${empty.length} key(s) present but empty (will render blank):`)
       empty.forEach((key) => console.log(`    - ${key}`))
+    }
+    for (const check of CONTENT_CHECKS) {
+      const keys = contentProblems[check.id]
+      if (!keys) continue
+      console.log(`  ${keys.length} key(s) with ${check.label}:`)
+      keys.forEach((key) => console.log(`    - ${key}`))
     }
     if (extra.length > 0) {
       console.log(`  note: ${extra.length} key(s) not present in ${BASE_LOCALE}.json (dead weight):`)
@@ -174,15 +279,16 @@ const main = () => {
   }
 
   if (failed) {
-    console.log("Translation parity check failed.")
+    console.log("Translation check failed.")
     console.log(
       `Add the missing keys to the locale files, or — if a key is intentionally English-only —\n` +
-        `add it to scripts/known-translation-gaps.json with a reason.`
+        `add it to scripts/known-translation-gaps.json with a reason. Value problems (variables,\n` +
+        `plural forms, encoding) need fixing in Phrase so the fix survives the next sync.`
     )
     process.exit(1)
   }
 
-  console.log("Translation parity check passed.")
+  console.log("Translation check passed.")
   if (totalAllowed > 0) {
     console.log(
       `${totalAllowed} allowlisted gap(s) remain in scripts/known-translation-gaps.json — these are\n` +

--- a/scripts/known-translation-gaps.json
+++ b/scripts/known-translation-gaps.json
@@ -1,0 +1,133 @@
+{
+  "README": [
+    "Keys exempted from scripts/check-translation-parity.js.",
+    "",
+    "This is a ratchet, not a resolution. Every key listed here is rendering the",
+    "ENGLISH string to speakers of that language right now, because loadTranslations()",
+    "in app/javascript/util/languageUtil.tsx overlays the locale file on top of",
+    "en.json — a missing key silently falls back rather than erroring.",
+    "",
+    "The list was seeded from the state of main on 2026-07-25 so the check could be",
+    "turned on without blocking unrelated PRs. It should only ever get shorter.",
+    "Do not add to it to make a build pass; add the translated strings instead."
+  ],
+  "gaps": {
+    "es": [
+      {
+        "reason": "Language switcher labels are deliberately shown in their own language ('Español', '中文'), so the en.json values are correct for every locale and the fallback is intended.",
+        "keys": ["languages.en", "languages.es", "languages.tl", "languages.zh"]
+      },
+      {
+        "reason": "Key-name mismatch, not a missing translation: en.json defines 'label.Other' while the locale files define 'label.Other.other'. The locale value is also the untranslated string 'Other'. Needs reconciling in a follow-up — see PR description.",
+        "keys": ["label.Other"]
+      },
+      {
+        "reason": "The en.json value is an empty string, so there is nothing to translate. Candidate for deletion.",
+        "keys": ["listings.occupancyDescriptionAllSroPlural"]
+      },
+      {
+        "reason": "DAH-4213 housing counselor agency access shipped ahead of its translations. These 20 strings render in English today and are the reason this check was written.",
+        "keys": [
+          "accountSettings.housingCounselor.agencyCan",
+          "accountSettings.housingCounselor.banner.shortError",
+          "accountSettings.housingCounselor.banner.title",
+          "accountSettings.housingCounselor.checkbox",
+          "accountSettings.housingCounselor.checkboxError",
+          "accountSettings.housingCounselor.description",
+          "accountSettings.housingCounselor.fieldError",
+          "accountSettings.housingCounselor.heading",
+          "accountSettings.housingCounselor.label",
+          "accountSettings.housingCounselor.p1",
+          "accountSettings.housingCounselor.p2",
+          "accountSettings.housingCounselor.p3",
+          "accountSettings.housingCounselor.p4",
+          "accountSettings.housingCounselor.placeholder",
+          "accountSettings.housingCounselor.revokeButton",
+          "accountSettings.housingCounselor.shareButton",
+          "accountSettings.housingCounselor.sharedOn",
+          "accountSettings.housingCounselor.sharedWith",
+          "accountSettings.housingCounselor.toastShared",
+          "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      }
+    ],
+    "tl": [
+      {
+        "reason": "Language switcher labels are deliberately shown in their own language ('Español', '中文'), so the en.json values are correct for every locale and the fallback is intended.",
+        "keys": ["languages.en", "languages.es", "languages.tl", "languages.zh"]
+      },
+      {
+        "reason": "Key-name mismatch, not a missing translation: en.json defines 'label.Other' while the locale files define 'label.Other.other'. The locale value is also the untranslated string 'Other'. Needs reconciling in a follow-up — see PR description.",
+        "keys": ["label.Other"]
+      },
+      {
+        "reason": "The en.json value is an empty string, so there is nothing to translate. Candidate for deletion.",
+        "keys": ["listings.occupancyDescriptionAllSroPlural"]
+      },
+      {
+        "reason": "DAH-4213 housing counselor agency access shipped ahead of its translations. These 20 strings render in English today and are the reason this check was written.",
+        "keys": [
+          "accountSettings.housingCounselor.agencyCan",
+          "accountSettings.housingCounselor.banner.shortError",
+          "accountSettings.housingCounselor.banner.title",
+          "accountSettings.housingCounselor.checkbox",
+          "accountSettings.housingCounselor.checkboxError",
+          "accountSettings.housingCounselor.description",
+          "accountSettings.housingCounselor.fieldError",
+          "accountSettings.housingCounselor.heading",
+          "accountSettings.housingCounselor.label",
+          "accountSettings.housingCounselor.p1",
+          "accountSettings.housingCounselor.p2",
+          "accountSettings.housingCounselor.p3",
+          "accountSettings.housingCounselor.p4",
+          "accountSettings.housingCounselor.placeholder",
+          "accountSettings.housingCounselor.revokeButton",
+          "accountSettings.housingCounselor.shareButton",
+          "accountSettings.housingCounselor.sharedOn",
+          "accountSettings.housingCounselor.sharedWith",
+          "accountSettings.housingCounselor.toastShared",
+          "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      }
+    ],
+    "zh": [
+      {
+        "reason": "Language switcher labels are deliberately shown in their own language ('Español', '中文'), so the en.json values are correct for every locale and the fallback is intended.",
+        "keys": ["languages.en", "languages.es", "languages.tl", "languages.zh"]
+      },
+      {
+        "reason": "Key-name mismatch, not a missing translation: en.json defines 'label.Other' while the locale files define 'label.Other.other'. The locale value is also the untranslated string 'Other'. Needs reconciling in a follow-up — see PR description.",
+        "keys": ["label.Other"]
+      },
+      {
+        "reason": "The en.json value is an empty string, so there is nothing to translate. Candidate for deletion.",
+        "keys": ["listings.occupancyDescriptionAllSroPlural"]
+      },
+      {
+        "reason": "DAH-4213 housing counselor agency access shipped ahead of its translations. These 20 strings render in English today and are the reason this check was written.",
+        "keys": [
+          "accountSettings.housingCounselor.agencyCan",
+          "accountSettings.housingCounselor.banner.shortError",
+          "accountSettings.housingCounselor.banner.title",
+          "accountSettings.housingCounselor.checkbox",
+          "accountSettings.housingCounselor.checkboxError",
+          "accountSettings.housingCounselor.description",
+          "accountSettings.housingCounselor.fieldError",
+          "accountSettings.housingCounselor.heading",
+          "accountSettings.housingCounselor.label",
+          "accountSettings.housingCounselor.p1",
+          "accountSettings.housingCounselor.p2",
+          "accountSettings.housingCounselor.p3",
+          "accountSettings.housingCounselor.p4",
+          "accountSettings.housingCounselor.placeholder",
+          "accountSettings.housingCounselor.revokeButton",
+          "accountSettings.housingCounselor.shareButton",
+          "accountSettings.housingCounselor.sharedOn",
+          "accountSettings.housingCounselor.sharedWith",
+          "accountSettings.housingCounselor.toastShared",
+          "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/known-translation-gaps.json
+++ b/scripts/known-translation-gaps.json
@@ -49,6 +49,42 @@
           "accountSettings.housingCounselor.toastShared",
           "accountSettings.housingCounselor.toastStoppedSharing"
         ]
+      },
+      {
+        "reason": "DAH-4198 sign-in-with-email-and-code page shipped ahead of its translations. These 31 strings render in English today.",
+        "keys": [
+          "createAccount.addPassword",
+          "createAccount.checkEmail",
+          "createAccount.choosePasswordOptional",
+          "createAccount.codeDescription",
+          "createAccount.codeInvalid.p1",
+          "createAccount.codeInvalid.p2",
+          "createAccount.confirmCode",
+          "createAccount.didntGetEmail",
+          "createAccount.editEmail",
+          "createAccount.enterCode",
+          "createAccount.getCode",
+          "createAccount.getHelp",
+          "createAccount.getHelpLink",
+          "createAccount.howTo.p1",
+          "createAccount.howTo.p2",
+          "createAccount.howTo.p3",
+          "createAccount.howTo.p4",
+          "createAccount.howTo.p5",
+          "createAccount.howToUseCode",
+          "createAccount.okayToSkipPassword",
+          "createAccount.savePassword",
+          "createAccount.sendAgain",
+          "createAccount.skipForNow",
+          "createAccount.weSentCodeTo",
+          "signIn.codeDescription",
+          "signIn.createAccount",
+          "signIn.createAccountDescription",
+          "signIn.getHelpLink",
+          "signIn.oneTimeCode",
+          "signIn.oneTimeCodeNote",
+          "signIn.passwordInstead"
+        ]
       }
     ],
     "tl": [
@@ -88,6 +124,42 @@
           "accountSettings.housingCounselor.toastShared",
           "accountSettings.housingCounselor.toastStoppedSharing"
         ]
+      },
+      {
+        "reason": "DAH-4198 sign-in-with-email-and-code page shipped ahead of its translations. These 31 strings render in English today.",
+        "keys": [
+          "createAccount.addPassword",
+          "createAccount.checkEmail",
+          "createAccount.choosePasswordOptional",
+          "createAccount.codeDescription",
+          "createAccount.codeInvalid.p1",
+          "createAccount.codeInvalid.p2",
+          "createAccount.confirmCode",
+          "createAccount.didntGetEmail",
+          "createAccount.editEmail",
+          "createAccount.enterCode",
+          "createAccount.getCode",
+          "createAccount.getHelp",
+          "createAccount.getHelpLink",
+          "createAccount.howTo.p1",
+          "createAccount.howTo.p2",
+          "createAccount.howTo.p3",
+          "createAccount.howTo.p4",
+          "createAccount.howTo.p5",
+          "createAccount.howToUseCode",
+          "createAccount.okayToSkipPassword",
+          "createAccount.savePassword",
+          "createAccount.sendAgain",
+          "createAccount.skipForNow",
+          "createAccount.weSentCodeTo",
+          "signIn.codeDescription",
+          "signIn.createAccount",
+          "signIn.createAccountDescription",
+          "signIn.getHelpLink",
+          "signIn.oneTimeCode",
+          "signIn.oneTimeCodeNote",
+          "signIn.passwordInstead"
+        ]
       }
     ],
     "zh": [
@@ -126,6 +198,42 @@
           "accountSettings.housingCounselor.sharedWith",
           "accountSettings.housingCounselor.toastShared",
           "accountSettings.housingCounselor.toastStoppedSharing"
+        ]
+      },
+      {
+        "reason": "DAH-4198 sign-in-with-email-and-code page shipped ahead of its translations. These 31 strings render in English today.",
+        "keys": [
+          "createAccount.addPassword",
+          "createAccount.checkEmail",
+          "createAccount.choosePasswordOptional",
+          "createAccount.codeDescription",
+          "createAccount.codeInvalid.p1",
+          "createAccount.codeInvalid.p2",
+          "createAccount.confirmCode",
+          "createAccount.didntGetEmail",
+          "createAccount.editEmail",
+          "createAccount.enterCode",
+          "createAccount.getCode",
+          "createAccount.getHelp",
+          "createAccount.getHelpLink",
+          "createAccount.howTo.p1",
+          "createAccount.howTo.p2",
+          "createAccount.howTo.p3",
+          "createAccount.howTo.p4",
+          "createAccount.howTo.p5",
+          "createAccount.howToUseCode",
+          "createAccount.okayToSkipPassword",
+          "createAccount.savePassword",
+          "createAccount.sendAgain",
+          "createAccount.skipForNow",
+          "createAccount.weSentCodeTo",
+          "signIn.codeDescription",
+          "signIn.createAccount",
+          "signIn.createAccountDescription",
+          "signIn.getHelpLink",
+          "signIn.oneTimeCode",
+          "signIn.oneTimeCodeNote",
+          "signIn.passwordInstead"
         ]
       }
     ]


### PR DESCRIPTION
## Problem

`loadTranslations()` in [`app/javascript/util/languageUtil.tsx`](https://github.com/SFDigitalServices/sf-dahlia-web/blob/main/app/javascript/util/languageUtil.tsx) loads English first and then overlays the target locale, so a key missing from `es.json`/`tl.json`/`zh.json` silently renders the English string. Nothing in the app surfaces it, and the existing `translations-check` workflow only ran `jsonlint` and a sort check — it never compared key sets or validated string content.

Separately, devs have been checking translated *values* by hand with the [Translation-Checker](https://github.com/chadbrokaw/Translation-Checker/) tool, a browser page you paste XLIFF into. Nothing ran its rules automatically. See DAH-3291.

## What this adds

`scripts/check-translation-parity.js` now does two things against `app/assets/json/translations/react/*.json`, comparing each locale to `en.json`:

**Key parity** — fails on keys missing from a locale (silently render in English) or present but empty (render blank, worse than the fallback). Reports, without failing, keys present in a locale but not in `en.json` (dead weight).

**Value checks** (ported from Translation-Checker, adapted for JSON rather than XLIFF):
- encoding errors (a literal `&amp;`/`nbsp;` means double-encoding)
- variables missing their `%` prefix (`{name}` vs `%{name}`)
- variables differing from `en.json`
- plural separators that aren't exactly four bars (`||||`)
- pluralized strings with the wrong number of forms

Two of the value checks are adapted rather than copied 1:1 from the XLF tool, because a literal port produced false positives on real strings: variable comparison uses the set of variable names rather than occurrence counts (a pluralized string legitimately repeats a variable once per form), and plural form count is checked against what each locale needs (1 for `zh`, 2 otherwise) rather than against `en.json` (English often has one form where Spanish needs two).

Runs as a job in the existing `translations-check` workflow, and locally via `yarn check:translations`.

## The allowlist is a ratchet, not a resolution

`scripts/known-translation-gaps.json` is seeded with the keys already missing on `main` per locale, grouped under a written reason, so this can merge without blocking unrelated PRs. It should only get shorter — the script flags stale/orphaned allowlist entries.

## Testing

- Against `main` as-is: passes (key parity + all five value checks).
- Negative tests: injected one defect per value check into `es.json`, plus deleted/blanked keys — each check fires on exactly its own key, exit 1. Reverted, `git diff` clean.
- `yarn lint` and `npx prettier --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)