### PR TITLE
fix: DAH-0000 Check for Clerk flag on listing details page

### DIFF
--- a/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
@@ -67,6 +67,26 @@ const ordinalHeader = (ordinal: number, title: string) => {
   )
 }
 
+const ApplyButton = ({ href }: { href: string }) => (
+  <LinkButton
+    styleType={AppearanceStyleType.primary}
+    className={"w-full"}
+    transition={true}
+    href={href}
+  >
+    {t("label.applyOnline")}
+  </LinkButton>
+)
+
+const ClerkApplyOnlineButton = ({ applyLink }: { applyLink: string }) => {
+  const { isLoaded, isSignedIn } = useAuth()
+  const { profile, initialStateLoaded } = useContext(UserContext)
+  const href =
+    isLoaded && isSignedIn && initialStateLoaded && !profile ? getAddProfilePath() : applyLink
+
+  return <ApplyButton href={href} />
+}
+
 /**
  * If the React form engine is enabled, link to the React application.
  * If Clerk is enabled and the user has an incomplete profile, redirect to the add profile page.
@@ -75,26 +95,16 @@ const ordinalHeader = (ordinal: number, title: string) => {
 const ApplyOnlineButton = ({ listingId }: { listingId: string }) => {
   const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
   const { unleashFlag: formEngine } = useFeatureFlag(UNLEASH_FLAG.FORM_ENGINE, false)
-  const { isLoaded, isSignedIn } = useAuth()
-  const { profile, initialStateLoaded } = useContext(UserContext)
   let applyLink = localizedPath(`listings/${listingId}/apply-welcome/intro`)
   if (formEngine) {
     applyLink = localizedPath(`listings/${listingId}/apply/intro`)
   }
-  if (flagsReady && clerkEnabled && isLoaded && isSignedIn && initialStateLoaded && !profile) {
-    applyLink = getAddProfilePath()
+
+  if (flagsReady && clerkEnabled) {
+    return <ClerkApplyOnlineButton applyLink={applyLink} />
   }
 
-  return (
-    <LinkButton
-      styleType={AppearanceStyleType.primary}
-      className={"w-full"}
-      transition={true}
-      href={applyLink}
-    >
-      {t("label.applyOnline")}
-    </LinkButton>
-  )
+  return <ApplyButton href={applyLink} />
 }
 
 const StandardHowToApply = ({


### PR DESCRIPTION
## Description

The listing details apply button checks for Clerk to redirect users to the add profile page. We do not want to do this for the existing Devise page. This PR separates out the apply button logic and checks for the Unleash flag before using Clerk. 

To review, ensure the listing details apply button works with the Clerk flag both on and off. 

## Before requesting eng review

### Version Control

- [ ] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag