### PR TITLE
fix: DAH-4186 Intercept unleash flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ coverage
 jest-test-coverage
 junit.xml
 cypress/screenshots/*
+cypress/results/*
 jestInspectOutput.txt
 
 # Yalc

--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -138,6 +138,7 @@ export const interceptUnleashFlags = () => {
           if (!existingToggleNames.has(toggleName))
             interceptedToggles.push({ name: toggleName, enabled: true } as IToggle)
         })
+        console.log("Intercepted and modified unleash flags:", interceptedToggles)
         response.body.toggles = interceptedToggles
       })
     }

--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -1,3 +1,5 @@
+import { type IToggle } from "unleash-proxy-client"
+
 const staticUserData = {
   provider: "email",
   id: 123,
@@ -112,22 +114,31 @@ export const userObjectGenerator = ({
 }
 
 export const interceptUnleashFlags = () => {
+  const toggleOffNames = new Set(["temp.all.housingCounselorAccess", "temp.webapp.auth.clerk"])
+  const toggleOnNames = new Set(["temp.webapp.newAccountLayout"])
   cy.intercept(
     "GET",
     "https://dahlia-feature-service-fbc319c3f542.herokuapp.com/api/frontend**",
     (request) => {
       request.continue((response) => {
-        response.body.toggles.forEach((toggle) => {
-          if (toggle.name === "temp.webapp.newAccountLayout") {
-            toggle.enabled = true
-          }
-          if (toggle.name === "temp.all.housingCounselorAccess") {
-            toggle.enabled = false
-          }
-          if (toggle.name === "temp.webapp.auth.clerk") {
-            toggle.enabled = false
-          }
+        const interceptedToggles: IToggle[] = []
+        const existingToggleNames = new Set(
+          response.body.toggles.map((toggle: IToggle) => toggle.name) as string[]
+        )
+        // exclude "off" toggles from the payload
+        response.body.toggles.forEach((toggle: IToggle) => {
+          if (!toggleOffNames.has(toggle.name))
+            interceptedToggles.push({
+              ...toggle,
+              enabled: toggleOnNames.has(toggle.name) || toggle.enabled,
+            })
         })
+        // add "on" toggles to the payload if they're not already there
+        toggleOnNames.forEach((toggleName: string) => {
+          if (!existingToggleNames.has(toggleName))
+            interceptedToggles.push({ name: toggleName, enabled: true } as IToggle)
+        })
+        response.body.toggles = interceptedToggles
       })
     }
   ).as("unleashFlags")


### PR DESCRIPTION
## Description

Fix how we intercept Unleash flags. Unleash omits "off" toggles from the request payload, it does not set them to `"enabled": false`.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4186

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag