### PR TITLE
fix: DAH-4328 Show SRO info card when unit summaries are in the reserved bucket

### DIFF
--- a/app/javascript/__tests__/data/RailsRentalListing/listing-rental-sro.ts
+++ b/app/javascript/__tests__/data/RailsRentalListing/listing-rental-sro.ts
@@ -692,3 +692,53 @@ export const sroMixedRentalListing: RailsRentalListing = {
     ],
   },
 }
+
+/**
+ * A reserved-community (senior) SRO listing, modeled on listing a0W7y00000J1wlNEAR.
+ * Salesforce puts the unit summaries of reserved-community listings in `reserved` and leaves
+ * `general` null, so SRO helpers have to read both buckets to see these units at all.
+ */
+export const reservedSroRentalListing: RailsRentalListing = {
+  ...sroRentalListing,
+  Reserved_community_type: "Senior",
+  Reserved_community_minimum_age: 62,
+  reservedDescriptor: [
+    {
+      shortDescription: null,
+      numberOfUnits: 20,
+      name: "Senior",
+      listingId: "a0W4U00000HnVLJUA3",
+    },
+  ],
+  unitSummaries: {
+    general: null,
+    reserved: [
+      {
+        unitType: "SRO",
+        totalUnits: 20,
+        minSquareFt: 158,
+        minRentalMinIncome: 1300,
+        minPriceWithParking: null,
+        minPriceWithoutParking: null,
+        minPercentIncome: null,
+        minOccupancy: 1,
+        minMonthlyRent: 650,
+        minHoaDuesWithParking: null,
+        minHoaDuesWithoutParking: null,
+        maxSquareFt: 259,
+        maxRentalMinIncome: 1500,
+        maxPriceWithParking: null,
+        maxPriceWithoutParking: null,
+        maxPercentIncome: null,
+        maxOccupancy: 2,
+        maxMonthlyRent: 750,
+        maxHoaDuesWithParking: null,
+        maxHoaDuesWithoutParking: null,
+        listingID: "a0W4U00000HnVLJUA3",
+        availability: 15,
+        absoluteMinIncome: 1300,
+        absoluteMaxIncome: 5620,
+      },
+    ],
+  },
+}

--- a/app/javascript/__tests__/pages/listings/ListingDetail.test.tsx
+++ b/app/javascript/__tests__/pages/listings/ListingDetail.test.tsx
@@ -3,7 +3,10 @@ import { cleanup, waitFor } from "@testing-library/react"
 import ListingDetail from "../../../../javascript/pages/listings/listing-detail"
 import { openRentalListing } from "../../data/RailsRentalListing/listing-rental-open"
 import { habitatListing } from "../../data/RailsSaleListing/listing-sale-habitat"
-import { sroRentalListing } from "../../data/RailsRentalListing/listing-rental-sro"
+import {
+  reservedSroRentalListing,
+  sroRentalListing,
+} from "../../data/RailsRentalListing/listing-rental-sro"
 import { renderAndLoadAsync } from "../../__util__/renderUtils"
 import { resetAccordionUuid } from "@bloom-housing/ui-components"
 import TagManager from "react-gtm-module"
@@ -78,6 +81,26 @@ describe("Listing Detail", () => {
 
     expect(await findAllByText(sroRentalListing.Name)).toBeDefined()
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it("renders the SRO info card when the sro units are in the reserved unit summaries", async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        listing: reservedSroRentalListing,
+        units: reservedSroRentalListing.Units,
+        ami: [],
+      },
+    })
+    const { findAllByText, findByText } = await renderAndLoadAsync(<ListingDetail assetPaths="/" />)
+
+    expect(await findAllByText(reservedSroRentalListing.Name)).toBeDefined()
+    expect(await findByText("Single Room Occupancy")).toBeDefined()
+    // maxOccupancy is 2, so the multiple occupancy description applies
+    expect(
+      await findByText(
+        "This property offers single rooms for up to 2 people only. Tenants may share bathrooms, and sometimes kitchen facilities."
+      )
+    ).toBeDefined()
   })
 
   it("initializes Google Tag Manager for a sales listing", async () => {

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -29,6 +29,7 @@ import {
   isFcfsSalesListing,
   isDeadlinePassed,
   getAllUnitSummaries,
+  getOccupancyRangeByUnitType,
 } from "../../util/listingUtil"
 
 // Configure dayjs with required plugins
@@ -46,6 +47,7 @@ import {
   sroRentalListing,
   pluralSroRentalListing,
   reservedSroRentalListing,
+  sroMixedRentalListing,
 } from "../data/RailsRentalListing/listing-rental-sro"
 import { unitsWithOccupancyAndMaxIncome, units } from "../data/RailsListingUnits/listing-units"
 import { amiCharts } from "../data/RailsAmiCharts/ami-charts"
@@ -162,6 +164,67 @@ describe("listingUtil", () => {
 
     it("should return true for plural SROs in the reserved summaries", () => {
       expect(isPluralSRO(reservedSroRentalListing)).toBe(true)
+    })
+  })
+
+  describe("getOccupancyRangeByUnitType", () => {
+    it("should return one entry per unit summary when unit types are distinct", () => {
+      expect(getOccupancyRangeByUnitType(sroMixedRentalListing)).toEqual([
+        { unitType: "SRO", minOccupancy: 1, maxOccupancy: 1 },
+        { unitType: "1 BR", minOccupancy: 1, maxOccupancy: 3 },
+      ])
+    })
+
+    it("should collapse a unit type that appears in both buckets into a single entry", () => {
+      // Mirrors listing a0W7y000004QCMbEAO, which has a general 1 BR and a senior-reserved 1 BR
+      const [studio, oneBed] = sroMixedRentalListing.unitSummaries.general
+
+      expect(
+        getOccupancyRangeByUnitType({
+          ...sroMixedRentalListing,
+          unitSummaries: { general: [studio, oneBed], reserved: [oneBed] },
+        })
+      ).toEqual([
+        { unitType: "SRO", minOccupancy: 1, maxOccupancy: 1 },
+        { unitType: "1 BR", minOccupancy: 1, maxOccupancy: 3 },
+      ])
+    })
+
+    it("should merge occupancy bounds when the same unit type has different ranges", () => {
+      const [, oneBed] = sroMixedRentalListing.unitSummaries.general
+
+      expect(
+        getOccupancyRangeByUnitType({
+          ...sroMixedRentalListing,
+          unitSummaries: {
+            general: [{ ...oneBed, minOccupancy: 2, maxOccupancy: 3 }],
+            reserved: [{ ...oneBed, minOccupancy: 1, maxOccupancy: 5 }],
+          },
+        })
+      ).toEqual([{ unitType: "1 BR", minOccupancy: 1, maxOccupancy: 5 }])
+    })
+
+    it("should keep a defined bound when the matching summary has a null bound", () => {
+      const [, oneBed] = sroMixedRentalListing.unitSummaries.general
+
+      expect(
+        getOccupancyRangeByUnitType({
+          ...sroMixedRentalListing,
+          unitSummaries: {
+            general: [{ ...oneBed, minOccupancy: 1, maxOccupancy: null }],
+            reserved: [{ ...oneBed, minOccupancy: null, maxOccupancy: 4 }],
+          },
+        })
+      ).toEqual([{ unitType: "1 BR", minOccupancy: 1, maxOccupancy: 4 }])
+    })
+
+    it("should return an empty array when the listing has no unit summaries", () => {
+      expect(
+        getOccupancyRangeByUnitType({
+          ...sroRentalListing,
+          unitSummaries: { general: null, reserved: null },
+        })
+      ).toEqual([])
     })
   })
 

--- a/app/javascript/__tests__/util/listingUtil.test.ts
+++ b/app/javascript/__tests__/util/listingUtil.test.ts
@@ -28,6 +28,7 @@ import {
   preferenceNameHasVeteran,
   isFcfsSalesListing,
   isDeadlinePassed,
+  getAllUnitSummaries,
 } from "../../util/listingUtil"
 
 // Configure dayjs with required plugins
@@ -44,6 +45,7 @@ import { habitatListing } from "../data/RailsSaleListing/listing-sale-habitat"
 import {
   sroRentalListing,
   pluralSroRentalListing,
+  reservedSroRentalListing,
 } from "../data/RailsRentalListing/listing-rental-sro"
 import { unitsWithOccupancyAndMaxIncome, units } from "../data/RailsListingUnits/listing-units"
 import { amiCharts } from "../data/RailsAmiCharts/ami-charts"
@@ -129,6 +131,10 @@ describe("listingUtil", () => {
     it("should return true when all units are SRO", () => {
       expect(listingHasOnlySROUnits(sroRentalListing)).toBe(true)
     })
+
+    it("should return true when all SRO units are in the reserved summaries", () => {
+      expect(listingHasOnlySROUnits(reservedSroRentalListing)).toBe(true)
+    })
   })
 
   describe("listingHasSROUnits", () => {
@@ -139,6 +145,10 @@ describe("listingUtil", () => {
     it("should return true when listing has SRO units", () => {
       expect(listingHasSROUnits(sroRentalListing)).toBe(true)
     })
+
+    it("should return true when the SRO units are in the reserved summaries", () => {
+      expect(listingHasSROUnits(reservedSroRentalListing)).toBe(true)
+    })
   })
 
   describe("isPluralSRO", () => {
@@ -148,6 +158,46 @@ describe("listingUtil", () => {
 
     it("should return true for a plural SROs", () => {
       expect(isPluralSRO(pluralSroRentalListing)).toBe(true)
+    })
+
+    it("should return true for plural SROs in the reserved summaries", () => {
+      expect(isPluralSRO(reservedSroRentalListing)).toBe(true)
+    })
+  })
+
+  describe("getAllUnitSummaries", () => {
+    it("should return the general summaries when only general is populated", () => {
+      expect(getAllUnitSummaries(sroRentalListing)).toEqual(sroRentalListing.unitSummaries.general)
+    })
+
+    it("should return the reserved summaries when only reserved is populated", () => {
+      expect(getAllUnitSummaries(reservedSroRentalListing)).toEqual(
+        reservedSroRentalListing.unitSummaries.reserved
+      )
+    })
+
+    it("should combine both buckets when general and reserved are populated", () => {
+      const mixedBucketListing = {
+        ...sroRentalListing,
+        unitSummaries: {
+          general: sroRentalListing.unitSummaries.general,
+          reserved: reservedSroRentalListing.unitSummaries.reserved,
+        },
+      }
+
+      expect(getAllUnitSummaries(mixedBucketListing)).toEqual([
+        ...sroRentalListing.unitSummaries.general,
+        ...reservedSroRentalListing.unitSummaries.reserved,
+      ])
+    })
+
+    it("should return an empty array when neither bucket is populated", () => {
+      expect(
+        getAllUnitSummaries({
+          ...sroRentalListing,
+          unitSummaries: { general: null, reserved: null },
+        })
+      ).toEqual([])
     })
   })
 

--- a/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
@@ -15,6 +15,7 @@ import {
   isEducatorOne,
   isEducatorBrightwell,
   isFcfsSalesListing,
+  getAllUnitSummaries,
   isHabitatListing,
   isPluralSRO,
   isRental,
@@ -95,7 +96,7 @@ export const ListingDetailsEligibility = ({
     occupancy: "t.occupancy",
   }
 
-  const occupancyTableData = listing.unitSummaries.general?.map((unit) => {
+  const occupancyTableData = getAllUnitSummaries(listing).map((unit) => {
     let occupancyLabel = ""
     if (unit.maxOccupancy === 1) {
       occupancyLabel = t("listings.onePerson")

--- a/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
+++ b/app/javascript/modules/listingDetails/ListingDetailsEligibility.tsx
@@ -15,7 +15,7 @@ import {
   isEducatorOne,
   isEducatorBrightwell,
   isFcfsSalesListing,
-  getAllUnitSummaries,
+  getOccupancyRangeByUnitType,
   isHabitatListing,
   isPluralSRO,
   isRental,
@@ -96,7 +96,7 @@ export const ListingDetailsEligibility = ({
     occupancy: "t.occupancy",
   }
 
-  const occupancyTableData = getAllUnitSummaries(listing).map((unit) => {
+  const occupancyTableData = getOccupancyRangeByUnitType(listing).map((unit) => {
     let occupancyLabel = ""
     if (unit.maxOccupancy === 1) {
       occupancyLabel = t("listings.onePerson")

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -186,6 +186,41 @@ export const getAllUnitSummaries = (listing: RailsRentalListing | RailsSaleListi
 
 const isSROUnitType = (unitType: string) => unitType === "SRO" || unitType === "Room"
 
+const lowerBound = (a: number, b: number) => (a == null ? b : (b == null ? a : Math.min(a, b)))
+const upperBound = (a: number, b: number) => (a == null ? b : (b == null ? a : Math.max(a, b)))
+
+/**
+ * Collapse a listing's unit summaries into one occupancy range per unit type.
+ *
+ * A unit type can appear in both the general and reserved buckets (e.g. a building with one
+ * senior-reserved 1 BR alongside a general 1 BR), which would otherwise produce duplicate rows
+ * in the occupancy table. Occupancy bounds are merged so the range still covers every unit of
+ * that type.
+ *
+ * @param {RailsRentalListing | RailsSaleListing} listing
+ * @returns one entry per unit type, in the order the unit types are first encountered
+ */
+export const getOccupancyRangeByUnitType = (listing: RailsRentalListing | RailsSaleListing) => {
+  const rangesByUnitType = new Map<
+    string,
+    { unitType: string; minOccupancy: number; maxOccupancy: number }
+  >()
+
+  getAllUnitSummaries(listing).forEach(({ unitType, minOccupancy, maxOccupancy }) => {
+    const existingRange = rangesByUnitType.get(unitType)
+
+    if (!existingRange) {
+      rangesByUnitType.set(unitType, { unitType, minOccupancy, maxOccupancy })
+      return
+    }
+
+    existingRange.minOccupancy = lowerBound(existingRange.minOccupancy, minOccupancy)
+    existingRange.maxOccupancy = upperBound(existingRange.maxOccupancy, maxOccupancy)
+  })
+
+  return [...rangesByUnitType.values()]
+}
+
 /**
  * Check if a listing has only SRO units
  * @param {RailsRentalListing | RailsRentalListing} listing

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -169,14 +169,33 @@ export const isCSLP = (listing: RailsRentalListing | RailsSaleListing) =>
   listing.Program_Type === "CSLP"
 
 /**
+ * Collect every unit summary on a listing, across both the general and reserved buckets.
+ *
+ * Salesforce splits unit summaries into `general` and `reserved`, and a listing can populate
+ * either or both. Reserved-community listings (senior, veteran, etc.) put all of their summaries
+ * in `reserved` and leave `general` null, so anything reading only `general` silently sees no
+ * units at all. Callers that care about unit types or occupancy should use this instead.
+ *
+ * @param {RailsRentalListing | RailsSaleListing} listing
+ * @returns the combined general and reserved unit summaries, empty when the listing has neither
+ */
+export const getAllUnitSummaries = (listing: RailsRentalListing | RailsSaleListing) => [
+  ...(listing.unitSummaries?.general ?? []),
+  ...(listing.unitSummaries?.reserved ?? []),
+]
+
+const isSROUnitType = (unitType: string) => unitType === "SRO" || unitType === "Room"
+
+/**
  * Check if a listing has only SRO units
  * @param {RailsRentalListing | RailsRentalListing} listing
  * @returns {boolean} returns true if the listing has all SRO unit types, false otherwise
  */
-export const listingHasOnlySROUnits = (listing: RailsRentalListing | RailsSaleListing) =>
-  listing.unitSummaries.general?.every(
-    (unit) => unit.unitType === "SRO" || unit.unitType === "Room"
-  )
+export const listingHasOnlySROUnits = (listing: RailsRentalListing | RailsSaleListing) => {
+  const unitSummaries = getAllUnitSummaries(listing)
+
+  return unitSummaries.length > 0 && unitSummaries.every((unit) => isSROUnitType(unit.unitType))
+}
 
 /**
  * Check if a listing has at least one SRO unit
@@ -184,7 +203,7 @@ export const listingHasOnlySROUnits = (listing: RailsRentalListing | RailsSaleLi
  * @returns {boolean} returns true if the listing has at least one SRO unit type, false otherwise
  */
 export const listingHasSROUnits = (listing: RailsRentalListing | RailsSaleListing) =>
-  listing.unitSummaries.general?.some((unit) => unit.unitType === "SRO" || unit.unitType === "Room")
+  getAllUnitSummaries(listing).some((unit) => isSROUnitType(unit.unitType))
 /**
  * Check if a listing is multi-occupancy SRO
  * @param {string} name
@@ -193,8 +212,8 @@ export const listingHasSROUnits = (listing: RailsRentalListing | RailsSaleListin
  * permit multiple occupancy, false otherwise
  */
 export const isPluralSRO = (listing: RailsRentalListing | RailsSaleListing): boolean => {
-  return listing.unitSummaries.general?.some(
-    (unit) => (unit.unitType === "SRO" || unit.unitType === "Room") && unit.maxOccupancy > 1
+  return getAllUnitSummaries(listing).some(
+    (unit) => isSROUnitType(unit.unitType) && unit.maxOccupancy > 1
   )
 }
 /**

--- a/app/javascript/util/listingUtil.ts
+++ b/app/javascript/util/listingUtil.ts
@@ -186,8 +186,19 @@ export const getAllUnitSummaries = (listing: RailsRentalListing | RailsSaleListi
 
 const isSROUnitType = (unitType: string) => unitType === "SRO" || unitType === "Room"
 
-const lowerBound = (a: number, b: number) => (a == null ? b : (b == null ? a : Math.min(a, b)))
-const upperBound = (a: number, b: number) => (a == null ? b : (b == null ? a : Math.max(a, b)))
+const definedBounds = (a: number, b: number) => [a, b].filter((bound) => bound != null)
+
+const lowerBound = (a: number, b: number) => {
+  const bounds = definedBounds(a, b)
+
+  return bounds.length > 0 ? Math.min(...bounds) : null
+}
+
+const upperBound = (a: number, b: number) => {
+  const bounds = definedBounds(a, b)
+
+  return bounds.length > 0 ? Math.max(...bounds) : null
+}
 
 /**
  * Collapse a listing's unit summaries into one occupancy range per unit type.


### PR DESCRIPTION
## Description

The "Single Room Occupancy" info card was missing on [1303 Larkin Street](https://housing.sfgov.org/listings/a0W7y00000J1wlNEAR?preview=true), which is a 62+ SRO listing.  This seems to be because the SRO helpers only read `unitSummaries.general` and 1303 Larkin has all of its unit summaries in `unitSummaries.reserved`.

**Before**

<img width="1792" height="1013" alt="image" src="https://github.com/user-attachments/assets/9260c9b5-2c56-4031-891b-ced398b55d53" />

<br>
<br>

**After**

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/4e13dfca-65ca-4725-9f1e-78bc55120719" />

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4328

## Review instructions

1. Open a reserved-community SRO listing, e.g. `/listings/a0W7y00000J1wlNEAR`.
2. The Single Room Occupancy info card appears below the pricing table, with the "up to 2 people" wording.
3. The eligibility section's occupancy table lists the SRO unit type.
4. Confirm no regression on `/listings/a0W7y00000ImkxREAR` (non-reserved SRO) or `/listings/a0W4U00000IgwwgUAB` (general-bucketed).

<details><summary><h3>Details</h3></summary>
<p>

## What was happening

The card is gated by `listingHasSROUnits(listing)`, which only inspected the `general` bucket:

```ts
listing.unitSummaries.general?.some((u) => u.unitType === "SRO" || u.unitType === "Room")
```

On a reserved-community listing `general` is `null`, so the optional chain short-circuits to `undefined` and the card never renders. Live API data:

| Listing | general | reserved | card |
| --- | --- | --- | --- |
| [a0W7y00000J1wlNEAR](https://housing.sfgov.org/listings/a0W7y00000J1wlNEAR?preview=true) (1303 Larkin, Senior 62+) | null | SRO, 20 units, maxOccupancy 2 | missing |
| [a0W7y00000ImkxREAR](https://housing.sfgov.org/listings/a0W7y00000ImkxREAR?preview=true) (750 Harrison, not reserved) | SRO, 9 units | empty | renders |
| [a0W4U00000IgwwgUAB](https://housing.sfgov.org/listings/a0W4U00000IgwwgUAB?preview=true) (Larkin Pine, older record) | SRO, 45 units | null | renders |

Note the third listing is the same building as the first and is also Senior 62+, but its summaries land in `general`. Its `Listing_Unit__c` junction records appear to be missing `Reserved_Type__c`, so it renders the card by accident. That is why this is fixed in the front end rather than by editing Salesforce data — correcting that record would make it lose the card too.

## Changes

- Add `getAllUnitSummaries` to `listingUtil.ts`, combining `general` and `reserved`.
- Use it in `listingHasSROUnits`, `listingHasOnlySROUnits`, and `isPluralSRO`, and extract a shared `isSROUnitType` predicate.
- Use it for `occupancyTableData` in `ListingDetailsEligibility.tsx`, which had the same `general`-only read, so the occupancy table and subtitle were also empty on reserved-only listings.
- Add a `reservedSroRentalListing` fixture modeled on a0W7y00000J1wlNEAR, plus unit tests for the helpers and a `ListingDetail` test asserting the card renders with the multiple-occupancy copy (its units are `maxOccupancy: 2`).

A union rather than the `general ?? reserved` fallback used in `for-rent.tsx` and `for-sale.tsx`, so listings with a mix of general and reserved units are handled correctly.

Two behavior notes for review:

- `listingHasOnlySROUnits` previously returned `undefined` when `general` was absent and `true` for an empty array. It now requires at least one summary, so a listing with no unit summaries returns `false` rather than a truthy-empty `true`.
- `occupancyTableData` was `UnitSummary[] | undefined` and is now always an array, so `StandardTable` gets `[]` instead of `undefined` on a listing with no summaries. Renders the same, snapshots unchanged.


</p>
</details> 

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [x] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
