### PR TITLE
fix: DAH-4353 Update BiSHoP address

### DIFF
--- a/app/assets/json/housing_counselors_react.json
+++ b/app/assets/json/housing_counselors_react.json
@@ -105,7 +105,7 @@
             ],
             "address": [
                 {
-                    "street": "1110 Howard Street",
+                    "street": "1338 Mission St. 3rd Floor",
                     "cityState": "San Francisco, CA 94103"
                 }
             ],


### PR DESCRIPTION
## Description

Updates the static Housing Counselor directory data with BiSHoP’s current Mission Street address. The page rendered an outdated Howard Street address because its agency information is maintained in `housing_counselors_react.json`.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4353

## Before requesting eng review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Code conventions

- [ ] web pages are formatted with `.scss` stylesheets and `ui-seeds` tokens, rather than inline styles or Tailwind

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

## Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag