### PR TITLE
feat: DAH-4253 Authenticate housing counselor access with sign in link 

### DIFF
--- a/app/controllers/api/v1/housing_counselor_controller.rb
+++ b/app/controllers/api/v1/housing_counselor_controller.rb
@@ -9,14 +9,24 @@ class Api::V1::HousingCounselorController < ApiController
 
   # Authenticate housing counselor access to applicant contact ID in JWT
   def access
+    applicant_contact_id = JsonWebTokenService.decode_token(params[:t])['contactId']
+    if applicant_contact_id.blank?
+      Rails.logger.info(
+        'HousingCounselorController#access: JWT missing applicant contact ID',
+      )
+      render json: { error: 'unauthorized' }, status: :unauthorized
+      return
+    end
+
     result = Force::HousingCounselorService.authorize_access(
-      token: params[:t] || params[:token],
+      applicant_contact_id:,
       counselor_contact_id: current_user.salesforce_contact_id,
     )
     unless result
       Rails.logger.info(
         'HousingCounselorController#access: ' \
-        "Access denied for current user with contact ID=#{current_user.salesforce_contact_id}",
+        "Access denied for applicant contact ID=#{applicant_contact_id} " \
+        "and housing counselor contact ID=#{current_user.salesforce_contact_id}",
       )
       render json: { error: 'forbidden' }, status: :forbidden
       return

--- a/app/controllers/api/v1/housing_counselor_controller.rb
+++ b/app/controllers/api/v1/housing_counselor_controller.rb
@@ -6,4 +6,33 @@ class Api::V1::HousingCounselorController < ApiController
   def agencies
     render json: { agencies: Force::HousingCounselorService.agencies }
   end
+
+  # Authenticate housing counselor access to applicant contact ID in JWT
+  def access
+    result = Force::HousingCounselorService.authorize_access(
+      token: params[:t] || params[:token],
+      counselor_contact_id: current_user.salesforce_contact_id,
+    )
+    unless result
+      Rails.logger.info(
+        'HousingCounselorController#access: ' \
+        "Access denied for current user with contact ID=#{current_user.salesforce_contact_id}",
+      )
+      render json: { error: 'forbidden' }, status: :forbidden
+      return
+    end
+
+    Rails.logger.info(
+      'HousingCounselorController#access: ' \
+      "Access granted for applicant contact ID=#{result[:applicant_contact_id]} " \
+      "and housing counselor contact ID=#{result[:counselor_contact_id]}",
+    )
+    render json: { success: true }
+  rescue JsonWebTokenService::InvalidTokenError => e
+    Rails.logger.info(
+      'HousingCounselorController#access: ' \
+      "invalid JWT: #{e.message}",
+    )
+    render json: { error: 'unauthorized' }, status: :unauthorized
+  end
 end

--- a/app/javascript/__tests__/api/authApiService.test.ts
+++ b/app/javascript/__tests__/api/authApiService.test.ts
@@ -19,7 +19,7 @@ import {
   updatePhone,
   getHousingCounselorAgencies,
   updateHousingCounselorAccess,
-  authenticateHousingCounselor,
+  authorizeHousingCounselor,
 } from "../../api/authApiService"
 import { mockProfileStub } from "../__util__/accountUtils"
 
@@ -166,9 +166,9 @@ describe("authApiService", () => {
     })
   })
 
-  describe("authenticateHousingCounselor", () => {
+  describe("authorizeHousingCounselor", () => {
     it("posts the JWT to the housing counselor access endpoint", async () => {
-      await authenticateHousingCounselor("jwt.token")
+      await authorizeHousingCounselor("jwt.token")
       expect(authenticatedPost).toHaveBeenCalledWith("/api/v1/housing-counselor/access", {
         t: "jwt.token",
       })

--- a/app/javascript/__tests__/api/authApiService.test.ts
+++ b/app/javascript/__tests__/api/authApiService.test.ts
@@ -4,6 +4,7 @@ import {
   post,
   put,
   authenticatedPut,
+  authenticatedPost,
 } from "../../api/apiService"
 
 import {
@@ -18,6 +19,7 @@ import {
   updatePhone,
   getHousingCounselorAgencies,
   updateHousingCounselorAccess,
+  authenticateHousingCounselor,
 } from "../../api/authApiService"
 import { mockProfileStub } from "../__util__/accountUtils"
 
@@ -27,6 +29,7 @@ jest.mock("../../api/apiService", () => ({
   authenticatedGet: jest.fn(),
   authenticatedDelete: jest.fn(),
   authenticatedPut: jest.fn(),
+  authenticatedPost: jest.fn(),
   post: jest.fn(),
   put: jest.fn(),
 }))
@@ -36,6 +39,7 @@ describe("authApiService", () => {
     ;(authenticatedGet as jest.Mock).mockResolvedValue({ data: { data: "test-data" } })
     ;(authenticatedDelete as jest.Mock).mockResolvedValue({ data: { data: "test-data" } })
     ;(authenticatedPut as jest.Mock).mockResolvedValue({ data: { data: "test-data" } })
+    ;(authenticatedPost as jest.Mock).mockResolvedValue({ data: { success: true } })
     ;(post as jest.Mock).mockResolvedValue({ data: "test-data", headers: "test-headers" })
     ;(put as jest.Mock).mockResolvedValue({ data: { message: "test-message" } })
   })
@@ -158,6 +162,15 @@ describe("authApiService", () => {
           alternatePhoneType: mockProfileStub.alternatePhoneType,
           housingCounselingAgencyId: mockProfileStub.housingCounselingAgencyId,
         },
+      })
+    })
+  })
+
+  describe("authenticateHousingCounselor", () => {
+    it("posts the JWT to the housing counselor access endpoint", async () => {
+      await authenticateHousingCounselor("jwt.token")
+      expect(authenticatedPost).toHaveBeenCalledWith("/api/v1/housing-counselor/access", {
+        t: "jwt.token",
       })
     })
   })

--- a/app/javascript/__tests__/pages/SignIn.test.tsx
+++ b/app/javascript/__tests__/pages/SignIn.test.tsx
@@ -5,13 +5,13 @@ import SignIn from "../../pages/sign-in"
 import { renderAndLoadAsync } from "../__util__/renderUtils"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
-import { post } from "../../api/apiService"
+import { authenticatedPost, post } from "../../api/apiService"
 import { SiteAlert } from "../../components/SiteAlert"
 import { t } from "@bloom-housing/ui-components"
 import "@testing-library/jest-dom"
 import TagManager from "react-gtm-module"
 import { useFeatureFlag } from "../../hooks/useFeatureFlag"
-import { isTokenValid } from "../../authentication/token"
+import { clearHeaders, isTokenValid } from "../../authentication/token"
 
 jest.mock("../../hooks/useFeatureFlag", () => ({
   useFeatureFlag: jest.fn((flagName: string) => ({
@@ -23,6 +23,7 @@ jest.mock("../../hooks/useFeatureFlag", () => ({
 jest.mock("../../authentication/token", () => ({
   ...jest.requireActual("../../authentication/token"),
   isTokenValid: jest.fn(() => false),
+  clearHeaders: jest.fn(),
 }))
 
 jest.mock("react-helmet-async", () => {
@@ -34,6 +35,7 @@ jest.mock("react-helmet-async", () => {
 
 jest.mock("../../api/apiService", () => ({
   post: jest.fn(),
+  authenticatedPost: jest.fn(),
 }))
 
 jest.mock("react-gtm-module", () => ({
@@ -56,6 +58,58 @@ jest.mock("@bloom-housing/ui-seeds", () => {
     Dialog: MockDialog,
   }
 })
+
+const setLocationSearch = (search: string) => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: {
+      ...window.location,
+      search,
+      href: `http://dahlia.com/sign-in${search}`,
+    },
+  })
+}
+
+const renderWithAccountRoute = () =>
+  renderAndLoadAsync(<SignIn assetPaths={{}} />, {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <MemoryRouter initialEntries={["/sign-in"]}>
+        <Routes>
+          <Route path="/sign-in" element={children} />
+          <Route path="/account" element={<div>Account page</div>} />
+        </Routes>
+      </MemoryRouter>
+    ),
+  })
+
+const mockSuccessfulSignIn = () => {
+  ;(post as jest.Mock).mockResolvedValue({
+    data: {
+      data: {
+        id: 1,
+        uid: "abc",
+        email: "test@test.com",
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    },
+    headers: {
+      expiry: "9999999999",
+      "access-token": "token",
+      client: "client",
+      uid: "abc",
+      "token-type": "Bearer",
+    },
+  })
+}
+
+const submitSignInForm = async () => {
+  await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@test.com")
+  await userEvent.type(screen.getByLabelText(/^password$/i), "Password1")
+  await userEvent.click(screen.getByRole("button", { name: /sign in/i }))
+}
 
 describe("<SignIn />", () => {
   beforeEach(() => {
@@ -438,5 +492,84 @@ describe("<SignIn />", () => {
       expect(screen.getByText("Account page")).not.toBeNull()
     })
     expect(screen.queryByRole("textbox", { name: /email/i })).toBeNull()
+  })
+
+  describe("Housing counselor access", () => {
+    beforeEach(() => {
+      setLocationSearch("")
+      window.scrollTo = jest.fn()
+      jest.spyOn(console, "log").mockImplementation(() => {})
+      ;(authenticatedPost as jest.Mock).mockResolvedValue({})
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it("authenticates the housing counselor JWT after a successful sign in and redirects to the account overview page", async () => {
+      setLocationSearch("?t=jwt.token")
+      mockSuccessfulSignIn()
+
+      await renderWithAccountRoute()
+      await submitSignInForm()
+
+      await waitFor(() => {
+        expect(authenticatedPost).toHaveBeenCalledWith("/api/v1/housing-counselor/access", {
+          t: "jwt.token",
+        })
+      })
+      expect(await screen.findByText("Account page")).not.toBeNull()
+    })
+
+    it("shows an error and stays on sign in when housing counselor authentication fails", async () => {
+      setLocationSearch("?t=jwt.token")
+      mockSuccessfulSignIn()
+      ;(authenticatedPost as jest.Mock).mockRejectedValue(new Error("forbidden"))
+
+      await renderWithAccountRoute()
+      await submitSignInForm()
+
+      await waitFor(() => {
+        expect(authenticatedPost).toHaveBeenCalledWith("/api/v1/housing-counselor/access", {
+          t: "jwt.token",
+        })
+      })
+      expect(clearHeaders).toHaveBeenCalled()
+      expect(screen.getByRole("alert")).not.toBeNull()
+      expect(screen.queryByText("Account page")).toBeNull()
+      expect(screen.getByRole("textbox", { name: /email/i })).not.toBeNull()
+    })
+
+    it("authenticates the housing counselor JWT with an already signed in user and redirects to the account overview page", async () => {
+      setLocationSearch("?t=jwt.token")
+      ;(isTokenValid as jest.Mock).mockReturnValue(true)
+
+      await renderWithAccountRoute()
+
+      await waitFor(() => {
+        expect(authenticatedPost).toHaveBeenCalledWith("/api/v1/housing-counselor/access", {
+          t: "jwt.token",
+        })
+      })
+      expect(await screen.findByText("Account page")).not.toBeNull()
+    })
+
+    it("shows an error and stays on sign in when housing counselor authentication fails with an already signed in user", async () => {
+      setLocationSearch("?t=jwt.token")
+      ;(isTokenValid as jest.Mock).mockReturnValue(true)
+      ;(authenticatedPost as jest.Mock).mockRejectedValue(new Error("forbidden"))
+
+      await renderWithAccountRoute()
+
+      await waitFor(() => {
+        expect(authenticatedPost).toHaveBeenCalledWith("/api/v1/housing-counselor/access", {
+          t: "jwt.token",
+        })
+      })
+      expect(clearHeaders).toHaveBeenCalled()
+      expect(screen.getByRole("alert")).not.toBeNull()
+      expect(screen.queryByText("Account page")).toBeNull()
+      expect(screen.getByRole("textbox", { name: /email/i })).not.toBeNull()
+    })
   })
 })

--- a/app/javascript/__tests__/setupTests.ts
+++ b/app/javascript/__tests__/setupTests.ts
@@ -79,6 +79,8 @@ beforeEach(() => {
   jest.resetAllMocks()
   setDefaultClerkAuth()
   jest.spyOn(console, "log").mockImplementation(() => {})
+  document.documentElement.lang = "en"
+  document.title = "DAHLIA San Francisco Housing Portal"
 })
 
 let previousHeapUsage: number | null = null
@@ -105,6 +107,7 @@ afterEach(() => {
     previousHeapUsage = currentHeapUsage
   }
   cleanup()
+  document.title = "DAHLIA San Francisco Housing Portal"
 
   // fail test if api call has not been mocked up
   expect(spies.delete).not.toHaveBeenCalled()

--- a/app/javascript/__tests__/setupTests.ts
+++ b/app/javascript/__tests__/setupTests.ts
@@ -57,6 +57,8 @@ jest.mock("react-helmet-async", () => {
   }
 })
 
+jest.mock("@axe-core/react", () => jest.fn())
+
 jest.mock("@clerk/clerk-react", () => {
   const Clerk = jest.requireActual("@clerk/clerk-react")
   return {

--- a/app/javascript/api/authApiService.ts
+++ b/app/javascript/api/authApiService.ts
@@ -1,11 +1,20 @@
 import { AxiosResponse } from "axios"
 import { Contact, User, UserData } from "../authentication/user"
-import { authenticatedDelete, authenticatedGet, authenticatedPut, post } from "./apiService"
+import {
+  authenticatedDelete,
+  authenticatedGet,
+  authenticatedPost,
+  authenticatedPut,
+  post,
+} from "./apiService"
 import { AuthHeaders, setAuthHeaders } from "../authentication/token"
 import { Application } from "./types/rails/application/RailsApplication"
 import { getCurrentLanguage, getRoutePrefix, LanguagePrefix } from "../util/languageUtil"
 import { getResetPasswordPath } from "../util/routeUtil"
-import { housingCounselorAgencies, updateHousingCounselor } from "./apiEndpoints"
+import {
+  housingCounselorAgencies,
+  updateHousingCounselor,
+} from "./apiEndpoints"
 
 const contactObject = (user: User): Contact => ({
   email: user.email,
@@ -113,6 +122,10 @@ export const getHousingCounselorAgencies = async (): Promise<HousingCounselorAge
   authenticatedGet<{ agencies: HousingCounselorAgency[] }>(housingCounselorAgencies()).then(
     ({ data }) => data.agencies
   )
+
+export const authenticateHousingCounselor = async (token: string): Promise<void> => {
+  await authenticatedPost("/api/v1/housing-counselor/access", { t: token })
+}
 
 export const resetPassword = async (new_password: string): Promise<string> =>
   authenticatedPut<{ message: string }>("/api/v1/auth/password", {

--- a/app/javascript/api/authApiService.ts
+++ b/app/javascript/api/authApiService.ts
@@ -11,10 +11,7 @@ import { AuthHeaders, setAuthHeaders } from "../authentication/token"
 import { Application } from "./types/rails/application/RailsApplication"
 import { getCurrentLanguage, getRoutePrefix, LanguagePrefix } from "../util/languageUtil"
 import { getResetPasswordPath } from "../util/routeUtil"
-import {
-  housingCounselorAgencies,
-  updateHousingCounselor,
-} from "./apiEndpoints"
+import { housingCounselorAgencies, updateHousingCounselor } from "./apiEndpoints"
 
 const contactObject = (user: User): Contact => ({
   email: user.email,

--- a/app/javascript/api/authApiService.ts
+++ b/app/javascript/api/authApiService.ts
@@ -120,7 +120,7 @@ export const getHousingCounselorAgencies = async (): Promise<HousingCounselorAge
     ({ data }) => data.agencies
   )
 
-export const authenticateHousingCounselor = async (token: string): Promise<void> => {
+export const authorizeHousingCounselor = async (token: string): Promise<void> => {
   await authenticatedPost("/api/v1/housing-counselor/access", { t: token })
 }
 

--- a/app/javascript/authentication/SignInForm.tsx
+++ b/app/javascript/authentication/SignInForm.tsx
@@ -18,6 +18,7 @@ import {
   getForgotPasswordPath,
   getCreateAccountPath,
   getSignInRedirectUrl,
+  getMyAccountPath,
   mapRedirectParamToEnum,
   AlertReason,
   mapAlertParamToEnum,
@@ -31,7 +32,11 @@ import { AccountAlreadyConfirmedModal } from "./components/AccountAlreadyConfirm
 import { NewAccountNotConfirmedModal } from "./components/NewAccountNotConfirmedModal"
 import { ExpiredUnconfirmedModal } from "./components/ExpiredUnconfirmedModal"
 import { renderInlineMarkup } from "../util/languageUtil"
+import { authenticateHousingCounselor } from "../api/authApiService"
+import { isTokenValid } from "./token"
 import { useGTMDataLayer } from "../hooks/analytics/useGTMDataLayer"
+
+const getHousingCounselorToken = () => new URLSearchParams(window.location.search).get("t")
 
 const getExpiredConfirmedEmail = () => {
   const urlParams = new URLSearchParams(window.location.search)
@@ -224,11 +229,30 @@ const SignInForm = () => {
     }
   }
 
+  const checkHousingCounselorAccess = async () => {
+    const token = getHousingCounselorToken()
+    if (!token) return true
+    try {
+      await authenticateHousingCounselor(token)
+      console.log(
+        "TODO: Housing counselor successfully authenticated, TBD banner and applicant view"
+      )
+      return true
+    } catch {
+      setRequestError({
+        message: t("signIn.unknownError"),
+        alertType: "alert",
+      })
+      return false
+    }
+  }
+
   const onSubmit = (data: { email: string; password: string }) => {
     const { email, password } = data
     setRequestError(undefined)
     signIn(email, password, "Sign In Page")
       .then(async () => {
+        if (!(await checkHousingCounselorAccess())) return
         const redirectType = getRedirectTypeFromURL()
         await navigate(getSignInRedirectUrl(redirectType))
         window.scrollTo(0, 0)
@@ -237,6 +261,19 @@ const SignInForm = () => {
         handleRequestError(error)
       })
   }
+
+  // Check if there is already a logged in housing counselor hitting the sign-in page with an access link
+  useEffect(() => {
+    if (!isTokenValid() || !getHousingCounselorToken()) return
+
+    void checkHousingCounselorAccess().then(async (ok) => {
+      if (ok) {
+        console.log("TODO: Housing counselor already signed in, TBD banner and applicant view")
+        await navigate(getMyAccountPath())
+      }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     const alertType = getAlertFromURL()

--- a/app/javascript/authentication/SignInForm.tsx
+++ b/app/javascript/authentication/SignInForm.tsx
@@ -33,7 +33,7 @@ import { NewAccountNotConfirmedModal } from "./components/NewAccountNotConfirmed
 import { ExpiredUnconfirmedModal } from "./components/ExpiredUnconfirmedModal"
 import { renderInlineMarkup } from "../util/languageUtil"
 import { authenticateHousingCounselor } from "../api/authApiService"
-import { isTokenValid } from "./token"
+import { clearHeaders, isTokenValid } from "./token"
 import { useGTMDataLayer } from "../hooks/analytics/useGTMDataLayer"
 
 const getHousingCounselorToken = () => new URLSearchParams(window.location.search).get("t")
@@ -239,6 +239,7 @@ const SignInForm = () => {
       )
       return true
     } catch {
+      clearHeaders()
       setRequestError({
         message: t("signIn.unknownError"),
         alertType: "alert",

--- a/app/javascript/authentication/SignInForm.tsx
+++ b/app/javascript/authentication/SignInForm.tsx
@@ -32,7 +32,7 @@ import { AccountAlreadyConfirmedModal } from "./components/AccountAlreadyConfirm
 import { NewAccountNotConfirmedModal } from "./components/NewAccountNotConfirmedModal"
 import { ExpiredUnconfirmedModal } from "./components/ExpiredUnconfirmedModal"
 import { renderInlineMarkup } from "../util/languageUtil"
-import { authenticateHousingCounselor } from "../api/authApiService"
+import { authorizeHousingCounselor } from "../api/authApiService"
 import { clearHeaders, isTokenValid } from "./token"
 import { useGTMDataLayer } from "../hooks/analytics/useGTMDataLayer"
 
@@ -233,7 +233,7 @@ const SignInForm = () => {
     const token = getHousingCounselorToken()
     if (!token) return true
     try {
-      await authenticateHousingCounselor(token)
+      await authorizeHousingCounselor(token)
       console.log(
         "TODO: Housing counselor successfully authenticated, TBD banner and applicant view"
       )

--- a/app/javascript/layouts/withAppSetup.tsx
+++ b/app/javascript/layouts/withAppSetup.tsx
@@ -35,7 +35,7 @@ const withAppSetup =
     }
   ) =>
   (props: P) => {
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test") {
       void axe(React, ReactDOM, 1000)
     }
 

--- a/app/javascript/pages/sign-in.tsx
+++ b/app/javascript/pages/sign-in.tsx
@@ -25,7 +25,7 @@ const SignIn = (_props: SignInProps) => {
 
   if (clerkEnabled) {
     return <SignInFlow />
-  } else if (isTokenValid() && !new URLSearchParams(window.location.search).get("t")) {
+  } else if (isTokenValid() && !new URLSearchParams(window.location.search).has("t")) {
     return <Navigate to={getMyAccountPath()} replace />
   }
 

--- a/app/javascript/pages/sign-in.tsx
+++ b/app/javascript/pages/sign-in.tsx
@@ -25,7 +25,7 @@ const SignIn = (_props: SignInProps) => {
 
   if (clerkEnabled) {
     return <SignInFlow />
-  } else if (isTokenValid()) {
+  } else if (isTokenValid() && !new URLSearchParams(window.location.search).get("t")) {
     return <Navigate to={getMyAccountPath()} replace />
   }
 

--- a/app/services/force/housing_counselor_service.rb
+++ b/app/services/force/housing_counselor_service.rb
@@ -10,6 +10,15 @@ module Force
       return if applicant_contact_id.blank? || counselor_contact_id.blank?
 
       counselor = fetch_housing_counselor(counselor_contact_id)
+      unless counselor
+        Rails.logger.info(
+          'HousingCounselorService#authorize_access: counselor not found ' \
+          "applicant_contact_id=#{applicant_contact_id} " \
+          "counselor_contact_id=#{counselor_contact_id}",
+        )
+        return
+      end
+
       applicant = Force::AccountService.get(applicant_contact_id)
       unless access?(counselor, applicant)
         log_access_denied(

--- a/app/services/force/housing_counselor_service.rb
+++ b/app/services/force/housing_counselor_service.rb
@@ -5,5 +5,117 @@ module Force
     def self.agencies
       Request.new.cached_get('/housingCounselingAgencies/')
     end
+
+    def self.authorize_access(applicant_contact_id:, counselor_contact_id:)
+      return if applicant_contact_id.blank? || counselor_contact_id.blank?
+
+      counselor = fetch_housing_counselor(counselor_contact_id)
+      applicant = Force::AccountService.get(applicant_contact_id)
+      unless access?(counselor, applicant)
+        log_access_denied(
+          counselor,
+          applicant,
+          applicant_contact_id:,
+          counselor_contact_id:,
+        )
+        return
+      end
+
+      { applicant_contact_id:, counselor_contact_id: }
+    rescue Restforce::NotFoundError => e
+      Rails.logger.info(
+        "HousingCounselorService#authorize_access: #{e.message}",
+      )
+      nil
+    end
+
+    def self.fetch_housing_counselor(counselor_contact_id)
+      result = Request.new.get("/housingCounselingAgencies/#{counselor_contact_id}")
+      find_counselor(result, counselor_contact_id)
+    rescue Restforce::NotFoundError => e
+      Rails.logger.info(
+        'HousingCounselorService housingCounselingAgencies ' \
+        "response=#{e.message}",
+      )
+      nil
+    end
+
+    def self.find_counselor(agencies, counselor_contact_id)
+      Array.wrap(agencies).each do |agency|
+        counselors = Array.wrap(agency['housingCounselors'])
+        counselor = counselors.find { |contact| contact['id'] == counselor_contact_id }
+        next unless counselor
+
+        return counselor.merge('relatedAccount' => agency['id'])
+      end
+      nil
+    end
+
+    def self.access?(counselor, applicant)
+      counselor && applicant &&
+        counselor['isHousingCounselor'] &&
+        !counselor['inactiveContact'] &&
+        counselor['relatedAccount'].present? &&
+        counselor['relatedAccount'] == applicant['housingCounselingAgencyId']
+    end
+
+    def self.log_access_denied(
+      counselor, applicant, applicant_contact_id:, counselor_contact_id:
+    )
+      log_if_not_housing_counselor(counselor, counselor_contact_id)
+      log_if_inactive_housing_counselor(counselor, counselor_contact_id)
+      log_if_agency_denied(
+        counselor,
+        applicant,
+        applicant_contact_id:,
+        counselor_contact_id:,
+      )
+    end
+
+    def self.log_if_not_housing_counselor(counselor, counselor_contact_id)
+      return if counselor && counselor['isHousingCounselor']
+
+      Rails.logger.error(
+        'The currently logged in user with contact ' \
+        "ID=#{counselor_contact_id} is not a housing counselor",
+      )
+    end
+
+    def self.log_if_inactive_housing_counselor(counselor, counselor_contact_id)
+      return unless counselor
+      return unless counselor['inactiveContact']
+
+      Rails.logger.error(
+        'The currently logged in housing counselor with contact ' \
+        "ID=#{counselor_contact_id} is inactive",
+      )
+    end
+
+    def self.log_if_agency_denied(
+      counselor, applicant, applicant_contact_id:, counselor_contact_id:
+    )
+      return unless applicant
+
+      if applicant['housingCounselingAgencyId'].blank?
+        Rails.logger.error(
+          'The provided applicant contact ' \
+          "ID=#{applicant_contact_id} user did not grant access to a " \
+          'housing counselor agency',
+        )
+      elsif counselor &&
+            counselor['relatedAccount'] != applicant['housingCounselingAgencyId']
+        Rails.logger.error(
+          'The housing counselor agency relatedAccount ' \
+          "ID=#{counselor['relatedAccount']} of the housing counselor " \
+          "contact ID=#{counselor_contact_id} does not match the applicant " \
+          "contact ID=#{applicant_contact_id} housing counselor agency " \
+          "ID=#{applicant['housingCounselingAgencyId']}",
+        )
+      end
+    end
+    private_class_method :fetch_housing_counselor, :find_counselor, :access?,
+                         :log_access_denied, :log_if_not_housing_counselor,
+                         :log_if_inactive_housing_counselor,
+                         :log_if_agency_denied
   end
 end

--- a/app/services/force/housing_counselor_service.rb
+++ b/app/services/force/housing_counselor_service.rb
@@ -11,11 +11,7 @@ module Force
 
       counselor = fetch_housing_counselor(counselor_contact_id)
       unless counselor
-        Rails.logger.info(
-          'HousingCounselorService#authorize_access: counselor not found ' \
-          "applicant_contact_id=#{applicant_contact_id} " \
-          "counselor_contact_id=#{counselor_contact_id}",
-        )
+        log_if_not_housing_counselor(nil, counselor_contact_id)
         return
       end
 
@@ -82,7 +78,15 @@ module Force
     end
 
     def self.log_if_not_housing_counselor(counselor, counselor_contact_id)
-      return if counselor && counselor['isHousingCounselor']
+      if counselor.nil?
+        Rails.logger.error(
+          'Housing counselor contact is not associated with an agency ' \
+          "contact ID=#{counselor_contact_id}",
+        )
+        return
+      end
+
+      return if counselor['isHousingCounselor']
 
       Rails.logger.error(
         'The currently logged in user with contact ' \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
       end
       scope '/housing-counselor' do
         get 'agencies' => 'housing_counselor#agencies'
+        post 'access' => 'housing_counselor#access'
       end
     end
   end

--- a/spec/controllers/api/v1/housing_counselor_controller_spec.rb
+++ b/spec/controllers/api/v1/housing_counselor_controller_spec.rb
@@ -20,7 +20,60 @@ RSpec.describe Api::V1::HousingCounselorController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to eq('agencies' => agencies)
-      expect(Force::HousingCounselorService).to have_received(:agencies)
+    end
+  end
+
+  describe 'POST #access' do
+    let(:token) { 'jwt.token' }
+    let(:applicant_contact_id) { '003ABC' }
+
+    before do
+      allow(JsonWebTokenService).to receive(:decode_token)
+        .with(token).and_return('contactId' => applicant_contact_id)
+      allow(Force::HousingCounselorService).to receive(:authorize_access)
+    end
+
+    it 'returns success when the housing counselor has access to the applicant' do
+      allow(Force::HousingCounselorService).to receive(:authorize_access).and_return(
+        {
+          applicant_contact_id:,
+          counselor_contact_id: user.salesforce_contact_id,
+        },
+      )
+
+      post :access, params: { t: token }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq('success' => true)
+    end
+
+    it 'returns unauthorized when the JWT is missing contactId' do
+      allow(JsonWebTokenService).to receive(:decode_token)
+        .with(token).and_return('contactId' => nil)
+
+      post :access, params: { t: token }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)).to eq('error' => 'unauthorized')
+    end
+
+    it 'returns unauthorized when the JWT is invalid' do
+      allow(JsonWebTokenService).to receive(:decode_token)
+        .and_raise(JsonWebTokenService::InvalidTokenError, 'Invalid JWT')
+
+      post :access, params: { t: token }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)).to eq('error' => 'unauthorized')
+    end
+
+    it 'returns forbidden when the housing counselor does not have access' do
+      allow(Force::HousingCounselorService).to receive(:authorize_access).and_return(nil)
+
+      post :access, params: { t: token }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)).to eq('error' => 'forbidden')
     end
   end
 end

--- a/spec/services/force/housing_counselor_service_spec.rb
+++ b/spec/services/force/housing_counselor_service_spec.rb
@@ -3,25 +3,126 @@
 require 'rails_helper'
 
 RSpec.describe Force::HousingCounselorService do
+  let(:request_instance) { instance_double(Force::Request) }
+
+  before do
+    allow(Force::Request).to receive(:new).and_return(request_instance)
+  end
+
   describe '.agencies' do
-    let(:request_instance) { instance_double(Force::Request) }
-    let(:agencies) do
-      [
-        { 'id' => '123', 'name' => 'Test Agency A', 'shortName' => 'A' },
-      ]
-    end
-
-    before do
-      allow(Force::Request).to receive(:new).and_return(request_instance)
-    end
-
     it 'fetches housing counseling agencies from Salesforce' do
+      agencies = [{ 'id' => '123', 'name' => 'Test Agency A', 'shortName' => 'A' }]
       expect(request_instance)
         .to receive(:cached_get)
         .with('/housingCounselingAgencies/')
         .and_return(agencies)
 
       expect(described_class.agencies).to eq(agencies)
+    end
+  end
+
+  describe '.authorize_access' do
+    let(:counselor_contact_id) { 'hc123' }
+    let(:applicant_contact_id) { '003ABC' }
+    let(:agency_id) { 'agency1' }
+    let(:counselor_contact) do
+      {
+        'id' => counselor_contact_id,
+        'isHousingCounselor' => true,
+        'inactiveContact' => false,
+      }
+    end
+    let(:applicant) { { 'housingCounselingAgencyId' => agency_id } }
+
+    def stub_agencies(contact = counselor_contact)
+      allow(request_instance).to receive(:get)
+        .with("/housingCounselingAgencies/#{counselor_contact_id}")
+        .and_return(
+          [{ 'id' => agency_id, 'housingCounselors' => Array.wrap(contact) }],
+        )
+    end
+
+    before do
+      stub_agencies
+      allow(Force::AccountService).to receive(:get)
+        .with(applicant_contact_id).and_return(applicant)
+    end
+
+    it 'returns contact ids when the counselor has access to the applicant' do
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to eq(applicant_contact_id:, counselor_contact_id:)
+    end
+
+    it 'returns nil when the applicant contact id is blank' do
+      expect(
+        described_class.authorize_access(
+          applicant_contact_id: nil,
+          counselor_contact_id:,
+        ),
+      ).to be_nil
+    end
+
+    it 'returns nil when the contact is missing from housingCounselors' do
+      stub_agencies([])
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
+    end
+
+    it 'returns nil when the logged in user is not a housing counselor' do
+      stub_agencies(counselor_contact.merge('isHousingCounselor' => false))
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
+    end
+
+    it 'returns nil when the housing counselor is inactive' do
+      stub_agencies(counselor_contact.merge('inactiveContact' => true))
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
+    end
+
+    it 'returns nil when the applicant did not grant access to an agency' do
+      allow(Force::AccountService).to receive(:get)
+        .with(applicant_contact_id)
+        .and_return('housingCounselingAgencyId' => nil)
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
+    end
+
+    it 'returns nil when agency ids do not match' do
+      allow(Force::AccountService).to receive(:get)
+        .with(applicant_contact_id)
+        .and_return('housingCounselingAgencyId' => 'other-agency')
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
+    end
+
+    it 'returns nil when housingCounselingAgencies is not found' do
+      allow(request_instance).to receive(:get)
+        .and_raise(Restforce::NotFoundError, 'Could not find a match for URL')
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
+    end
+
+    it 'returns nil when the applicant contact is not found' do
+      allow(Force::AccountService).to receive(:get)
+        .and_raise(Restforce::NotFoundError, 'Could not find a match for URL')
+
+      expect(
+        described_class.authorize_access(applicant_contact_id:, counselor_contact_id:),
+      ).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Description

When a user hits /sign-in?t={token}, authenticate for an active housing counselor who works for the same agency that the applicant specified in the token has granted access to. 

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4253

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [ ] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag