### PR TITLE
feat: DAH-4345 Add Auth Session Layer

### DIFF
--- a/app/javascript/__tests__/__util__/accountUtils.tsx
+++ b/app/javascript/__tests__/__util__/accountUtils.tsx
@@ -4,6 +4,9 @@ import UserContext, { ContextProps } from "../../authentication/context/UserCont
 import { User } from "../../authentication/user"
 import * as authApiService from "../../api/authApiService"
 
+// Saved before any spy replaces it, so the spy never calls itself.
+const realUseContext = React.useContext
+
 export const mockProfileStub: User = {
   uid: "abc123",
   id: 20,
@@ -40,18 +43,11 @@ export const setupUserContext = ({
     initialStateLoaded: true,
   }
 
-  // Restore an earlier spy so a second call doesn't wrap itself and recurse.
-  if (jest.isMockFunction(React.useContext)) {
-    ;(React.useContext as unknown as jest.SpyInstance).mockRestore()
-  }
-
-  const originalUseContext = React.useContext
-
   jest.spyOn(React, "useContext").mockImplementation((context) => {
     if (context === UserContext) {
       return mockContextValue
     }
-    return originalUseContext(context)
+    return realUseContext(context)
   })
 
   if (jest.isMockFunction(useAuth)) {

--- a/app/javascript/__tests__/__util__/accountUtils.tsx
+++ b/app/javascript/__tests__/__util__/accountUtils.tsx
@@ -40,9 +40,7 @@ export const setupUserContext = ({
     initialStateLoaded: true,
   }
 
-  // Calling this helper twice in one test would otherwise capture the previous
-  // spy as `originalUseContext` and make the passthrough below recurse into
-  // itself. Restore first so we always wrap the real useContext.
+  // Restore an earlier spy so a second call doesn't wrap itself and recurse.
   if (jest.isMockFunction(React.useContext)) {
     ;(React.useContext as unknown as jest.SpyInstance).mockRestore()
   }

--- a/app/javascript/__tests__/__util__/accountUtils.tsx
+++ b/app/javascript/__tests__/__util__/accountUtils.tsx
@@ -40,6 +40,13 @@ export const setupUserContext = ({
     initialStateLoaded: true,
   }
 
+  // Calling this helper twice in one test would otherwise capture the previous
+  // spy as `originalUseContext` and make the passthrough below recurse into
+  // itself. Restore first so we always wrap the real useContext.
+  if (jest.isMockFunction(React.useContext)) {
+    ;(React.useContext as unknown as jest.SpyInstance).mockRestore()
+  }
+
   const originalUseContext = React.useContext
 
   jest.spyOn(React, "useContext").mockImplementation((context) => {

--- a/app/javascript/__tests__/__util__/renderUtils.tsx
+++ b/app/javascript/__tests__/__util__/renderUtils.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import { act, render, RenderOptions, RenderResult } from "@testing-library/react"
 import { t } from "@bloom-housing/ui-components"
 import { MemoryRouter, type InitialEntry } from "react-router"
-import { AuthSessionProvider } from "../../authentication/session/AuthSessionProvider"
 import crypto from "crypto"
 import { useForm, FormProvider } from "react-hook-form"
 import { FormEngineProvider } from "../../formEngine/formEngineContext"
@@ -40,15 +39,8 @@ export const restoreWindowLocation = (originalLocation: typeof window.location):
  * By default the MemoryRouter starts at "/" - pass `initialEntries` to render
  * under a specific path (e.g. for components that parse an id out of the URL).
  *
- * AuthSessionProvider is included because withAppSetup mounts it above every
- * page in the app, so anything reading useAuthSession has it in production.
- * Which provider it picks follows the mocked Clerk flag, and the session it
- * reports follows the mocked useAuth - see setupUserContext.
- *
- * Note that AuthSessionProvider renders nothing until flags resolve, so a test
- * mocking useFeatureFlag to return `flagsReady: false` renders an empty tree
- * rather than failing loudly. Outside a FlagProvider the real hook reports
- * ready, which is why tests that mock nothing still render.
+ * Page exports already include AuthSessionProvider through withAppSetup.
+ * Standalone components that need a session should supply their own provider.
  */
 export const renderAndLoadAsync = async (
   ui: React.ReactElement,
@@ -67,13 +59,7 @@ export const renderAndLoadAsync = async (
   await act(async () => {
     renderResponse = render(ui, {
       ...options,
-      // Applied even when the caller brings its own wrapper, since a caller
-      // supplies one to control the router, not to opt out of the session.
-      wrapper: ({ children }: { children: React.ReactNode }) => (
-        <OuterWrapper>
-          <AuthSessionProvider>{children}</AuthSessionProvider>
-        </OuterWrapper>
-      ),
+      wrapper: OuterWrapper,
     }) as RenderResult
   })
 

--- a/app/javascript/__tests__/__util__/renderUtils.tsx
+++ b/app/javascript/__tests__/__util__/renderUtils.tsx
@@ -16,8 +16,6 @@ export const mockWindowLocation = (): typeof window.location => {
   window.location = {
     ...originalLocation,
     assign: jest.fn(),
-    // ErrorBoundary redirects to /500.html via replace().
-    replace: jest.fn(),
   } as any
   return originalLocation
 }
@@ -37,8 +35,6 @@ export const restoreWindowLocation = (originalLocation: typeof window.location):
  *
  * By default the MemoryRouter starts at "/" - pass `initialEntries` to render
  * under a specific path (e.g. for components that parse an id out of the URL).
- *
- * Doesn't add AuthSessionProvider; wrap standalone components that need one.
  */
 export const renderAndLoadAsync = async (
   ui: React.ReactElement,
@@ -46,18 +42,13 @@ export const renderAndLoadAsync = async (
   initialEntries: InitialEntry[] = ["/"]
 ): Promise<RenderResult> => {
   let renderResponse: RenderResult = {} as RenderResult
-
-  const OuterWrapper =
-    options?.wrapper ??
-    (({ children }: { children: React.ReactNode }) => (
-      <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-    ))
-
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderResponse = render(ui, {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      ),
       ...options,
-      wrapper: OuterWrapper,
     }) as RenderResult
   })
 

--- a/app/javascript/__tests__/__util__/renderUtils.tsx
+++ b/app/javascript/__tests__/__util__/renderUtils.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { act, render, RenderOptions, RenderResult } from "@testing-library/react"
 import { t } from "@bloom-housing/ui-components"
 import { MemoryRouter, type InitialEntry } from "react-router"
+import { AuthSessionProvider } from "../../authentication/session/AuthSessionProvider"
 import crypto from "crypto"
 import { useForm, FormProvider } from "react-hook-form"
 import { FormEngineProvider } from "../../formEngine/formEngineContext"
@@ -16,6 +17,9 @@ export const mockWindowLocation = (): typeof window.location => {
   window.location = {
     ...originalLocation,
     assign: jest.fn(),
+    // ErrorBoundary sends the browser to /500.html via replace(), so any test
+    // whose tree throws hits this before its own assertions.
+    replace: jest.fn(),
   } as any
   return originalLocation
 }
@@ -35,6 +39,16 @@ export const restoreWindowLocation = (originalLocation: typeof window.location):
  *
  * By default the MemoryRouter starts at "/" - pass `initialEntries` to render
  * under a specific path (e.g. for components that parse an id out of the URL).
+ *
+ * AuthSessionProvider is included because withAppSetup mounts it above every
+ * page in the app, so anything reading useAuthSession has it in production.
+ * Which provider it picks follows the mocked Clerk flag, and the session it
+ * reports follows the mocked useAuth - see setupUserContext.
+ *
+ * Note that AuthSessionProvider renders nothing until flags resolve, so a test
+ * mocking useFeatureFlag to return `flagsReady: false` renders an empty tree
+ * rather than failing loudly. Outside a FlagProvider the real hook reports
+ * ready, which is why tests that mock nothing still render.
  */
 export const renderAndLoadAsync = async (
   ui: React.ReactElement,
@@ -42,13 +56,24 @@ export const renderAndLoadAsync = async (
   initialEntries: InitialEntry[] = ["/"]
 ): Promise<RenderResult> => {
   let renderResponse: RenderResult = {} as RenderResult
+
+  const OuterWrapper =
+    options?.wrapper ??
+    (({ children }: { children: React.ReactNode }) => (
+      <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+    ))
+
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderResponse = render(ui, {
-      wrapper: ({ children }: { children: React.ReactNode }) => (
-        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-      ),
       ...options,
+      // Applied even when the caller brings its own wrapper, since a caller
+      // supplies one to control the router, not to opt out of the session.
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <OuterWrapper>
+          <AuthSessionProvider>{children}</AuthSessionProvider>
+        </OuterWrapper>
+      ),
     }) as RenderResult
   })
 

--- a/app/javascript/__tests__/__util__/renderUtils.tsx
+++ b/app/javascript/__tests__/__util__/renderUtils.tsx
@@ -16,8 +16,7 @@ export const mockWindowLocation = (): typeof window.location => {
   window.location = {
     ...originalLocation,
     assign: jest.fn(),
-    // ErrorBoundary sends the browser to /500.html via replace(), so any test
-    // whose tree throws hits this before its own assertions.
+    // ErrorBoundary redirects to /500.html via replace().
     replace: jest.fn(),
   } as any
   return originalLocation
@@ -39,8 +38,7 @@ export const restoreWindowLocation = (originalLocation: typeof window.location):
  * By default the MemoryRouter starts at "/" - pass `initialEntries` to render
  * under a specific path (e.g. for components that parse an id out of the URL).
  *
- * Page exports already include AuthSessionProvider through withAppSetup.
- * Standalone components that need a session should supply their own provider.
+ * Doesn't add AuthSessionProvider; wrap standalone components that need one.
  */
 export const renderAndLoadAsync = async (
   ui: React.ReactElement,

--- a/app/javascript/__tests__/authentication/context/UserProvider.test.tsx
+++ b/app/javascript/__tests__/authentication/context/UserProvider.test.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react"
 import { act, render, screen, waitFor } from "@testing-library/react"
+import { AuthSessionProvider } from "../../../authentication/session/AuthSessionProvider"
 import UserProvider from "../../../authentication/context/UserProvider"
 import UserContext, { ContextProps } from "../../../authentication/context/UserContext"
 import { getProfile, signIn } from "../../../api/authApiService"
@@ -71,9 +72,11 @@ describe("UserProvider", () => {
     ;(isTokenValid as jest.Mock).mockReturnValue(true)
 
     render(
-      <UserProvider>
-        <TestComponent />
-      </UserProvider>
+      <AuthSessionProvider>
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      </AuthSessionProvider>
     )
 
     await waitFor(() => expect(screen.getByText("Signed in as abc123")).not.toBeNull())
@@ -85,9 +88,11 @@ describe("UserProvider", () => {
     ;(isTokenValid as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(true)
 
     await renderAndLoadAsync(
-      <UserProvider>
-        <TestComponent />
-      </UserProvider>
+      <AuthSessionProvider>
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      </AuthSessionProvider>
     )
 
     act(() => {
@@ -108,9 +113,11 @@ describe("UserProvider", () => {
     ;(getProfile as jest.Mock).mockRejectedValueOnce(new Error("Token expired"))
 
     await renderAndLoadAsync(
-      <UserProvider>
-        <TestComponent />
-      </UserProvider>
+      <AuthSessionProvider>
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      </AuthSessionProvider>
     )
 
     await waitFor(() => expect(screen.getByText("Initial state loaded")).not.toBeNull())
@@ -127,9 +134,11 @@ describe("UserProvider", () => {
     ;(getProfile as jest.Mock).mockResolvedValue(mockProfileStub)
 
     await renderAndLoadAsync(
-      <UserProvider>
-        <TestComponent />
-      </UserProvider>
+      <AuthSessionProvider>
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      </AuthSessionProvider>
     )
 
     await waitFor(() => expect(screen.getByText("Signed in as abc123")).not.toBeNull())

--- a/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
+++ b/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
@@ -1,0 +1,129 @@
+import React from "react"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { useAuth } from "@clerk/react"
+
+import {
+  AuthSessionProvider,
+  useAuthSession,
+} from "../../../authentication/session/AuthSessionProvider"
+import { useFeatureFlag } from "../../../hooks/useFeatureFlag"
+
+jest.mock("@clerk/react", () => ({
+  useAuth: jest.fn(),
+  ClerkProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
+}))
+
+const mockFlag = (unleashFlag: boolean, flagsReady = true) =>
+  (useFeatureFlag as jest.Mock).mockReturnValue({ unleashFlag, flagsReady })
+
+const mockClerk = (token: string | null, isSignedIn = true) =>
+  (useAuth as jest.Mock).mockReturnValue({
+    isLoaded: true,
+    isSignedIn,
+    getToken: jest.fn().mockResolvedValue(token),
+  })
+
+const Probe = () => {
+  const { status, getCredentials } = useAuthSession()
+  const [credentials, setCredentials] = React.useState<string>("")
+
+  React.useEffect(() => {
+    void getCredentials().then((c) => setCredentials(JSON.stringify(c)))
+  }, [getCredentials])
+
+  return (
+    <div>
+      <p data-testid="status">{status.kind}</p>
+      <p data-testid="credentials">{credentials}</p>
+    </div>
+  )
+}
+
+// The probe resolves credentials in an effect, so the render has to settle
+// inside act() or React warns and jest-fail-on-console turns that into an error.
+const renderProbe = async () => {
+  let result: ReturnType<typeof render>
+  // eslint-disable-next-line @typescript-eslint/require-await
+  await act(async () => {
+    result = render(
+      <AuthSessionProvider>
+        <Probe />
+      </AuthSessionProvider>
+    )
+  })
+  return result
+}
+
+describe("AuthSessionProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // withAppSetup rendered nothing until the flag resolved, and this provider
+  // took that over. Rendering children here instead would expose every consumer
+  // to a state where auth is not yet knowable.
+  it("renders nothing until the flag resolves", async () => {
+    mockFlag(false, false)
+    mockClerk("token")
+
+    const { container } = await renderProbe()
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
+  it("renders children with no session when the flag is off", async () => {
+    mockFlag(false)
+    mockClerk("token")
+
+    await renderProbe()
+
+    // Children render, but nothing behind them claims a session.
+    expect(screen.getByTestId("status").textContent).toBe("initializing")
+    await waitFor(() =>
+      expect(screen.getByTestId("credentials").textContent).toBe(`{"kind":"none"}`)
+    )
+  })
+
+  it("provides Clerk's session when the flag is on", async () => {
+    mockFlag(true)
+    mockClerk("clerk-session-token")
+
+    await renderProbe()
+
+    expect(screen.getByTestId("status").textContent).toBe("signedIn")
+    await waitFor(() =>
+      expect(screen.getByTestId("credentials").textContent).toBe(
+        `{"kind":"bearerToken","token":"clerk-session-token"}`
+      )
+    )
+  })
+
+  // A signed-in user Clerk will not issue a token for has no usable session.
+  // Callers treat this as an error rather than sending an unauthenticated
+  // request, so the distinction has to survive the adapter.
+  it("reports no credentials when Clerk issues no token", async () => {
+    mockFlag(true)
+    mockClerk(null)
+
+    await renderProbe()
+
+    expect(screen.getByTestId("status").textContent).toBe("signedIn")
+    await waitFor(() =>
+      expect(screen.getByTestId("credentials").textContent).toBe(`{"kind":"none"}`)
+    )
+  })
+
+  it("reports signed out when Clerk has no session", async () => {
+    mockFlag(true)
+    mockClerk(null, false)
+
+    await renderProbe()
+
+    expect(screen.getByTestId("status").textContent).toBe("signedOut")
+  })
+})

--- a/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
+++ b/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
@@ -150,28 +150,6 @@ describe("AuthSessionProvider", () => {
     )
   })
 
-  // Page tests render withAppSetup exports, which mount their own provider, and
-  // then wrap them again. Two ClerkProviders means two Clerk instances with
-  // separate token caches; the stubbed ClerkProvider in setupTests hides it.
-  it("does not mount a second provider when nested", async () => {
-    mockFlag(true)
-    mockClerk("clerk-session-token")
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await act(async () => {
-      render(
-        <AuthSessionProvider>
-          <AuthSessionProvider>
-            <Probe />
-          </AuthSessionProvider>
-        </AuthSessionProvider>
-      )
-    })
-
-    expect(ClerkProvider).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId("status").textContent).toBe("signedIn")
-  })
-
   it("warns when a consumer has no provider above it", async () => {
     const consoleError = jest.spyOn(console, "error").mockImplementation(() => {})
 

--- a/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
+++ b/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
@@ -45,7 +45,7 @@ const Probe = () => {
 
 // Settle the credentials effect inside act() to avoid act() warnings.
 const renderProbe = async () => {
-  let result: ReturnType<typeof render>
+  let result!: ReturnType<typeof render>
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     result = render(

--- a/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
+++ b/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { act, render, screen, waitFor } from "@testing-library/react"
-import { useAuth } from "@clerk/react"
+import { ClerkProvider, useAuth } from "@clerk/react"
 
 import {
   AuthSessionProvider,
@@ -10,7 +10,7 @@ import { useFeatureFlag } from "../../../hooks/useFeatureFlag"
 
 jest.mock("@clerk/react", () => ({
   useAuth: jest.fn(),
-  ClerkProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ClerkProvider: jest.fn(({ children }: { children: React.ReactNode }) => <>{children}</>),
 }))
 
 jest.mock("../../../hooks/useFeatureFlag", () => ({
@@ -61,6 +61,11 @@ const renderProbe = async () => {
 describe("AuthSessionProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // setupTests resets all mocks between tests, which strips the passthrough
+    // implementation off the ClerkProvider spy.
+    ;(ClerkProvider as unknown as jest.Mock).mockImplementation(
+      ({ children }: { children: React.ReactNode }) => <>{children}</>
+    )
   })
 
   // withAppSetup rendered nothing until the flag resolved, and this provider
@@ -125,5 +130,58 @@ describe("AuthSessionProvider", () => {
     await renderProbe()
 
     expect(screen.getByTestId("status").textContent).toBe("signedOut")
+  })
+
+  // getToken() rejects when a refresh fails rather than returning null, and the
+  // signature promises a credential. A caller that copied the happy path would
+  // otherwise get an unhandled rejection.
+  it("reports no credentials when Clerk fails to issue a token", async () => {
+    mockFlag(true)
+    ;(useAuth as jest.Mock).mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      getToken: jest.fn().mockRejectedValue(new Error("network")),
+    })
+
+    await renderProbe()
+
+    await waitFor(() =>
+      expect(screen.getByTestId("credentials").textContent).toBe(`{"kind":"none"}`)
+    )
+  })
+
+  // Page tests render withAppSetup exports, which mount their own provider, and
+  // then wrap them again. Two ClerkProviders means two Clerk instances with
+  // separate token caches; the stubbed ClerkProvider in setupTests hides it.
+  it("does not mount a second provider when nested", async () => {
+    mockFlag(true)
+    mockClerk("clerk-session-token")
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      render(
+        <AuthSessionProvider>
+          <AuthSessionProvider>
+            <Probe />
+          </AuthSessionProvider>
+        </AuthSessionProvider>
+      )
+    })
+
+    expect(ClerkProvider).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId("status").textContent).toBe("signedIn")
+  })
+
+  it("warns when a consumer has no provider above it", async () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {})
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      render(<Probe />)
+    })
+
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("no AuthSessionProvider"))
+    expect(screen.getByTestId("status").textContent).toBe("initializing")
+    consoleError.mockRestore()
   })
 })

--- a/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
+++ b/app/javascript/__tests__/authentication/session/AuthSessionProvider.test.tsx
@@ -43,8 +43,7 @@ const Probe = () => {
   )
 }
 
-// The probe resolves credentials in an effect, so the render has to settle
-// inside act() or React warns and jest-fail-on-console turns that into an error.
+// Settle the credentials effect inside act() to avoid act() warnings.
 const renderProbe = async () => {
   let result: ReturnType<typeof render>
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -61,16 +60,12 @@ const renderProbe = async () => {
 describe("AuthSessionProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    // setupTests resets all mocks between tests, which strips the passthrough
-    // implementation off the ClerkProvider spy.
+    // setupTests resets mocks, which strips this passthrough.
     ;(ClerkProvider as unknown as jest.Mock).mockImplementation(
       ({ children }: { children: React.ReactNode }) => <>{children}</>
     )
   })
 
-  // withAppSetup rendered nothing until the flag resolved, and this provider
-  // took that over. Rendering children here instead would expose every consumer
-  // to a state where auth is not yet knowable.
   it("renders nothing until the flag resolves", async () => {
     mockFlag(false, false)
     mockClerk("token")
@@ -87,7 +82,6 @@ describe("AuthSessionProvider", () => {
 
     await renderProbe()
 
-    // Children render, but nothing behind them claims a session.
     expect(screen.getByTestId("status").textContent).toBe("initializing")
     await waitFor(() =>
       expect(screen.getByTestId("credentials").textContent).toBe(`{"kind":"none"}`)
@@ -108,9 +102,7 @@ describe("AuthSessionProvider", () => {
     )
   })
 
-  // A signed-in user Clerk will not issue a token for has no usable session.
-  // Callers treat this as an error rather than sending an unauthenticated
-  // request, so the distinction has to survive the adapter.
+  // Signed in without a token still means no usable session.
   it("reports no credentials when Clerk issues no token", async () => {
     mockFlag(true)
     mockClerk(null)
@@ -132,9 +124,7 @@ describe("AuthSessionProvider", () => {
     expect(screen.getByTestId("status").textContent).toBe("signedOut")
   })
 
-  // getToken() rejects when a refresh fails rather than returning null, and the
-  // signature promises a credential. A caller that copied the happy path would
-  // otherwise get an unhandled rejection.
+  // getToken() rejects when a refresh fails; getCredentials must not.
   it("reports no credentials when Clerk fails to issue a token", async () => {
     mockFlag(true)
     ;(useAuth as jest.Mock).mockReturnValue({

--- a/app/javascript/__tests__/authentication/session/authStatus.test.ts
+++ b/app/javascript/__tests__/authentication/session/authStatus.test.ts
@@ -26,8 +26,7 @@ describe("deriveClerkStatus", () => {
   })
 
   it("does not wait on the DAHLIA profile", () => {
-    // A signed-in user with no profile yet is on their way to add-profile, and
-    // is signed in while they get there.
+    // e.g. a signed-in user on their way to add-profile.
     expect(deriveClerkStatus({ isLoaded: true, isSignedIn: true })).toBe(SIGNED_IN)
   })
 })

--- a/app/javascript/__tests__/authentication/session/authStatus.test.ts
+++ b/app/javascript/__tests__/authentication/session/authStatus.test.ts
@@ -1,0 +1,51 @@
+import {
+  bearerToken,
+  deriveClerkStatus,
+  isAuthInitialized,
+  INITIALIZING,
+  NO_CREDENTIALS,
+  SIGNED_IN,
+  SIGNED_OUT,
+} from "../../../authentication/session/authStatus"
+
+describe("deriveClerkStatus", () => {
+  it("is initializing until Clerk has booted", () => {
+    expect(deriveClerkStatus({ isLoaded: false, isSignedIn: false })).toBe(INITIALIZING)
+    expect(deriveClerkStatus({ isLoaded: false, isSignedIn: true })).toBe(INITIALIZING)
+  })
+
+  it("returns the same reference for the same answer, so effects do not loop", () => {
+    expect(deriveClerkStatus({ isLoaded: true, isSignedIn: true })).toBe(
+      deriveClerkStatus({ isLoaded: true, isSignedIn: true })
+    )
+  })
+
+  it("takes Clerk's answer once it has booted", () => {
+    expect(deriveClerkStatus({ isLoaded: true, isSignedIn: true })).toBe(SIGNED_IN)
+    expect(deriveClerkStatus({ isLoaded: true, isSignedIn: false })).toBe(SIGNED_OUT)
+  })
+
+  it("does not wait on the DAHLIA profile", () => {
+    // A signed-in user with no profile yet is on their way to add-profile, and
+    // is signed in while they get there.
+    expect(deriveClerkStatus({ isLoaded: true, isSignedIn: true })).toBe(SIGNED_IN)
+  })
+})
+
+describe("isAuthInitialized", () => {
+  it("is false only while initializing", () => {
+    expect(isAuthInitialized(INITIALIZING)).toBe(false)
+    expect(isAuthInitialized(SIGNED_OUT)).toBe(true)
+    expect(isAuthInitialized(SIGNED_IN)).toBe(true)
+  })
+})
+
+describe("bearerToken", () => {
+  it("unwraps a token-bearing credential", () => {
+    expect(bearerToken({ kind: "bearerToken", token: "abc" })).toBe("abc")
+  })
+
+  it("is undefined when there is no usable session", () => {
+    expect(bearerToken(NO_CREDENTIALS)).toBeUndefined()
+  })
+})

--- a/app/javascript/__tests__/layouts/withAppSetup.test.tsx
+++ b/app/javascript/__tests__/layouts/withAppSetup.test.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { act, render } from "@testing-library/react"
+import IdleTimeout from "../../authentication/components/IdleTimeout"
+import withAppSetup from "../../layouts/withAppSetup"
+
+jest.mock("../../authentication/components/IdleTimeout", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
+
+describe("withAppSetup", () => {
+  it("logs when the idle timeout fires", async () => {
+    const Page = withAppSetup(() => <div>page</div>, {})
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      render(<Page assetPaths={{}} />)
+    })
+
+    const { onTimeout } = jest.mocked(IdleTimeout).mock.calls[0][0]
+    onTimeout?.()
+
+    expect(console.log).toHaveBeenCalledWith("Logout")
+  })
+})

--- a/app/javascript/authentication/context/UserProvider.tsx
+++ b/app/javascript/authentication/context/UserProvider.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useReducer } from "react"
-import { useAuth } from "@clerk/react"
 
 import { getProfile, signIn } from "../../api/authApiService"
+import { useAuthSession } from "../session/AuthSessionProvider"
+import { bearerToken, isAuthInitialized } from "../session/authStatus"
 import { attemptToSetAuthHeadersFromURL } from "../token"
 import { User } from "../user"
 import {
@@ -31,20 +32,20 @@ const ClerkProfile = ({
   hasProfile: boolean
   onLoaded: (profile: User | null) => void
 }) => {
-  const { isLoaded, isSignedIn, getToken } = useAuth()
+  const { status, getCredentials } = useAuthSession()
 
   useEffect(() => {
-    if (!isLoaded || hasProfile) {
+    if (!isAuthInitialized(status) || hasProfile) {
       return
     }
-    if (!isSignedIn) {
+    if (status.kind === "signedOut") {
       onLoaded(null)
       return
     }
 
     void (async () => {
       try {
-        const sessionToken: string | null = await getToken()
+        const sessionToken = bearerToken(await getCredentials())
         if (!sessionToken) {
           throw new Error("Missing Clerk session token")
         }
@@ -53,11 +54,16 @@ const ClerkProfile = ({
         onLoaded(null)
       }
     })()
-  }, [getToken, hasProfile, isLoaded, isSignedIn, onLoaded])
+  }, [getCredentials, hasProfile, status, onLoaded])
 
   return null
 }
 
+/**
+ * Everything tagged DEVISE TECH DEBT goes when Devise does, leaving the reducer
+ * and ClerkProfile — a profile store and nothing else. Worth renaming to
+ * ProfileProvider then; deferred now because UserContext has ~20 consumers.
+ */
 const UserProvider = (props: UserProviderProps) => {
   const [state, dispatch] = useReducer(UserReducer, {
     loading: false,
@@ -71,6 +77,10 @@ const UserProvider = (props: UserProviderProps) => {
     dispatch(profile ? saveProfile(profile) : systemSignOut())
   }, [])
 
+  // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
+  // Devise's profile fetch; ClerkProfile above is the replacement. Deleting it
+  // takes the flag read and the mount condition below with it.
+  //
   // Load our profile as soon as we have an access token available
   useEffect(() => {
     if (!flagsReady || clerkEnabled || state.profile) {
@@ -108,6 +118,9 @@ const UserProvider = (props: UserProviderProps) => {
     profile: state.profile,
     initialStateLoaded: state.initialStateLoaded,
     saveProfile: (profile) => dispatch(saveProfile(profile)),
+    // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
+    // Posts to /api/v1/auth/sign_in and stores Devise headers. Only reached
+    // from SignInForm, which only renders on the Devise branch of sign-in.tsx.
     signIn: async (email, password, origin) => {
       dispatch(systemSignOut())
       dispatch(startLoading())
@@ -127,10 +140,18 @@ const UserProvider = (props: UserProviderProps) => {
         })
         .finally(() => dispatch(stopLoading()))
     },
+    // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
+    // Clears Devise headers; ends no Clerk session. Layout, AccountNav and
+    // account.tsx branch to useAuth().signOut. A replacement must carry the
+    // GTM push with it.
     signOut: () => {
       pushToDataLayer("logout", { user_id: state.profile.id, reason: "User clicked logout" })
       dispatch(userSignOut())
     },
+    // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
+    // IdleTimeout does not branch on the flag, so under Clerk a timeout clears
+    // Devise headers and redirects while the Clerk session stays live.
+    // Pre-existing; needs its own ticket.
     timeOut: () => {
       pushToDataLayer("logout", { user_id: state.profile.id, reason: "Timed out" })
       dispatch(timeOut())

--- a/app/javascript/authentication/session/AuthSessionProvider.tsx
+++ b/app/javascript/authentication/session/AuthSessionProvider.tsx
@@ -8,10 +8,6 @@ import { useClerkAuthSession } from "./adapters/clerk/useClerkAuthSession"
 
 export type { AuthSession } from "./authStatus"
 
-/**
- * The session for a tree with the flag off. Stays in `initializing`, so a
- * consumer that lands here waits rather than acting on an answer nothing gave it.
- */
 const noSession: AuthSession = {
   status: INITIALIZING,
   getCredentials: () => Promise.resolve(NO_CREDENTIALS),
@@ -43,8 +39,6 @@ const ClerkAuthSession = ({ children }: { children: React.ReactNode }) => {
 }
 
 /**
- * Chooses the auth provider for the tree, once.
- *
  * Clerk is deliberately the only implementation. Components not yet on it keep
  * the code path they have always had, so nothing is re-expressed here and
  * nothing can drift.
@@ -52,9 +46,9 @@ const ClerkAuthSession = ({ children }: { children: React.ReactNode }) => {
 export const AuthSessionProvider = ({ children }: { children: React.ReactNode }) => {
   const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
 
-  // Nothing renders until the flag resolves, so the whole page waits on an
-  // Unleash call. Providing an "initializing" session instead would let the tree
+  // Providing an initializing session instead would let the tree
   // mount immediately, at the cost of every consumer handling that state.
+  // Probably a good TODO, but an improvement out of scope of creating this provider.
   if (!flagsReady) {
     return null
   }

--- a/app/javascript/authentication/session/AuthSessionProvider.tsx
+++ b/app/javascript/authentication/session/AuthSessionProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react"
+import React, { createContext, useContext, useEffect } from "react"
 import { ClerkProvider } from "@clerk/react"
 
 import { useFeatureFlag } from "../../hooks/useFeatureFlag"
@@ -9,19 +9,33 @@ import { useClerkAuthSession } from "./adapters/clerk/useClerkAuthSession"
 export type { AuthSession } from "./authStatus"
 
 /**
- * The session for a tree with no auth provider: rendered outside
- * AuthSessionProvider, or under it with the flag off. Stays in `initializing`,
- * so a consumer that lands here waits forever rather than acting on an answer
- * nothing gave it.
+ * The session for a tree with the flag off. Stays in `initializing`, so a
+ * consumer that lands here waits rather than acting on an answer nothing gave it.
  */
 const noSession: AuthSession = {
   status: INITIALIZING,
   getCredentials: () => Promise.resolve(NO_CREDENTIALS),
 }
 
-const AuthSessionContext = createContext<AuthSession>(noSession)
+// `null` rather than `noSession` so "no provider above me" is distinguishable
+// from "a provider chose not to supply a session". Both hand back noSession, but
+// only the first is a bug worth saying out loud.
+const AuthSessionContext = createContext<AuthSession | null>(null)
 
-export const useAuthSession = (): AuthSession => useContext(AuthSessionContext)
+export const useAuthSession = (): AuthSession => {
+  const session = useContext(AuthSessionContext)
+
+  // Without this the component sits in `initializing` forever and the page
+  // spins with nothing in the console. useAuth() used to throw here.
+  useEffect(() => {
+    if (session || process.env.NODE_ENV === "production") return
+    console.error(
+      "useAuthSession called with no AuthSessionProvider above it. The session will stay in `initializing` and never resolve. Mount AuthSessionProvider (withAppSetup does) or render this component under one."
+    )
+  }, [session])
+
+  return session ?? noSession
+}
 
 const ClerkAuthSession = ({ children }: { children: React.ReactNode }) => {
   const value = useClerkAuthSession()
@@ -37,6 +51,15 @@ const ClerkAuthSession = ({ children }: { children: React.ReactNode }) => {
  */
 export const AuthSessionProvider = ({ children }: { children: React.ReactNode }) => {
   const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
+  const parentSession = useContext(AuthSessionContext)
+
+  // Nesting is a no-op rather than a second provider: mounting ClerkProvider
+  // twice gives the tree two Clerk instances with separate token caches. Test
+  // helpers wrap trees that already carry their own provider from withAppSetup,
+  // and this keeps that from silently building the wrong shape.
+  if (parentSession) {
+    return <>{children}</>
+  }
 
   // Nothing renders until the flag resolves, so the whole page waits on an
   // Unleash call. Providing an "initializing" session instead would let the tree
@@ -46,9 +69,11 @@ export const AuthSessionProvider = ({ children }: { children: React.ReactNode })
   }
 
   // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
-  // The flag read above and this branch go once the flag does.
+  // The flag read above and this branch go once the flag does. noSession is
+  // provided explicitly rather than left unset, so that an absent context keeps
+  // meaning "no provider above me" and nothing else.
   if (!clerkEnabled) {
-    return <>{children}</>
+    return <AuthSessionContext.Provider value={noSession}>{children}</AuthSessionContext.Provider>
   }
 
   return (

--- a/app/javascript/authentication/session/AuthSessionProvider.tsx
+++ b/app/javascript/authentication/session/AuthSessionProvider.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext } from "react"
+import { ClerkProvider } from "@clerk/react"
+
+import { useFeatureFlag } from "../../hooks/useFeatureFlag"
+import { UNLEASH_FLAG } from "../../modules/constants"
+import { AuthSession, INITIALIZING, NO_CREDENTIALS } from "./authStatus"
+import { useClerkAuthSession } from "./adapters/clerk/useClerkAuthSession"
+
+export type { AuthSession } from "./authStatus"
+
+/**
+ * The session for a tree with no auth provider: rendered outside
+ * AuthSessionProvider, or under it with the flag off. Stays in `initializing`,
+ * so a consumer that lands here waits forever rather than acting on an answer
+ * nothing gave it.
+ */
+const noSession: AuthSession = {
+  status: INITIALIZING,
+  getCredentials: () => Promise.resolve(NO_CREDENTIALS),
+}
+
+const AuthSessionContext = createContext<AuthSession>(noSession)
+
+export const useAuthSession = (): AuthSession => useContext(AuthSessionContext)
+
+const ClerkAuthSession = ({ children }: { children: React.ReactNode }) => {
+  const value = useClerkAuthSession()
+  return <AuthSessionContext.Provider value={value}>{children}</AuthSessionContext.Provider>
+}
+
+/**
+ * Chooses the auth provider for the tree, once.
+ *
+ * Clerk is deliberately the only implementation. Components not yet on it keep
+ * the code path they have always had, so nothing is re-expressed here and
+ * nothing can drift.
+ */
+export const AuthSessionProvider = ({ children }: { children: React.ReactNode }) => {
+  const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
+
+  // Nothing renders until the flag resolves, so the whole page waits on an
+  // Unleash call. Providing an "initializing" session instead would let the tree
+  // mount immediately, at the cost of every consumer handling that state.
+  if (!flagsReady) {
+    return null
+  }
+
+  // TODO: CLERK MIGRATION - DEVISE TECH DEBT TO REMOVE
+  // The flag read above and this branch go once the flag does.
+  if (!clerkEnabled) {
+    return <>{children}</>
+  }
+
+  return (
+    <ClerkProvider publishableKey={process.env.CLERK_PUBLISHABLE_KEY}>
+      <ClerkAuthSession>{children}</ClerkAuthSession>
+    </ClerkProvider>
+  )
+}
+
+export default AuthSessionContext

--- a/app/javascript/authentication/session/AuthSessionProvider.tsx
+++ b/app/javascript/authentication/session/AuthSessionProvider.tsx
@@ -51,15 +51,6 @@ const ClerkAuthSession = ({ children }: { children: React.ReactNode }) => {
  */
 export const AuthSessionProvider = ({ children }: { children: React.ReactNode }) => {
   const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(UNLEASH_FLAG.CLERK_AUTH, false)
-  const parentSession = useContext(AuthSessionContext)
-
-  // Nesting is a no-op rather than a second provider: mounting ClerkProvider
-  // twice gives the tree two Clerk instances with separate token caches. Test
-  // helpers wrap trees that already carry their own provider from withAppSetup,
-  // and this keeps that from silently building the wrong shape.
-  if (parentSession) {
-    return <>{children}</>
-  }
 
   // Nothing renders until the flag resolves, so the whole page waits on an
   // Unleash call. Providing an "initializing" session instead would let the tree

--- a/app/javascript/authentication/session/adapters/clerk/useClerkAuthSession.ts
+++ b/app/javascript/authentication/session/adapters/clerk/useClerkAuthSession.ts
@@ -1,0 +1,29 @@
+import { useCallback, useMemo } from "react"
+import { useAuth } from "@clerk/react"
+
+import {
+  AuthCredentials,
+  AuthSession,
+  deriveClerkStatus,
+  NO_CREDENTIALS,
+} from "../../authStatus"
+
+/** Clerk's session, behind the neutral interface. No effects, no state. */
+export const useClerkAuthSession = (): AuthSession => {
+  const { isLoaded, isSignedIn, getToken } = useAuth()
+
+  const getCredentials = useCallback(async (): Promise<AuthCredentials> => {
+    // Annotated because @clerk/react v6's types don't resolve under
+    // moduleResolution:"node". Goes away with "bundler".
+    const token: string | null = await getToken()
+    return token ? { kind: "bearerToken", token } : NO_CREDENTIALS
+  }, [getToken])
+
+  return useMemo(
+    (): AuthSession => ({
+      status: deriveClerkStatus({ isLoaded, isSignedIn: Boolean(isSignedIn) }),
+      getCredentials,
+    }),
+    [isLoaded, isSignedIn, getCredentials]
+  )
+}

--- a/app/javascript/authentication/session/adapters/clerk/useClerkAuthSession.ts
+++ b/app/javascript/authentication/session/adapters/clerk/useClerkAuthSession.ts
@@ -1,22 +1,24 @@
 import { useCallback, useMemo } from "react"
 import { useAuth } from "@clerk/react"
 
-import {
-  AuthCredentials,
-  AuthSession,
-  deriveClerkStatus,
-  NO_CREDENTIALS,
-} from "../../authStatus"
+import { AuthCredentials, AuthSession, deriveClerkStatus, NO_CREDENTIALS } from "../../authStatus"
 
 /** Clerk's session, behind the neutral interface. No effects, no state. */
 export const useClerkAuthSession = (): AuthSession => {
   const { isLoaded, isSignedIn, getToken } = useAuth()
 
   const getCredentials = useCallback(async (): Promise<AuthCredentials> => {
-    // Annotated because @clerk/react v6's types don't resolve under
-    // moduleResolution:"node". Goes away with "bundler".
-    const token: string | null = await getToken()
-    return token ? { kind: "bearerToken", token } : NO_CREDENTIALS
+    try {
+      // Annotated because @clerk/react v6's types don't resolve under
+      // moduleResolution:"node". Goes away with "bundler".
+      const token: string | null = await getToken()
+      return token ? { kind: "bearerToken", token } : NO_CREDENTIALS
+    } catch {
+      // getToken() returns null when there is no session, but rejects when a
+      // refresh fails. Both mean the same thing to a caller, and the signature
+      // promises a credential rather than a throw.
+      return NO_CREDENTIALS
+    }
   }, [getToken])
 
   return useMemo(

--- a/app/javascript/authentication/session/authStatus.ts
+++ b/app/javascript/authentication/session/authStatus.ts
@@ -1,0 +1,58 @@
+/**
+ * The three states an auth check can settle into. A union, so "still working it
+ * out" is a state rather than the absence of one.
+ *
+ * Says nothing about the DAHLIA profile — that is the profile store's question,
+ * and keeping them apart is what lets the store depend on this layer without
+ * this layer reading back.
+ */
+export type AuthStatus = { kind: "initializing" } | { kind: "signedOut" } | { kind: "signedIn" }
+
+export const INITIALIZING: AuthStatus = { kind: "initializing" }
+export const SIGNED_OUT: AuthStatus = { kind: "signedOut" }
+export const SIGNED_IN: AuthStatus = { kind: "signedIn" }
+
+/** True once the initial "is anyone signed in?" question has an answer. */
+export const isAuthInitialized = (status: AuthStatus): boolean => status.kind !== "initializing"
+
+/** What a request needs to authenticate itself, without naming a provider. */
+export type AuthCredentials =
+  /** No usable session. A request made with these will not authenticate. */
+  | { kind: "none" }
+  | { kind: "bearerToken"; token: string }
+
+export const NO_CREDENTIALS: AuthCredentials = { kind: "none" }
+
+export type ClerkStatusInput = {
+  /** Clerk has finished booting. */
+  isLoaded: boolean
+  isSignedIn: boolean
+}
+
+/**
+ * Once Clerk has booted, its answer is the answer. Nothing here waits on the
+ * profile: a signed-in user on their way to add-profile is still signed in.
+ */
+export const deriveClerkStatus = ({ isLoaded, isSignedIn }: ClerkStatusInput): AuthStatus => {
+  if (!isLoaded) return INITIALIZING
+  return isSignedIn ? SIGNED_IN : SIGNED_OUT
+}
+
+/**
+ * The bearer token, when the session has one. `undefined` means no usable
+ * session, so callers may treat it as an error — true only while every provider
+ * here issues tokens.
+ */
+export const bearerToken = (credentials: AuthCredentials): string | undefined =>
+  credentials.kind === "bearerToken" ? credentials.token : undefined
+
+/**
+ * The questions a component may ask. Providers are indistinguishable.
+ *
+ * Ending the session belongs here too, but no caller needs it yet — the
+ * sign-out buttons still branch on the flag. Add it with its first consumer.
+ */
+export type AuthSession = {
+  status: AuthStatus
+  getCredentials: () => Promise<AuthCredentials>
+}

--- a/app/javascript/authentication/session/authStatus.ts
+++ b/app/javascript/authentication/session/authStatus.ts
@@ -14,8 +14,7 @@ export const SIGNED_IN: AuthStatus = { kind: "signedIn" }
 
 export const isAuthInitialized = (status: AuthStatus): boolean => status.kind !== "initializing"
 
-export type AuthCredentials =
-  { kind: "none" } | { kind: "bearerToken"; token: string }
+export type AuthCredentials = { kind: "none" } | { kind: "bearerToken"; token: string }
 
 export const NO_CREDENTIALS: AuthCredentials = { kind: "none" }
 

--- a/app/javascript/authentication/session/authStatus.ts
+++ b/app/javascript/authentication/session/authStatus.ts
@@ -12,45 +12,26 @@ export const INITIALIZING: AuthStatus = { kind: "initializing" }
 export const SIGNED_OUT: AuthStatus = { kind: "signedOut" }
 export const SIGNED_IN: AuthStatus = { kind: "signedIn" }
 
-/** True once the initial "is anyone signed in?" question has an answer. */
 export const isAuthInitialized = (status: AuthStatus): boolean => status.kind !== "initializing"
 
-/** What a request needs to authenticate itself, without naming a provider. */
 export type AuthCredentials =
-  /** No usable session. A request made with these will not authenticate. */
   { kind: "none" } | { kind: "bearerToken"; token: string }
 
 export const NO_CREDENTIALS: AuthCredentials = { kind: "none" }
 
 export type ClerkStatusInput = {
-  /** Clerk has finished booting. */
   isLoaded: boolean
   isSignedIn: boolean
 }
 
-/**
- * Once Clerk has booted, its answer is the answer. Nothing here waits on the
- * profile: a signed-in user on their way to add-profile is still signed in.
- */
 export const deriveClerkStatus = ({ isLoaded, isSignedIn }: ClerkStatusInput): AuthStatus => {
   if (!isLoaded) return INITIALIZING
   return isSignedIn ? SIGNED_IN : SIGNED_OUT
 }
 
-/**
- * The bearer token, when the session has one. `undefined` means no usable
- * session, so callers may treat it as an error — true only while every provider
- * here issues tokens.
- */
 export const bearerToken = (credentials: AuthCredentials): string | undefined =>
   credentials.kind === "bearerToken" ? credentials.token : undefined
 
-/**
- * The questions a component may ask. Providers are indistinguishable.
- *
- * Ending the session belongs here too, but no caller needs it yet — the
- * sign-out buttons still branch on the flag. Add it with its first consumer.
- */
 export type AuthSession = {
   status: AuthStatus
   getCredentials: () => Promise<AuthCredentials>

--- a/app/javascript/authentication/session/authStatus.ts
+++ b/app/javascript/authentication/session/authStatus.ts
@@ -18,8 +18,7 @@ export const isAuthInitialized = (status: AuthStatus): boolean => status.kind !=
 /** What a request needs to authenticate itself, without naming a provider. */
 export type AuthCredentials =
   /** No usable session. A request made with these will not authenticate. */
-  | { kind: "none" }
-  | { kind: "bearerToken"; token: string }
+  { kind: "none" } | { kind: "bearerToken"; token: string }
 
 export const NO_CREDENTIALS: AuthCredentials = { kind: "none" }
 

--- a/app/javascript/layouts/withAppSetup.tsx
+++ b/app/javascript/layouts/withAppSetup.tsx
@@ -3,17 +3,15 @@ import React from "react"
 import axe from "@axe-core/react"
 import ReactDOM from "react-dom"
 import { FlagProvider } from "@unleash/proxy-client-react"
-import { ClerkProvider } from "@clerk/react"
-import { useFeatureFlag } from "../hooks/useFeatureFlag"
 import IdleTimeout from "../authentication/components/IdleTimeout"
 import UserProvider from "../authentication/context/UserProvider"
+import { AuthSessionProvider } from "../authentication/session/AuthSessionProvider"
 import ListingDetailsProvider from "../contexts/listingDetails/listingDetailsProvider"
 import { ConfigProvider } from "../lib/ConfigContext"
 import ErrorBoundary, { BoundaryScope } from "../components/ErrorBoundary"
 import "@bloom-housing/ui-seeds/src/global/app-css.scss"
 import { useGTMInitializer } from "../hooks/analytics/useInitializeGTM"
 import { AppPages } from "../util/routeUtil"
-import { UNLEASH_FLAG } from "../modules/constants"
 
 interface ObjectWithAssets {
   assetPaths: unknown
@@ -41,45 +39,24 @@ const withAppSetup =
 
     useGTMInitializer(process.env.GOOGLE_TAG_MANAGER_KEY)
 
-    function ProvidersWithConditionalClerk() {
-      const { unleashFlag: clerkEnabled, flagsReady } = useFeatureFlag(
-        UNLEASH_FLAG.CLERK_AUTH,
-        false
-      )
-      if (!flagsReady) {
-        return null
-      }
-
-      const Providers = (
+    return (
+      <FlagProvider config={config}>
         <ErrorBoundary boundaryScope={BoundaryScope.page}>
           <ListingDetailsProvider>
-            {/* eslint-disable react/prop-types */}
             <ConfigProvider assetPaths={props.assetPaths}>
-              <UserProvider>
-                <IdleTimeout
-                  onTimeout={() => console.log("Logout")}
-                  useFormTimeout={configuration?.useFormTimeout}
-                  pageName={configuration?.pageName}
-                />
-                <Component {...props} />
-              </UserProvider>
+              <AuthSessionProvider>
+                <UserProvider>
+                  <IdleTimeout
+                    onTimeout={() => console.log("Logout")}
+                    useFormTimeout={configuration?.useFormTimeout}
+                    pageName={configuration?.pageName}
+                  />
+                  <Component {...props} />
+                </UserProvider>
+              </AuthSessionProvider>
             </ConfigProvider>
           </ListingDetailsProvider>
         </ErrorBoundary>
-      )
-
-      return clerkEnabled ? (
-        <ClerkProvider publishableKey={process.env.CLERK_PUBLISHABLE_KEY}>
-          {Providers}
-        </ClerkProvider>
-      ) : (
-        Providers
-      )
-    }
-
-    return (
-      <FlagProvider config={config}>
-        <ProvidersWithConditionalClerk />
       </FlagProvider>
     )
   }


### PR DESCRIPTION
## Description

Introduces a shared auth session layer for session status and token retrieval, and updates profile loading to use it. Includes tests for session states, token failures, and provider behavior. This PR is intentionally kept small and focused; additional PRs will follow to complete the remaining work for this ticket. Also had to fix a bug in accountutil.test where a mock context was mocking a mock context and breaking tests.

## Jira ticket

https://sfgovdt.jira.com/browse/<JIRA TICKET NUMBER>

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag