### PR TITLE
feat: DAH-0000 Read the signed-in user from one session provider

### DIFF
--- a/app/javascript/__tests__/__util__/accountUtils.tsx
+++ b/app/javascript/__tests__/__util__/accountUtils.tsx
@@ -3,6 +3,13 @@ import { useAuth } from "@clerk/clerk-react"
 import UserContext, { ContextProps } from "../../authentication/context/UserContext"
 import { User } from "../../authentication/user"
 import * as authApiService from "../../api/authApiService"
+import {
+  Session,
+  SessionContext,
+  SessionContextValue,
+  SessionProviderKind,
+  SessionStatus,
+} from "../../authentication/session"
 
 export const mockProfileStub: User = {
   uid: "abc123",
@@ -21,14 +28,32 @@ export const mockProfileStub: User = {
   housingCounselingAgencyId: null,
 }
 
+const buildSession = (loggedIn: boolean, profile: ContextProps["profile"]): Session => {
+  if (!loggedIn) {
+    return { status: SessionStatus.SignedOut }
+  }
+  if (!profile) {
+    // Only reachable under Clerk, but tests drive it directly via hasProfile.
+    return { status: SessionStatus.SignedInWithoutProfile, userId: "clerk-user-id" }
+  }
+  return { status: SessionStatus.SignedIn, userId: String(profile.id), profile }
+}
+
 export const setupUserContext = ({
   loggedIn,
   mockProfile = mockProfileStub,
   hasProfile = loggedIn,
+  clerkEnabled = true,
 }: {
   loggedIn: boolean
   mockProfile?: ContextProps["profile"]
   hasProfile?: boolean
+  /**
+   * Which backend the stubbed session facade reports. Defaults to Clerk,
+   * matching the suites that reach for this helper: they mock the Clerk flag on.
+   * Pass false to exercise a Devise-only branch.
+   */
+  clerkEnabled?: boolean
 }): ContextProps => {
   const mockContextValue: ContextProps = {
     profile: hasProfile ? mockProfile : undefined,
@@ -42,9 +67,23 @@ export const setupUserContext = ({
 
   const originalUseContext = React.useContext
 
+  const mockSessionValue = (): SessionContextValue => ({
+    session: buildSession(loggedIn, mockContextValue.profile),
+    provider: clerkEnabled ? SessionProviderKind.Clerk : SessionProviderKind.Devise,
+    hasCredentials: loggedIn,
+    signOut: mockContextValue.signOut as () => Promise<void>,
+    timeOut: mockContextValue.timeOut as () => Promise<void>,
+    getToken: () => Promise.resolve("clerk-session-token"),
+  })
+
   jest.spyOn(React, "useContext").mockImplementation((context) => {
     if (context === UserContext) {
       return mockContextValue
+    }
+    // Components ask the session facade rather than UserContext directly, so it
+    // has to be stubbed here too or they see the default Loading session.
+    if (context === SessionContext) {
+      return mockSessionValue()
     }
     return originalUseContext(context)
   })

--- a/app/javascript/__tests__/authentication/withAuthentication.test.tsx
+++ b/app/javascript/__tests__/authentication/withAuthentication.test.tsx
@@ -4,6 +4,7 @@ import { render } from "@testing-library/react"
 import { mockWindowLocation, restoreWindowLocation } from "../__util__/renderUtils"
 import { withAuthentication } from "../../authentication/withAuthentication"
 import UserContext, { ContextProps } from "../../authentication/context/UserContext"
+import { SessionProvider } from "../../authentication/session"
 import { isTokenValid, parseUrlParams } from "../../authentication/token"
 import { useAuth } from "@clerk/clerk-react"
 import { getLocalizedPath, getAddProfilePath, RedirectType } from "../../util/routeUtil"
@@ -84,7 +85,9 @@ describe("withAuthentication", () => {
 
     const { getByText } = render(
       <UserContext.Provider value={mockContextValue}>
-        <WrappedComponent />
+        <SessionProvider>
+          <WrappedComponent />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -97,7 +100,9 @@ describe("withAuthentication", () => {
 
     render(
       <UserContext.Provider value={mockContextValue}>
-        <WrappedComponent />
+        <SessionProvider>
+          <WrappedComponent />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -114,7 +119,9 @@ describe("withAuthentication", () => {
 
     render(
       <UserContext.Provider value={mockContextValue}>
-        <WrappedWithRedirect />
+        <SessionProvider>
+          <WrappedWithRedirect />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -128,7 +135,9 @@ describe("withAuthentication", () => {
 
     const { container } = render(
       <UserContext.Provider value={mockContextValue}>
-        <WrappedComponent />
+        <SessionProvider>
+          <WrappedComponent />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -141,7 +150,9 @@ describe("withAuthentication", () => {
 
     const { container } = render(
       <UserContext.Provider value={mockContextValue}>
-        <WrappedComponent />
+        <SessionProvider>
+          <WrappedComponent />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -185,7 +196,9 @@ describe("withAuthentication", () => {
 
     render(
       <UserContext.Provider value={mockContextValue}>
-        <WrappedComponent />
+        <SessionProvider>
+          <WrappedComponent />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -220,7 +233,9 @@ describe("withAuthentication", () => {
 
       const { getByText } = render(
         <UserContext.Provider value={mockContextValue}>
-          <WrappedComponent />
+          <SessionProvider>
+            <WrappedComponent />
+          </SessionProvider>
         </UserContext.Provider>
       )
 
@@ -233,7 +248,9 @@ describe("withAuthentication", () => {
 
       render(
         <UserContext.Provider value={mockContextValue}>
-          <WrappedComponent />
+          <SessionProvider>
+            <WrappedComponent />
+          </SessionProvider>
         </UserContext.Provider>
       )
 
@@ -247,7 +264,9 @@ describe("withAuthentication", () => {
 
       render(
         <UserContext.Provider value={mockContextValue}>
-          <WrappedComponent />
+          <SessionProvider>
+            <WrappedComponent />
+          </SessionProvider>
         </UserContext.Provider>
       )
 

--- a/app/javascript/__tests__/components/IdleTimeout.test.tsx
+++ b/app/javascript/__tests__/components/IdleTimeout.test.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { act, render, screen, waitFor, fireEvent } from "@testing-library/react"
+import { useAuth } from "@clerk/clerk-react"
 import IdleTimeout from "../../authentication/components/IdleTimeout"
 import UserContext from "../../authentication/context/UserContext"
+import { SessionProvider } from "../../authentication/session"
 import { mockProfileStub } from "../__util__/accountUtils"
 import { renderAndLoadAsync } from "../__util__/renderUtils"
 import TagManager from "react-gtm-module"
@@ -58,9 +60,18 @@ describe("IdleTimeout", () => {
 
   it("triggers auto timeout when user is logged in", async () => {
     const timeOutMock = jest.fn()
+    const clerkSignOut = jest.fn()
+    ;(useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      signOut: clerkSignOut,
+      getToken: jest.fn().mockResolvedValue("clerk-session-token"),
+    })
     const utils = await renderAndLoadAsync(
       <UserContext.Provider value={{ profile: mockProfileStub, timeOut: timeOutMock }}>
-        <IdleTimeout pageName="testPage" />
+        <SessionProvider>
+          <IdleTimeout pageName="testPage" />
+        </SessionProvider>
       </UserContext.Provider>
     )
 
@@ -95,7 +106,11 @@ describe("IdleTimeout", () => {
         }),
       })
     )
-    expect(timeOutMock).toHaveBeenCalled()
+    // Under Clerk the session has to be ended with Clerk, not with Devise's
+    // timeOut. Before the session facade this only called timeOut, so the user
+    // was redirected to the sign-in page still signed in.
+    await waitFor(() => expect(clerkSignOut).toHaveBeenCalled())
+    expect(timeOutMock).not.toHaveBeenCalled()
 
     act(() => {
       utils.unmount()
@@ -151,9 +166,17 @@ describe("IdleTimeout", () => {
 
   it("handles cancel action in prompt", async () => {
     const timeOutMock = jest.fn()
+    ;(useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      signOut: jest.fn(),
+      getToken: jest.fn().mockResolvedValue("clerk-session-token"),
+    })
     const utils = await renderAndLoadAsync(
       <UserContext.Provider value={{ profile: mockProfileStub, timeOut: timeOutMock }}>
-        <IdleTimeout pageName="testPage" />
+        <SessionProvider>
+          <IdleTimeout pageName="testPage" />
+        </SessionProvider>
       </UserContext.Provider>
     )
 

--- a/app/javascript/authentication/components/IdleTimeout.tsx
+++ b/app/javascript/authentication/components/IdleTimeout.tsx
@@ -1,9 +1,10 @@
-import React, { useContext } from "react"
+import React from "react"
 
 import { t } from "@bloom-housing/ui-components"
 
-import { getHomepagePath, getSignInPath } from "../../util/routeUtil"
-import UserContext from "../context/UserContext"
+import { AlertReason, getHomepagePath } from "../../util/routeUtil"
+import { setSignInPageAlert } from "../token"
+import { isAuthenticated, SessionStatus, useSession } from "../session"
 import BaseIdleTimeout from "./BaseIdleTimeout"
 import { useGTMDataLayer } from "../../hooks/analytics/useGTMDataLayer"
 
@@ -14,28 +15,36 @@ interface IdleTimeoutProps {
 }
 
 const IdleTimeout = ({ onTimeout, useFormTimeout = false, pageName }: IdleTimeoutProps) => {
-  const { profile, timeOut } = useContext(UserContext)
+  const { session, timeOut } = useSession()
   const { pushToDataLayer } = useGTMDataLayer()
+  const signedIn = isAuthenticated(session)
 
   const handleTimeout = async (shouldTimeOut: boolean) => {
     onTimeout && (await onTimeout())
     pushToDataLayer("session_exp_warning_action", {
       label: pageName,
       url: window.location.href,
-      action: profile?.id ? "timed out and logged out" : "timed out not logged in",
+      action: signedIn ? "timed out and logged out" : "timed out not logged in",
       is_during_application_flow: false, // When we move to the react application flow this will need to be updated
     })
-    timeOut && shouldTimeOut && timeOut()
+    // Ends the session with whichever backend owns it. Previously this only
+    // ever called Devise's timeOut, so under Clerk the user was redirected to
+    // the sign-in page still signed in, and bounced straight back.
+    if (shouldTimeOut) {
+      await timeOut()
+    }
   }
 
-  // Only render the IdleTimeout component if the user is logged in
-  if (profile && timeOut) {
+  // Only offer the logged-in prompt once we know there is a session to lose.
+  if (session.status === SessionStatus.SignedIn) {
     return (
       <BaseIdleTimeout
         promptTitle={t("idleTimeout.stayLoggedIn")}
         promptText={t("idleTimeout.sessionInactivityLoggedIn")}
         promptAction={t("t.continue")}
-        redirectPath={getSignInPath()}
+        // Matches where timeOut sends them, so the redirect that BaseIdleTimeout
+        // performs afterwards does not strip the explanatory alert param.
+        redirectPath={setSignInPageAlert(AlertReason.TimeOut)}
         alertMessage={t("signIn.userTokenValidationTimeout")}
         alertType={useFormTimeout ? "alert" : "notice"}
         onPrompt={() => {

--- a/app/javascript/authentication/session/SessionContext.ts
+++ b/app/javascript/authentication/session/SessionContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react"
+import { SessionContextValue, SessionProviderKind, SessionStatus } from "./types"
+
+/**
+ * Defaults to Loading rather than SignedOut so that a component rendered
+ * outside a SessionProvider waits instead of redirecting the user to sign in.
+ */
+const defaultValue: SessionContextValue = {
+  session: { status: SessionStatus.Loading },
+  provider: SessionProviderKind.Devise,
+  hasCredentials: false,
+  signOut: () => Promise.resolve(),
+  timeOut: () => Promise.resolve(),
+  getToken: () => Promise.resolve(null),
+}
+
+const SessionContext = createContext<SessionContextValue>(defaultValue)
+
+export default SessionContext

--- a/app/javascript/authentication/session/SessionProvider.tsx
+++ b/app/javascript/authentication/session/SessionProvider.tsx
@@ -1,0 +1,172 @@
+import React from "react"
+import { useAuth } from "@clerk/clerk-react"
+
+import UserContext from "../context/UserContext"
+import { clearHeaders, clearHeadersSignOut, clearHeadersTimeOut, isTokenValid } from "../token"
+import { User } from "../user"
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
+import { UNLEASH_FLAG } from "../../modules/constants"
+import SessionContext from "./SessionContext"
+import { Session, SessionContextValue, SessionProviderKind, SessionStatus } from "./types"
+
+interface SessionProviderProps {
+  children?: React.ReactNode
+}
+
+const loadingSession: Session = { status: SessionStatus.Loading }
+const signedOutSession: Session = { status: SessionStatus.SignedOut }
+
+/**
+ * Mirrors the loading rule the route guard used before this provider existed:
+ * once Clerk reports a session we are still loading until the profile request
+ * settles one way or the other.
+ */
+const clerkSession = (
+  isLoaded: boolean,
+  isSignedIn: boolean,
+  userId: string | null | undefined,
+  profile: User | undefined,
+  initialStateLoaded: boolean
+): Session => {
+  if (!isLoaded) return loadingSession
+  if (!isSignedIn) return signedOutSession
+  if (profile) return { status: SessionStatus.SignedIn, userId: userId ?? "", profile }
+  if (!initialStateLoaded) return loadingSession
+  return { status: SessionStatus.SignedInWithoutProfile, userId: userId ?? "" }
+}
+
+/**
+ * The profile is the session on the Devise path: there is no
+ * authenticated-without-profile state, because registration created both.
+ */
+const deviseSession = (
+  loading: boolean,
+  initialStateLoaded: boolean,
+  profile: User | undefined
+): Session => {
+  if (loading || !initialStateLoaded) return loadingSession
+  if (!isTokenValid() || !profile) return signedOutSession
+  return { status: SessionStatus.SignedIn, userId: String(profile.id), profile }
+}
+
+/**
+ * Reads the Clerk session. Only ever mounted inside a ClerkProvider, because
+ * useAuth throws without one and withAppSetup mounts ClerkProvider only when
+ * the Clerk flag is on.
+ */
+const ClerkSessionSource = ({ children }: SessionProviderProps) => {
+  const { isLoaded, isSignedIn, userId, signOut, getToken } = useAuth()
+  const { profile, initialStateLoaded } = React.useContext(UserContext)
+
+  // Ends the session only; where to go next is the caller's decision, since
+  // both current callers already navigate once this resolves. Navigating here
+  // too would race them.
+  const endSession = React.useCallback(async () => {
+    // A user who signed in under Devise before the flag flipped can still have
+    // stale headers in storage.
+    clearHeaders()
+    await signOut()
+  }, [signOut])
+
+  const value: SessionContextValue = React.useMemo(
+    () => ({
+      session: clerkSession(
+        Boolean(isLoaded),
+        Boolean(isSignedIn),
+        userId,
+        profile,
+        Boolean(initialStateLoaded)
+      ),
+      provider: SessionProviderKind.Clerk,
+      hasCredentials: Boolean(isSignedIn),
+      // Identical under Clerk: the two exist because the Devise path signals a
+      // different reason to the sign-in page, and callers redirect differently.
+      signOut: endSession,
+      timeOut: endSession,
+      // Asks Clerk each time rather than caching: session tokens are short
+      // lived, so one held for a page's lifetime is often already expired.
+      getToken: () => getToken(),
+    }),
+    [isLoaded, isSignedIn, userId, profile, initialStateLoaded, endSession, getToken]
+  )
+
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+}
+
+/** Reads the Devise session out of UserContext and the stored header bundle. */
+const DeviseSessionSource = ({ children }: SessionProviderProps) => {
+  const {
+    profile,
+    loading,
+    initialStateLoaded,
+    signOut: contextSignOut,
+    timeOut: contextTimeOut,
+  } = React.useContext(UserContext)
+
+  const value: SessionContextValue = React.useMemo(
+    () => ({
+      session: deviseSession(Boolean(loading), Boolean(initialStateLoaded), profile),
+      provider: SessionProviderKind.Devise,
+      hasCredentials: Boolean(isTokenValid()),
+      // The context actions push analytics then dispatch, and the reducer
+      // clears storage and navigates. They dereference profile.id unguarded,
+      // so fall back to clearing storage directly when there is no profile.
+      signOut: () => {
+        profile && contextSignOut ? contextSignOut() : clearHeadersSignOut()
+        return Promise.resolve()
+      },
+      timeOut: () => {
+        profile && contextTimeOut ? contextTimeOut() : clearHeadersTimeOut()
+        return Promise.resolve()
+      },
+      // Devise credentials travel ambiently: the API layer reads the header
+      // bundle out of storage, so there is no bearer token to hand out.
+      getToken: () => Promise.resolve(null),
+    }),
+    [loading, initialStateLoaded, profile, contextSignOut, contextTimeOut]
+  )
+
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+}
+
+/** Provides the Loading session while we do not yet know which backend to ask. */
+const UnresolvedSessionSource = ({ children }: SessionProviderProps) => {
+  const value: SessionContextValue = React.useMemo(
+    () => ({
+      session: loadingSession,
+      provider: SessionProviderKind.Devise,
+      // Devise headers are readable synchronously, so header chrome can be
+      // right even before we know which provider is active.
+      hasCredentials: Boolean(isTokenValid()),
+      signOut: () => Promise.resolve(),
+      timeOut: () => Promise.resolve(),
+      getToken: () => Promise.resolve(null),
+    }),
+    []
+  )
+
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+}
+
+/**
+ * Provides the one answer to "who is signed in", so that call sites stop
+ * re-deciding the Clerk flag. This is the only place in the React app that
+ * should know both auth backends exist.
+ *
+ * Must be mounted inside UserProvider, which owns the profile fetch.
+ */
+const SessionProvider = ({ children }: SessionProviderProps) => {
+  const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
+
+  if (!flagsReady) {
+    return <UnresolvedSessionSource>{children}</UnresolvedSessionSource>
+  }
+
+  return clerkEnabled ? (
+    <ClerkSessionSource>{children}</ClerkSessionSource>
+  ) : (
+    <DeviseSessionSource>{children}</DeviseSessionSource>
+  )
+}
+
+export default SessionProvider

--- a/app/javascript/authentication/session/index.ts
+++ b/app/javascript/authentication/session/index.ts
@@ -1,0 +1,11 @@
+export { default as SessionProvider } from "./SessionProvider"
+export { default as SessionContext } from "./SessionContext"
+export { useSession } from "./useSession"
+export {
+  SessionStatus,
+  SessionProviderKind,
+  isLoading,
+  isSignedIn,
+  isAuthenticated,
+} from "./types"
+export type { Session, SessionContextValue } from "./types"

--- a/app/javascript/authentication/session/types.ts
+++ b/app/javascript/authentication/session/types.ts
@@ -1,0 +1,98 @@
+import { User } from "../user"
+
+/**
+ * The identity provider backing the current session.
+ *
+ * Consumers should not need this: it exists for analytics, debugging, and the
+ * small number of call sites that genuinely have to behave differently (for
+ * example the Angular bridge, which can only speak Devise). Anything that
+ * branches on `provider` to answer "am I signed in" is a bug.
+ */
+export enum SessionProviderKind {
+  Clerk = "clerk",
+  Devise = "devise",
+}
+
+export enum SessionStatus {
+  /**
+   * We do not yet know whether anyone is signed in. Feature flags, the Clerk
+   * client, or the profile request are still in flight. Render nothing that
+   * depends on identity.
+   */
+  Loading = "loading",
+  /** Nobody is signed in. */
+  SignedOut = "signedOut",
+  /**
+   * Authenticated against the identity provider, but we have no Salesforce
+   * Contact for them yet, so they cannot apply or view an account. They need to
+   * finish onboarding at /add-profile.
+   *
+   * Only reachable under Clerk: a Devise session and a Contact were created
+   * together, so the state could not exist.
+   */
+  SignedInWithoutProfile = "signedInWithoutProfile",
+  /** Authenticated and we have their profile. The only state that can apply. */
+  SignedIn = "signedIn",
+}
+
+/**
+ * A discriminated union so that every identity-dependent decision is a total
+ * function of one value. Switch on `status` and let the compiler tell you which
+ * cases you have not handled, rather than composing `isLoaded`, `isSignedIn`,
+ * `initialStateLoaded` and `profile` by hand at each call site.
+ */
+export type Session =
+  | { status: SessionStatus.Loading }
+  | { status: SessionStatus.SignedOut }
+  | { status: SessionStatus.SignedInWithoutProfile; userId: string }
+  | { status: SessionStatus.SignedIn; userId: string; profile: User }
+
+export interface SessionContextValue {
+  session: Session
+  /** Which backend produced `session`. See the caveat on SessionProviderKind. */
+  provider: SessionProviderKind
+  /**
+   * Synchronously true when credentials are present, before we know whether
+   * they resolve to a usable profile. Available during Loading, which `session`
+   * deliberately is not.
+   *
+   * For chrome only — deciding whether the header offers "Sign in" or "My
+   * account", so a returning user does not see it flip after the profile
+   * request lands. Never gate access or data on this; gate on `session`.
+   */
+  hasCredentials: boolean
+  /**
+   * End the session with whichever backend owns it, clearing the other's
+   * leftovers. Callers must not also call Clerk's `signOut` or `clearHeaders`.
+   */
+  signOut: () => Promise<void>
+  /**
+   * End the session because the user went idle. Separate from `signOut` so the
+   * sign-in page can explain why they were returned to it.
+   */
+  timeOut: () => Promise<void>
+  /**
+   * A bearer token for API calls, or null when credentials travel ambiently
+   * (the Devise path reads its headers out of storage inside the API layer).
+   *
+   * Prefer letting the API layer call this over threading tokens through
+   * component props.
+   */
+  getToken: () => Promise<string | null>
+}
+
+/** Narrowing helpers, so callers do not re-derive these from `status`. */
+export const isLoading = (session: Session): boolean => session.status === SessionStatus.Loading
+
+export const isSignedIn = (
+  session: Session
+): session is { status: SessionStatus.SignedIn; userId: string; profile: User } =>
+  session.status === SessionStatus.SignedIn
+
+/**
+ * True when the identity provider knows them, whether or not we have a profile.
+ * Use this for "should I offer sign in", not for "may they apply".
+ */
+export const isAuthenticated = (session: Session): boolean =>
+  session.status === SessionStatus.SignedIn ||
+  session.status === SessionStatus.SignedInWithoutProfile

--- a/app/javascript/authentication/session/useSession.ts
+++ b/app/javascript/authentication/session/useSession.ts
@@ -1,0 +1,22 @@
+import React from "react"
+import SessionContext from "./SessionContext"
+import { SessionContextValue } from "./types"
+
+/**
+ * The one way to ask about the current session.
+ *
+ * Callers must not consult the Clerk flag, `useAuth`, `UserContext.profile`, or
+ * localStorage to answer identity questions. Switch on `session.status` so the
+ * compiler catches the state you forgot.
+ *
+ *   const { session } = useSession()
+ *   switch (session.status) {
+ *     case SessionStatus.Loading: return <LoadingOverlay />
+ *     case SessionStatus.SignedOut: return <SignInPrompt />
+ *     case SessionStatus.SignedInWithoutProfile: return <FinishProfilePrompt />
+ *     case SessionStatus.SignedIn: return <Apply profile={session.profile} />
+ *   }
+ */
+export const useSession = (): SessionContextValue => React.useContext(SessionContext)
+
+export default useSession

--- a/app/javascript/authentication/withAuthentication.tsx
+++ b/app/javascript/authentication/withAuthentication.tsx
@@ -1,12 +1,9 @@
 import React from "react"
-import { useAuth } from "@clerk/clerk-react"
-import { isTokenValid, parseUrlParams } from "./token"
-import UserContext from "./context/UserContext"
+import { parseUrlParams } from "./token"
 import { getAddProfilePath, getLocalizedPath, RedirectType } from "../util/routeUtil"
 import { getCurrentLanguage } from "../util/languageUtil"
 import { useGTMDataLayer } from "../hooks/analytics/useGTMDataLayer"
-import { useFeatureFlag } from "../hooks/useFeatureFlag"
-import { UNLEASH_FLAG } from "../modules/constants"
+import { SessionProviderKind, SessionStatus, useSession } from "./session"
 
 interface WithAuthenticationProps {
   redirectType?: RedirectType
@@ -18,74 +15,62 @@ const getSignInPath = (redirectType?: RedirectType) => {
 }
 
 /**
- * Higher-order component that handles authentication for protected routes.
- * When the Clerk flag is on, it checks the Clerk session; otherwise it uses
- * the Devise token / UserContext profile.
+ * Higher-order component that gates a route on having a usable session.
+ *
+ * It does not know which auth backend is in play: it asks the session facade
+ * and handles every state of the union, so a new state cannot be silently
+ * ignored here.
  */
 export const withAuthentication = <P extends object>(
   WrappedComponent: React.ComponentType<P>,
   { redirectType }: WithAuthenticationProps = {}
 ) => {
-  const DeviseAuthGate = (props: P) => {
-    const { profile, loading, initialStateLoaded } = React.useContext(UserContext)
+  const WithAuthenticationComponent = (props: P) => {
+    const { session, provider } = useSession()
     const { pushToDataLayer } = useGTMDataLayer()
 
     React.useEffect(() => {
-      const params = parseUrlParams(window.location.href)
+      switch (session.status) {
+        case SessionStatus.Loading:
+          return
+        case SessionStatus.SignedOut:
+          window.location.assign(getSignInPath(redirectType))
+          return
+        case SessionStatus.SignedInWithoutProfile:
+          window.location.assign(getAddProfilePath())
+          return
+        case SessionStatus.SignedIn:
+          return
+      }
+    }, [session.status])
 
-      if (!isTokenValid() && !loading && initialStateLoaded) {
-        window.location.assign(getSignInPath(redirectType))
-      } else if (
-        profile &&
+    // Devise sent the user back here from the email confirmation link with
+    // their credentials in the query string. Report the conversion once, then
+    // strip the params so a refresh does not report it again.
+    React.useEffect(() => {
+      if (provider !== SessionProviderKind.Devise || session.status !== SessionStatus.SignedIn) {
+        return
+      }
+      const params = parseUrlParams(window.location.href)
+      if (
         params.get("access-token") &&
         params.get("accountConfirmed") === "true" &&
         params.get("account_confirmation_success") === "true"
       ) {
-        pushToDataLayer("account_create_completed", { user_id: profile.id })
-        // We want to remove the query params from the URL so that the user can refresh the page without retriggering the analytics event
-        const url = window.location.origin + window.location.pathname
-        window.history.replaceState({}, document.title, url)
+        pushToDataLayer("account_create_completed", { user_id: session.profile.id })
+        window.history.replaceState(
+          {},
+          document.title,
+          window.location.origin + window.location.pathname
+        )
       }
-    }, [profile, pushToDataLayer, loading, initialStateLoaded])
+    }, [provider, session, pushToDataLayer])
 
-    if (loading || !profile) {
+    if (session.status !== SessionStatus.SignedIn) {
       return null
     }
 
     return <WrappedComponent {...props} />
-  }
-
-  const ClerkAuthGate = (props: P) => {
-    const { isLoaded, isSignedIn } = useAuth()
-    const { profile, initialStateLoaded } = React.useContext(UserContext)
-    const loading = !isLoaded || (isSignedIn && !profile && !initialStateLoaded)
-
-    React.useEffect(() => {
-      if (loading) return
-      if (!isSignedIn) {
-        window.location.assign(getSignInPath(redirectType))
-        return
-      }
-      if (!profile) {
-        window.location.assign(getAddProfilePath())
-      }
-    }, [loading, isSignedIn, profile])
-
-    if (loading || !isSignedIn || !profile) {
-      return null
-    }
-
-    return <WrappedComponent {...props} />
-  }
-
-  const WithAuthenticationComponent = (props: P) => {
-    const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
-
-    if (!flagsReady) {
-      return null
-    }
-
-    return clerkEnabled ? <ClerkAuthGate {...props} /> : <DeviseAuthGate {...props} />
   }
 
   // Set display name for easier debugging

--- a/app/javascript/layouts/Layout.tsx
+++ b/app/javascript/layouts/Layout.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react"
-import { useAuth } from "@clerk/clerk-react"
 import { useLocation } from "react-router"
 
 import {
@@ -14,8 +13,7 @@ import {
 } from "@bloom-housing/ui-components"
 import { SiteHeader, MenuLink } from "../components/SiteHeader/SiteHeader"
 import Markdown from "markdown-to-jsx"
-import UserContext from "../authentication/context/UserContext"
-import { clearHeaders, isTokenValid } from "../authentication/token"
+import { useSession } from "../authentication/session"
 import { ConfigContext } from "../lib/ConfigContext"
 import { Link } from "@bloom-housing/ui-seeds"
 import {
@@ -309,34 +307,20 @@ const LayoutContent = ({
   )
 }
 
-const DeviseLayout = (props: LayoutProps) => {
-  const { signOut } = useContext(UserContext)
-  return <LayoutContent {...props} signedIn={isTokenValid()} signOut={() => signOut?.()} />
-}
+const Layout = (props: LayoutProps) => {
+  const { hasCredentials, signOut } = useSession()
 
-const ClerkLayout = (props: LayoutProps) => {
-  const { isSignedIn, signOut } = useAuth()
+  // hasCredentials rather than the session status, so a returning user's header
+  // does not start on "Sign in" and flip once the profile request lands.
   return (
     <LayoutContent
       {...props}
-      signedIn={Boolean(isSignedIn)}
-      signOut={async () => {
-        // Log out Devise user
-        clearHeaders()
-        await signOut()
+      signedIn={hasCredentials}
+      signOut={() => {
+        void signOut()
       }}
     />
   )
-}
-
-const Layout = (props: LayoutProps) => {
-  const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
-
-  if (!flagsReady) {
-    return null
-  }
-
-  return clerkEnabled ? <ClerkLayout {...props} /> : <DeviseLayout {...props} />
 }
 
 export default Layout

--- a/app/javascript/layouts/withAppSetup.tsx
+++ b/app/javascript/layouts/withAppSetup.tsx
@@ -7,6 +7,7 @@ import { ClerkProvider } from "@clerk/clerk-react"
 import { useFeatureFlag } from "../hooks/useFeatureFlag"
 import IdleTimeout from "../authentication/components/IdleTimeout"
 import UserProvider from "../authentication/context/UserProvider"
+import { SessionProvider } from "../authentication/session"
 import ListingDetailsProvider from "../contexts/listingDetails/listingDetailsProvider"
 import { ConfigProvider } from "../lib/ConfigContext"
 import ErrorBoundary, { BoundaryScope } from "../components/ErrorBoundary"
@@ -56,12 +57,14 @@ const withAppSetup =
             {/* eslint-disable react/prop-types */}
             <ConfigProvider assetPaths={props.assetPaths}>
               <UserProvider>
-                <IdleTimeout
-                  onTimeout={() => console.log("Logout")}
-                  useFormTimeout={configuration?.useFormTimeout}
-                  pageName={configuration?.pageName}
-                />
-                <Component {...props} />
+                <SessionProvider>
+                  <IdleTimeout
+                    onTimeout={() => console.log("Logout")}
+                    useFormTimeout={configuration?.useFormTimeout}
+                    pageName={configuration?.pageName}
+                  />
+                  <Component {...props} />
+                </SessionProvider>
               </UserProvider>
             </ConfigProvider>
           </ListingDetailsProvider>

--- a/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
+++ b/app/javascript/modules/listingDetailsAside/ListingDetailsApply.tsx
@@ -1,5 +1,4 @@
-import React, { useContext, useState } from "react"
-import { useAuth } from "@clerk/clerk-react"
+import React, { useState } from "react"
 
 import {
   AppearanceStyleType,
@@ -27,7 +26,11 @@ import { getAddProfilePath, getSignInPath, localizedPath } from "../../util/rout
 import { ListingState } from "../listings/ListingState"
 import { useFeatureFlag } from "../../hooks/useFeatureFlag"
 import { UNLEASH_FLAG } from "../constants"
-import UserContext from "../../authentication/context/UserContext"
+import {
+  SessionProviderKind,
+  SessionStatus,
+  useSession,
+} from "../../authentication/session"
 
 export interface ListingDetailsApplyProps {
   listing: RailsListing
@@ -78,36 +81,53 @@ const ApplyButton = ({ href }: { href: string }) => (
   </LinkButton>
 )
 
-const ClerkApplyOnlineButton = ({ applyLink }: { applyLink: string }) => {
-  const { isLoaded, isSignedIn } = useAuth()
-  const { profile, initialStateLoaded } = useContext(UserContext)
-  let redirectOrApplyUrl = ""
-  if (isLoaded && isSignedIn && initialStateLoaded && profile) {
-    redirectOrApplyUrl = applyLink
-  } else if (isLoaded && !isSignedIn) {
-    redirectOrApplyUrl = getSignInPath()
-  } else if (isLoaded && isSignedIn && initialStateLoaded && !profile) {
-    redirectOrApplyUrl = getAddProfilePath()
-  }
+/**
+ * Where the apply button should send someone, given who they are.
+ *
+ * Every state of the session union is handled, so there is no path that leaves
+ * the button with an empty href. While we are still resolving the session the
+ * button is disabled rather than pointing at nothing.
+ */
+const GatedApplyOnlineButton = ({ applyLink }: { applyLink: string }) => {
+  const { session } = useSession()
 
-  return <ApplyButton href={redirectOrApplyUrl} />
+  switch (session.status) {
+    case SessionStatus.Loading:
+      return (
+        <Button styleType={AppearanceStyleType.primary} className={"w-full"} disabled={true}>
+          {t("label.applyOnline")}
+        </Button>
+      )
+    case SessionStatus.SignedOut:
+      return <ApplyButton href={getSignInPath()} />
+    case SessionStatus.SignedInWithoutProfile:
+      return <ApplyButton href={getAddProfilePath()} />
+    case SessionStatus.SignedIn:
+      return <ApplyButton href={applyLink} />
+  }
 }
 
 /**
  * If the React form engine is enabled, link to the React application.
- * If Clerk is enabled and the user has an incomplete profile, redirect to the add profile page.
  * Otherwise, link to the Angular application.
+ *
+ * Under Clerk, applying requires an account with a profile, so the button
+ * routes signed-out and profile-less users to finish that first. Under Devise
+ * the Angular flow still accepts anonymous applications, so the button links
+ * straight to the form regardless of session. That difference is product
+ * behaviour, not plumbing, which is why this is one of the few places that
+ * legitimately asks which provider is active.
  */
 const ApplyOnlineButton = ({ listingId }: { listingId: string }) => {
-  const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
+  const { provider } = useSession()
   const { unleashFlag: formEngine } = useFeatureFlag(UNLEASH_FLAG.FORM_ENGINE, false)
   let applyLink = localizedPath(`listings/${listingId}/apply-welcome/intro`)
   if (formEngine) {
     applyLink = localizedPath(`listings/${listingId}/apply/intro`)
   }
 
-  if (flagsReady && clerkEnabled) {
-    return <ClerkApplyOnlineButton applyLink={applyLink} />
+  if (provider === SessionProviderKind.Clerk) {
+    return <GatedApplyOnlineButton applyLink={applyLink} />
   }
 
   return <ApplyButton href={applyLink} />


### PR DESCRIPTION
## Description

Replaces the per-call-site "is the Clerk flag on?" branching with one `SessionProvider` that owns the answer, exposing session state as a discriminated union so each consumer handles every case or fails to compile. Migrating the existing consumers onto it fixes three defects: the apply button's empty `href` while loading (DAH-4340), an idle timeout that never ended a Clerk session, and `Layout`'s duplicated sign-out.

## What's here

New in `app/javascript/authentication/session/`:

| File | Role |
| --- | --- |
| `types.ts` | `Session` union: `Loading` / `SignedOut` / `SignedInWithoutProfile` / `SignedIn`, with each variant carrying its own payload |
| `SessionProvider.tsx` | Three source components — Clerk, Devise, unresolved — with one provider choosing between them |
| `useSession.ts`, `SessionContext.ts`, `index.ts` | Consumer surface |

Migrated: `withAuthentication`, `Layout`, `IdleTimeout`, `ListingDetailsApply`.

**Why a provider rather than a hook.** `useAuth()` throws outside a `ClerkProvider`, and `withAppSetup` mounts `ClerkProvider` only when the flag is on. So any hook calling `useAuth()` unconditionally crashes the Devise path. `useAuth()` is confined to `ClerkSessionSource`, which is only ever mounted inside `ClerkProvider`.

**Why `hasCredentials` exists alongside the union.** The header needs a synchronous answer or signed-in Devise users see "Sign In" for one paint and watch it flip. It's documented as chrome-only — please push back if you see it gating access or data anywhere.

**One deliberate `provider` check remains.** Under Devise the Angular flow still accepts anonymous applications, so the apply button links straight to the form; under Clerk it routes signed-out users to sign in first. That's product behaviour, not plumbing, and it's commented as such.

## Review instructions

Applies to **review/staging**, and to local dev. Everything below is on the listing details page and the account area; there is no new UI.

The Clerk path needs `?featureFlag[temp.webapp.auth.clerk]=true` on the URL; omit it for the Devise path.

**Accounts to use.** For the Devise path (section 3), review apps preload `test@test.com` / `abcd1234` via `rake preload:user` on postdeploy (`app.json:35`) — already confirmed, with a Salesforce Contact attached. That account does **not** work on the Clerk path, because it exists only in the Rails `users` table and Clerk sign-in never consults it. Sections 1 and 2 therefore need a Clerk identity: either a test account created directly in the Clerk instance, or one created through `/create-account` on the review app.

If you create one through the sign-up flow, a delayed verification email can trap you: clicking "Send again" invalidates the earlier code, so if the first email lands *after* you have requested a second, entering the first code fails. The on-screen error does say "Sent more than 1 code? Use the newest one" — trust it and use the most recent email. This is Clerk's behaviour and predates this branch; it is noted because it will bite anyone walking these steps. A newly created account also lands on `/add-profile` first, so complete that before returning to a listing in section 1.

**1. Apply button no longer dead-clicks (DAH-4340)**
1. Signed out, with Clerk on, open any open listing's details page.
2. Click **Apply Online** → goes to the sign-in page. Before this change, catching the page mid-load could produce a button that just reloaded the listing.
3. Throttle the network (DevTools → Network → Slow 3G) and reload. While loading, the Apply Online button is now **disabled** rather than a link to nowhere.
4. Sign in, return to the listing, click **Apply Online** → goes to the application.

**2. Idle timeout actually signs Clerk users out**
1. With Clerk on, sign in and land on `/account`.
2. Wait 30 minutes without interacting → "Stay logged in?" prompt.
3. Let it expire (60 more seconds).
4. You land on the sign-in page **and are signed out** — previously you were bounced straight back to `/account` because only the Devise sign-out ran.
5. Confirm the sign-in page still shows the inactivity message.

**3. Devise path unchanged (regression check)**
1. Without the flag param, sign in with a Devise account.
2. Header shows the account menu, not "Sign In" — watch the first paint on a hard reload, there should be no flicker between the two.
3. Sign out from the header menu → returns to the sign-in page, signed out.
4. Open a listing and click **Apply Online** → still goes straight to the application.

**Not yet performed end-to-end by me** — I ran the unit tests and typechecker, not the browser flows. The 30-minute idle wait in particular wants someone with a real environment. Flagging that rather than checking the box below.

## Notes for reviewers

- `accountUtils.setupUserContext` now also stubs `SessionContext`; without it, migrated components see the `Loading` default and render `null`. That one change repaired eight suites. It takes a `clerkEnabled` param defaulting to Clerk, matching what the suites using it already mock.
- Full Jest run has some `userEvent` 5s timeouts under parallel load. At `--testTimeout=30000` only two suites fail, both also fail on `main`, and both pass in isolation on this branch. `tsc --noEmit` and ESLint are clean. Leaving the "all checks pass" box unchecked for CI to confirm.
- Follow-up not in scope: remaining ad-hoc flag call sites, ambient credentials in the API layer, and the housing-counselor `delegate` state.

---

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.) — lint and typecheck clean locally; see notes on Jest flakiness, awaiting CI
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [x] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [ ] instructions have already been performed at least once — unit-tested only, browser flows not yet walked

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag — the Clerk path rides the existing `temp.webapp.auth.clerk` flag; the Devise path changes are not flagged, so section 3 above is the regression check that matters

